### PR TITLE
refactor: use ReplyTagsBuilder for reply tags in SubmitNote

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ use tears::subscription::time::{Message as TimerMessage, Timer};
 
 use crate::core::message::{AppMsg, EditorMsg, NostrMsg, SystemMsg, TimelineMsg};
 use crate::core::state::AppState;
+use crate::domain::nostr::nip10::ReplyTagsBuilder;
 use crate::domain::nostr::nip38::MusicStatus;
 use crate::infrastructure::config::Config;
 use crate::infrastructure::subscription::media::MediaEvents;
@@ -525,10 +526,9 @@ impl<'a> TearsApp<'a> {
                 // Build event with appropriate tags
                 let event_builder = if let Some(reply_to_event) = self.state.editor.reply_target() {
                     log::info!("Publishing reply: {content}");
-                    // Create reply with proper NIP-10 tags
+                    // Build NIP-10 reply tags (root/reply markers, deduped p-tag)
                     EventBuilder::text_note(&content)
-                        .tag(Tag::event(reply_to_event.id))
-                        .tag(Tag::public_key(reply_to_event.pubkey))
+                        .tags(ReplyTagsBuilder::build(reply_to_event.clone()))
                 } else {
                     log::info!("Publishing note: {content}");
                     EventBuilder::text_note(&content)


### PR DESCRIPTION
## Summary

Replace the inline reply tag construction in `EditorMsg::SubmitNote` with the existing `domain/nostr/nip10.rs::ReplyTagsBuilder::build`. This moves NIP-10 tagging logic out of `app.rs` and into the domain layer where it is already unit-tested — a single-responsibility change.

## Background

This is part of slimming down `app.rs` following the AGENTS.md principle that `app.rs` should focus on routing/orchestration while business logic is delegated to State/domain. `ReplyTagsBuilder` already existed with thorough tests but was left unused (dead) by `SubmitNote` after the tears migration.

## Behavioral effect

This is not a pure cleanup — it also restores NIP-10 marker tagging that was lost during the tears migration.

- Old (inline): attached bare `e`/`p` tags without markers
- New (`ReplyTagsBuilder`): threads root/reply markers and de-duplicates the author `p` tag

## Testing

- `just build` / `just lint` / `just fmt` / `just test` all pass (349 passed)
- The reply tag logic itself is covered by the existing tests in `domain/nostr/nip10.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)