### PR TITLE
refactor: move reaction/repost event builders into TextNote

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -363,7 +363,7 @@ impl<'a> TearsApp<'a> {
                     log::info!("Reacting to event: {note1}");
 
                     // Send the event
-                    let event_builder = EventBuilder::reaction(note.as_event(), "+");
+                    let event_builder = note.reaction_builder();
                     self.state
                         .nostr
                         .update(NostrMessage::EventSubmitted { event_builder });
@@ -383,7 +383,7 @@ impl<'a> TearsApp<'a> {
                     log::info!("Reposting event: {note1}");
 
                     // Send the event
-                    let event_builder = EventBuilder::repost(note.as_event(), None);
+                    let event_builder = note.repost_builder();
                     self.state
                         .nostr
                         .update(NostrMessage::EventSubmitted { event_builder });

--- a/src/model/timeline/text_note.rs
+++ b/src/model/timeline/text_note.rs
@@ -96,6 +96,16 @@ impl TextNote {
         self.event.tags.public_keys()
     }
 
+    /// Build a NIP-25 `+` reaction event targeting this note.
+    pub fn reaction_builder(&self) -> EventBuilder {
+        EventBuilder::reaction(&self.event, "+")
+    }
+
+    /// Build a NIP-18 repost event for this note.
+    pub fn repost_builder(&self) -> EventBuilder {
+        EventBuilder::repost(&self.event, None)
+    }
+
     pub fn update(&mut self, message: Message) {
         match message {
             Message::ReactionReceived(event) => {
@@ -243,6 +253,41 @@ mod tests {
         text_note.update(Message::ZapReceiptReceived(zap_receipt));
 
         assert_eq!(text_note.zap_amount(), 10000);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reaction_builder() -> Result<(), Box<dyn Error>> {
+        let event = create_test_event("Original post")?;
+        let text_note = TextNote::new(event.clone());
+
+        let keys = Keys::generate();
+        let reaction = text_note.reaction_builder().sign_with_keys(&keys)?;
+
+        assert_eq!(reaction.kind, Kind::Reaction);
+        assert_eq!(reaction.content, "+");
+        assert_eq!(
+            reaction.tags.event_ids().copied().collect::<Vec<_>>(),
+            vec![event.id]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repost_builder() -> Result<(), Box<dyn Error>> {
+        let event = create_test_event("Original post")?;
+        let text_note = TextNote::new(event.clone());
+
+        let keys = Keys::generate();
+        let repost = text_note.repost_builder().sign_with_keys(&keys)?;
+
+        assert_eq!(repost.kind, Kind::Repost);
+        assert_eq!(
+            repost.tags.event_ids().copied().collect::<Vec<_>>(),
+            vec![event.id]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Add `TextNote::reaction_builder` and `TextNote::repost_builder`, and call them from `app.rs` instead of constructing `EventBuilder::reaction` / `EventBuilder::repost` inline in `handle_timeline_msg`.

## Rationale

This continues slimming down `app.rs` per the AGENTS.md principle that it should focus on routing/orchestration while logic lives in State/domain. Building a note's reaction/repost events depends only on the source event, so that knowledge belongs next to `TextNote` (which owns the event), not in the app-level message handler.

The new builders are unit-tested directly in `text_note.rs` (`test_reaction_builder`, `test_repost_builder`), verifying event kind and that the built event references the source note.

## Testing

- `just build` / `just lint` / `just fmt` / `just test` all pass (348 passed, including the 2 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)