### PR TITLE
refactor: move live status builder into MusicStatus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -582,8 +582,7 @@ impl<'a> TearsApp<'a> {
                 if let MediaEvent::TrackChanged { track, .. } = event {
                     if let Some(status) = MusicStatus::new(track) {
                         let content = status.content();
-                        let event_builder =
-                            EventBuilder::live_status(status.into(), content.clone());
+                        let event_builder = status.live_status_builder();
 
                         self.state
                             .nostr

--- a/src/domain/nostr/nip38.rs
+++ b/src/domain/nostr/nip38.rs
@@ -29,15 +29,24 @@ impl MusicStatus {
             .duration
             .map(|duration| Timestamp::now() + duration)
     }
+
+    fn to_live_status(&self) -> LiveStatus {
+        LiveStatus {
+            status_type: StatusType::Music,
+            expiration: self.expiration(),
+            reference: Some(self.reference()),
+        }
+    }
+
+    /// Build a NIP-38 live status event for the currently playing track.
+    pub fn live_status_builder(&self) -> EventBuilder {
+        EventBuilder::live_status(self.to_live_status(), self.content())
+    }
 }
 
 impl From<MusicStatus> for LiveStatus {
     fn from(value: MusicStatus) -> Self {
-        LiveStatus {
-            status_type: StatusType::Music,
-            expiration: value.expiration(),
-            reference: Some(value.reference()),
-        }
+        value.to_live_status()
     }
 }
 
@@ -205,6 +214,22 @@ mod tests {
         assert_eq!(live_status.status_type, StatusType::Music);
         assert!(live_status.expiration.is_some());
         assert!(live_status.reference.is_some());
+    }
+
+    #[test]
+    fn test_live_status_builder() {
+        let track = create_valid_track();
+        let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
+        let expected_content = status.content();
+
+        let keys = Keys::generate();
+        let event = status
+            .live_status_builder()
+            .sign_with_keys(&keys)
+            .expect("Failed to sign live status event");
+
+        assert_eq!(event.kind, Kind::UserStatus);
+        assert_eq!(event.content, expected_content);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `MusicStatus::live_status_builder` and call it from `handle_media_msg` instead of constructing `EventBuilder::live_status` inline in `app.rs`.

The `LiveStatus` construction is factored into a private `to_live_status` helper that both the new builder and the existing `From<MusicStatus> for LiveStatus` impl delegate to, so there is no duplication.

## Rationale

This is the final step of the app.rs slimming effort, following the AGENTS.md principle that `app.rs` should focus on routing/orchestration while logic lives in State/domain. Building a NIP-38 live status event from a track depends only on `MusicStatus`, so it belongs in the domain layer next to that type, where it is unit-tested.

The new builder is covered by `test_live_status_builder` (verifies the event kind is `UserStatus` / NIP-38 and that the content matches).

## Testing

- `just build` / `just lint` / `just fmt` / `just test` all pass (349 passed, including the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)