### PR TITLE
refactor: replace production unwrap() with proper error handling

### DIFF
--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -13,10 +13,10 @@ impl Reference {
         Self { nip21, value }
     }
 
-    #[allow(clippy::unwrap_used)]
     pub fn find(text: &str) -> Vec<Self> {
         // TODO: Add nevent and nprofile support
-        let pattern = Regex::new(r"[^\w](nostr:(npub|note)1[a-z0-9]{58})[^\w]").unwrap();
+        let pattern = Regex::new(r"[^\w](nostr:(npub|note)1[a-z0-9]{58})[^\w]")
+            .expect("hardcoded NIP-27 reference regex must be valid");
         pattern
             .captures_iter(text)
             .filter_map(|capture| {

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -46,15 +46,22 @@ pub struct Config {
 }
 
 impl Config {
-    #[allow(clippy::unwrap_used)]
     pub fn new() -> Result<Self, config::ConfigError> {
         let default_config: Config = json5::from_str(CONFIG)
             .map_err(|e| ConfigError::Message(format!("Failed to load default config: {e}")))?;
         let data_dir = utils::get_data_dir();
         let config_dir = utils::get_config_dir();
+        let data_dir_str = data_dir.to_str().ok_or_else(|| {
+            ConfigError::Message(format!("Data dir path is not valid UTF-8: {data_dir:?}"))
+        })?;
+        let config_dir_str = config_dir.to_str().ok_or_else(|| {
+            ConfigError::Message(format!(
+                "Config dir path is not valid UTF-8: {config_dir:?}"
+            ))
+        })?;
         let mut builder = config::Config::builder()
-            .set_default("_data_dir", data_dir.to_str().unwrap())?
-            .set_default("_config_dir", config_dir.to_str().unwrap())?;
+            .set_default("_data_dir", data_dir_str)?
+            .set_default("_config_dir", config_dir_str)?;
 
         let config_files = [
             ("config.json5", config::FileFormat::Json5),

--- a/src/presentation/config/keybindings.rs
+++ b/src/presentation/config/keybindings.rs
@@ -100,7 +100,6 @@ fn extract_modifiers(raw: &str) -> (&str, KeyModifiers) {
     (current, modifiers)
 }
 
-#[allow(clippy::unwrap_used)]
 fn parse_key_code_with_modifiers(raw: &str, mut modifiers: KeyModifiers) -> Result<KeyEvent> {
     let c = match raw {
         "esc" => KeyCode::Esc,
@@ -137,7 +136,10 @@ fn parse_key_code_with_modifiers(raw: &str, mut modifiers: KeyModifiers) -> Resu
         "minus" => KeyCode::Char('-'),
         "tab" => KeyCode::Tab,
         c if c.len() == 1 => {
-            let mut c = c.chars().next().unwrap();
+            let mut c = c
+                .chars()
+                .next()
+                .expect("c has exactly one char because c.len() == 1");
             if modifiers.contains(KeyModifiers::SHIFT) {
                 c = c.to_ascii_uppercase();
             }


### PR DESCRIPTION
## Summary

Remove the three `.unwrap()` calls in non-test code (each previously suppressed with `#[allow(clippy::unwrap_used)]`), per the AGENTS.md rule that production code must not use `unwrap`/`panic`. The handling is chosen per case — propagate a `Result` where the failure is recoverable, `expect` where it is a documented invariant.

| File | Before | After | Reason |
| --- | --- | --- | --- |
| `infrastructure/config.rs` | `dir.to_str().unwrap()` | `.ok_or_else(|| ConfigError::Message(...))?` | `Config::new` returns `Result`; a non-UTF-8 path is recoverable and should be reported, not panic |
| `domain/nostr/nip27.rs` | `Regex::new(...).unwrap()` | `.expect("hardcoded NIP-27 reference regex must be valid")` | compile-time-constant regex; valid by construction |
| `presentation/config/keybindings.rs` | `c.chars().next().unwrap()` | `.expect("c has exactly one char because c.len() == 1")` | guarded by `c.len() == 1`, so always `Some` |

The `#[allow(clippy::unwrap_used)]` attributes on these functions are removed accordingly.

## Behavioral note

Only the `config.rs` case changes behavior, and only for the edge case of a non-UTF-8 config/data directory path: it now surfaces a `ConfigError` instead of panicking. The other two are infallible invariants whose intent is now documented via `expect`.

## Testing

- `just build` / `just lint` / `just fmt` / `just test` all pass (350 passed)
- No new tests: the `expect` paths are unreachable invariants, and the `config.rs` non-UTF-8 path is not portably constructible in a unit test

🤖 Generated with [Claude Code](https://claude.com/claude-code)