### PR TITLE
fix: align Timeline::is_empty() with active-tab semantics

### DIFF
--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -160,8 +160,11 @@ impl Timeline {
     }
 
     /// Check if the active timeline is empty
+    ///
+    /// This mirrors `len()`, which counts items in the active tab, so that
+    /// `len() == 0` is always equivalent to `is_empty()`.
     pub fn is_empty(&self) -> bool {
-        self.notes.is_empty()
+        self.active_tab().is_empty()
     }
 
     /// Get the index of currently selected note in the active tab
@@ -490,6 +493,32 @@ mod tests {
         });
 
         // Note should not be added
+        assert_eq!(timeline.len(), 0);
+        assert!(timeline.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_reflects_active_tab() {
+        let mut timeline = Timeline::default();
+        let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
+
+        // Add a note only to a non-active tab
+        let _ = timeline.update(Message::TabAdded {
+            tab_type: TimelineTabType::UserTimeline { pubkey },
+        });
+        let event = create_test_event(1000, 1, "Note");
+        let _ = timeline.update(Message::NoteAddedToTab {
+            event,
+            tab_type: TimelineTabType::UserTimeline { pubkey },
+        });
+
+        // The active tab (UserTimeline) has the note
+        assert_eq!(timeline.len(), 1);
+        assert!(!timeline.is_empty());
+
+        // Switching to the empty Home tab keeps len() and is_empty() consistent,
+        // even though the centralized storage still holds the note
+        let _ = timeline.update(Message::TabSelected { index: 0 });
         assert_eq!(timeline.len(), 0);
         assert!(timeline.is_empty());
     }


### PR DESCRIPTION
## Summary

`Timeline::len()` counts items in the **active tab**, but `Timeline::is_empty()` checked the centralized `notes` storage that is **shared across all tabs**. These two methods looked at different things, so `len() == 0` was not equivalent to `is_empty()`.

Concretely, when a non-active tab held notes while the active tab was empty, `is_empty()` returned `false` even though `len()` reported `0`. This violates the `len_without_is_empty` convention and is an easy source of subtle bugs.

This was found during an SRP-focused review of `src/model/timeline.rs`.

## Changes

- `is_empty()` now delegates to `self.active_tab().is_empty()`, keeping it consistent with `len()`.
- Added a regression test (`test_is_empty_reflects_active_tab`) that fails under the previous implementation: it puts a note in a non-active tab, then switches to the empty Home tab and asserts both `len() == 0` and `is_empty()`.

`is_empty()` was only used in tests; production empty-state checks already use `len() == 0` (`presentation/components/home/list.rs`), so behavior in the app is unchanged.

## Verification

- `just build` — ok
- `just test` — 351 passed, 0 failed
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)