### PR TITLE
refactor: move find_event_id_from_last_e_tag into domain layer

### DIFF
--- a/src/domain/nostr.rs
+++ b/src/domain/nostr.rs
@@ -4,5 +4,5 @@ pub mod nip27;
 pub mod nip38;
 mod profile;
 
-pub use event::SortableEventId;
+pub use event::{find_event_id_from_last_e_tag, SortableEventId};
 pub use profile::Profile;

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -47,6 +47,24 @@ impl Ord for SortableEventId {
     }
 }
 
+/// Extract the event ID referenced by the last `e` tag of an event.
+///
+/// Reactions (NIP-25), reposts (NIP-18) and zap receipts (NIP-57) reference
+/// their target event with an `e` tag; when multiple `e` tags are present, the
+/// last one identifies the target. Returns `None` if there is no `e` tag.
+pub fn find_event_id_from_last_e_tag(event: &Event) -> Option<EventId> {
+    event
+        .tags
+        .filter_standardized(TagKind::SingleLetter(SingleLetterTag::lowercase(
+            Alphabet::E,
+        )))
+        .last()
+        .and_then(|tag| match tag {
+            TagStandard::Event { event_id, .. } => Some(*event_id),
+            _ => None,
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,5 +160,47 @@ mod tests {
         // Should be sorted in reverse order (newest first)
         let sorted: Vec<_> = set.iter().map(|r| r.0).collect();
         assert_eq!(sorted, vec![id3, id2, id1]);
+    }
+
+    #[test]
+    fn test_find_event_id_from_last_e_tag() {
+        let keys = Keys::generate();
+        let target_id = EventId::all_zeros();
+
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .tags(vec![Tag::event(target_id)])
+            .sign_with_keys(&keys)
+            .expect("Failed to create event");
+
+        let found_id = find_event_id_from_last_e_tag(&event);
+        assert_eq!(found_id, Some(target_id));
+    }
+
+    #[test]
+    fn test_find_event_id_from_last_e_tag_multiple_tags() {
+        let keys = Keys::generate();
+        let first_id = EventId::all_zeros();
+        let last_id = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
+
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .tags(vec![Tag::event(first_id), Tag::event(last_id)])
+            .sign_with_keys(&keys)
+            .expect("Failed to create event");
+
+        // Should return the last 'e' tag
+        let found_id = find_event_id_from_last_e_tag(&event);
+        assert_eq!(found_id, Some(last_id));
+    }
+
+    #[test]
+    fn test_find_event_id_from_last_e_tag_no_tags() {
+        let keys = Keys::generate();
+
+        let event = EventBuilder::new(Kind::Reaction, "+")
+            .sign_with_keys(&keys)
+            .expect("Failed to create event");
+
+        let found_id = find_event_id_from_last_e_tag(&event);
+        assert_eq!(found_id, None);
     }
 }

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -10,7 +10,7 @@ use tears::Command;
 
 use crate::{
     core::message::AppMsg,
-    domain::nostr::SortableEventId,
+    domain::nostr::{find_event_id_from_last_e_tag, SortableEventId},
     model::timeline::{
         tab::{Message as TabMessage, TimelineTab, TimelineTabType},
         text_note::{Message as TextNoteMessage, TextNote},
@@ -89,20 +89,6 @@ pub struct Timeline {
 }
 
 impl Timeline {
-    /// Extract the last event ID from 'e' tags
-    fn find_event_id_from_last_e_tag(event: &Event) -> Option<EventId> {
-        event
-            .tags
-            .filter_standardized(TagKind::SingleLetter(SingleLetterTag::lowercase(
-                Alphabet::E,
-            )))
-            .last()
-            .and_then(|tag| match tag {
-                TagStandard::Event { event_id, .. } => Some(*event_id),
-                _ => None,
-            })
-    }
-
     /// Create a Timeline
     pub fn new(&self) -> Self {
         Self::default()
@@ -237,21 +223,21 @@ impl Timeline {
                 return tab.update(TabMessage::NoteAdded(sortable_id));
             }
             Message::ReactionAdded { event } => {
-                if let Some(target_event_id) = Self::find_event_id_from_last_e_tag(&event) {
+                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
                     self.notes.entry(target_event_id).and_modify(|note| {
                         note.update(TextNoteMessage::ReactionReceived(event));
                     });
                 }
             }
             Message::RepostAdded { event } => {
-                if let Some(target_event_id) = Self::find_event_id_from_last_e_tag(&event) {
+                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
                     self.notes.entry(target_event_id).and_modify(|note| {
                         note.update(TextNoteMessage::RepostReceived(event));
                     });
                 }
             }
             Message::ZapReceiptAdded { event } => {
-                if let Some(target_event_id) = Self::find_event_id_from_last_e_tag(&event) {
+                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
                     self.notes.entry(target_event_id).and_modify(|note| {
                         note.update(TextNoteMessage::ZapReceiptReceived(event));
                     });
@@ -1097,48 +1083,6 @@ mod tests {
         // Switch back to Home - selection should be independent
         let _ = timeline.update(Message::TabSelected { index: 0 });
         assert_eq!(timeline.selected_index(), None);
-    }
-
-    #[test]
-    fn test_find_event_id_from_last_e_tag() {
-        let keys = Keys::generate();
-        let target_id = EventId::all_zeros();
-
-        let event = EventBuilder::new(Kind::Reaction, "+")
-            .tags(vec![Tag::event(target_id)])
-            .sign_with_keys(&keys)
-            .expect("Failed to create event");
-
-        let found_id = Timeline::find_event_id_from_last_e_tag(&event);
-        assert_eq!(found_id, Some(target_id));
-    }
-
-    #[test]
-    fn test_find_event_id_from_last_e_tag_multiple_tags() {
-        let keys = Keys::generate();
-        let first_id = EventId::all_zeros();
-        let last_id = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
-
-        let event = EventBuilder::new(Kind::Reaction, "+")
-            .tags(vec![Tag::event(first_id), Tag::event(last_id)])
-            .sign_with_keys(&keys)
-            .expect("Failed to create event");
-
-        // Should return the last 'e' tag
-        let found_id = Timeline::find_event_id_from_last_e_tag(&event);
-        assert_eq!(found_id, Some(last_id));
-    }
-
-    #[test]
-    fn test_find_event_id_from_last_e_tag_no_tags() {
-        let keys = Keys::generate();
-
-        let event = EventBuilder::new(Kind::Reaction, "+")
-            .sign_with_keys(&keys)
-            .expect("Failed to create event");
-
-        let found_id = Timeline::find_event_id_from_last_e_tag(&event);
-        assert_eq!(found_id, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Timeline::find_event_id_from_last_e_tag` extracted the event ID referenced by the last `e` tag of an event. This is generic Nostr tag-parsing logic — reactions (NIP-25), reposts (NIP-18) and zap receipts (NIP-57) all reference their target event via the last `e` tag — and is not a responsibility of the `Timeline` model. Keeping it there leaked NIP tag-structure knowledge into the timeline orchestration logic (an SRP smell found during review of `src/model/timeline.rs`).

## Changes

- Move the function to `domain::nostr` as a free function alongside `SortableEventId` (in `domain/nostr/event.rs`), and re-export it from `domain::nostr`.
- Update `Timeline`'s reaction/repost/zap handlers to call the free function.
- Move the three associated unit tests next to the function.

No behavior change; this is a pure relocation. The same three tests now live in the domain module, so the total test count is unchanged.

## Verification

- `just build` — ok
- `just test` — 351 passed, 0 failed
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)