### PR TITLE
refactor: consolidate engagement handlers into apply_engagement

### DIFF
--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -89,6 +89,16 @@ pub struct Timeline {
 }
 
 impl Timeline {
+    /// Forward an engagement event (reaction, repost, zap receipt) to the note
+    /// it targets, identified by the last `e` tag.
+    fn apply_engagement(&mut self, event: Event, to_message: fn(Event) -> TextNoteMessage) {
+        if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
+            self.notes.entry(target_event_id).and_modify(|note| {
+                note.update(to_message(event));
+            });
+        }
+    }
+
     /// Create a Timeline
     pub fn new(&self) -> Self {
         Self::default()
@@ -223,25 +233,13 @@ impl Timeline {
                 return tab.update(TabMessage::NoteAdded(sortable_id));
             }
             Message::ReactionAdded { event } => {
-                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
-                    self.notes.entry(target_event_id).and_modify(|note| {
-                        note.update(TextNoteMessage::ReactionReceived(event));
-                    });
-                }
+                self.apply_engagement(event, TextNoteMessage::ReactionReceived);
             }
             Message::RepostAdded { event } => {
-                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
-                    self.notes.entry(target_event_id).and_modify(|note| {
-                        note.update(TextNoteMessage::RepostReceived(event));
-                    });
-                }
+                self.apply_engagement(event, TextNoteMessage::RepostReceived);
             }
             Message::ZapReceiptAdded { event } => {
-                if let Some(target_event_id) = find_event_id_from_last_e_tag(&event) {
-                    self.notes.entry(target_event_id).and_modify(|note| {
-                        note.update(TextNoteMessage::ZapReceiptReceived(event));
-                    });
-                }
+                self.apply_engagement(event, TextNoteMessage::ZapReceiptReceived);
             }
             Message::PreviousItemSelected => {
                 let tab = self.active_tab_mut();


### PR DESCRIPTION
## Summary

The `ReactionAdded`, `RepostAdded` and `ZapReceiptAdded` arms of `Timeline::update` were structurally identical — each looked up the target note via the last `e` tag and forwarded a corresponding `TextNote` message. Only the message variant differed, leaving three copies of the same body (a duplication smell found during review of `src/model/timeline.rs`).

## Changes

- Add a private `apply_engagement(event, to_message: fn(Event) -> TextNoteMessage)` helper that performs the shared lookup-and-forward logic.
- Replace the three duplicated arms with one-line calls passing the respective `TextNoteMessage` tuple-variant constructor.

`find_event_id_from_last_e_tag` borrows the event before `to_message(event)` consumes it, so ownership is fine. No behavior change.

## Verification

- `just build` — ok
- `just test` — 351 passed, 0 failed (existing reaction/repost/zap tests cover the behavior)
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)