### PR TITLE
refactor: remove unused Timeline::new with broken signature

### DIFF
--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -99,11 +99,6 @@ impl Timeline {
         }
     }
 
-    /// Create a Timeline
-    pub fn new(&self) -> Self {
-        Self::default()
-    }
-
     /// Get all tabs
     pub fn tabs(&self) -> &[TimelineTab] {
         &self.tabs


### PR DESCRIPTION
## Summary

`Timeline::new` had the signature `pub fn new(&self) -> Self` — it took `&self` (unusual for a constructor), ignored it, and simply returned `Self::default()`. It had no callers anywhere:

- Production constructs `Timeline` through `AppState`'s derived `Default`.
- Tests use `Timeline::default()` or the test-only `Timeline::new_loaded()`.

This was flagged during review of `src/model/timeline.rs` as a non-idiomatic, dead method.

## Changes

- Remove the unused `Timeline::new` method and rely on the existing `Default` impl, which is the idiomatic constructor already in use.

## Verification

- `just build` — ok
- `just test` — 351 passed, 0 failed
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)