### PR TITLE
refactor: move initial-load input gate from Timeline to app layer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -871,16 +871,11 @@ mod tests {
                 label: "Home".to_owned(),
                 message: "loading...".to_owned(),
             });
-        let loading_message = app.state.status_bar.message().map(str::to_owned);
-        assert!(loading_message.is_some());
 
         // While loading, a timeline operation is ignored and the status message
         // is preserved (the gate returns before clearing it).
         let _ = app.update(AppMsg::Timeline(TimelineMsg::Deselect));
-        assert_eq!(
-            app.state.status_bar.message().map(str::to_owned),
-            loading_message
-        );
+        assert_eq!(app.state.status_bar.message(), Some("[Home] loading..."));
 
         // Once the initial load completes, the same operation goes through and
         // clears the status message.

--- a/src/app.rs
+++ b/src/app.rs
@@ -306,6 +306,13 @@ impl<'a> TearsApp<'a> {
 
     /// Handle timeline messages
     fn handle_timeline_msg(&mut self, msg: TimelineMsg) -> Command<AppMsg> {
+        // Ignore timeline operations while the initial load is in progress, so the
+        // "loading..." status message is preserved until the first event arrives.
+        // Quitting is handled via SystemMsg and is unaffected by this gate.
+        if self.state.initial_load.is_loading() {
+            return Command::none();
+        }
+
         //  Clear status message
         self.state
             .status_bar
@@ -670,7 +677,7 @@ impl<'a> TearsApp<'a> {
                         event,
                     } = message
                     {
-                        if self.state.timeline.is_loading() {
+                        if self.state.initial_load.is_loading() {
                             let tab_title = self
                                 .state
                                 .timeline
@@ -849,6 +856,36 @@ mod tests {
 
         // Both selection and status message should be cleared
         assert_eq!(app.state.timeline.selected_note(), None);
+        assert_eq!(app.state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn test_timeline_ops_ignored_while_initial_loading() {
+        let mut app = create_test_app();
+        assert!(app.state.initial_load.is_loading());
+
+        // Simulate the "loading..." status message shown during initial load
+        app.state
+            .status_bar
+            .update(StatusBarMessage::MessageChanged {
+                label: "Home".to_owned(),
+                message: "loading...".to_owned(),
+            });
+        let loading_message = app.state.status_bar.message().map(str::to_owned);
+        assert!(loading_message.is_some());
+
+        // While loading, a timeline operation is ignored and the status message
+        // is preserved (the gate returns before clearing it).
+        let _ = app.update(AppMsg::Timeline(TimelineMsg::Deselect));
+        assert_eq!(
+            app.state.status_bar.message().map(str::to_owned),
+            loading_message
+        );
+
+        // Once the initial load completes, the same operation goes through and
+        // clears the status message.
+        app.state.initial_load.mark_completed();
+        let _ = app.update(AppMsg::Timeline(TimelineMsg::Deselect));
         assert_eq!(app.state.status_bar.message(), None);
     }
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -18,6 +18,28 @@ pub mod user;
 
 pub use user::UserState;
 
+/// Tracks whether the initial timeline load is still in progress.
+///
+/// While loading, the application ignores timeline operations so the
+/// "loading..." status message is preserved until the first event arrives.
+/// `Default` starts in the loading state.
+#[derive(Debug, Clone, Default)]
+pub struct InitialLoad {
+    completed: bool,
+}
+
+impl InitialLoad {
+    /// Whether the initial load is still in progress
+    pub fn is_loading(&self) -> bool {
+        !self.completed
+    }
+
+    /// Mark the initial load as completed (idempotent)
+    pub fn mark_completed(&mut self) {
+        self.completed = true;
+    }
+}
+
 /// Unified application state
 #[derive(Debug, Default)]
 pub struct AppState<'a> {
@@ -28,6 +50,7 @@ pub struct AppState<'a> {
     pub config: ConfigState,
     pub fps: Fps,
     pub status_bar: StatusBar,
+    pub initial_load: InitialLoad,
 }
 
 /// Configuration state - holds all user-configurable settings
@@ -61,6 +84,9 @@ impl<'a> AppState<'a> {
         event: Event,
         tab_type: &TimelineTabType,
     ) -> Command<AppMsg> {
+        // Receiving any event means the initial load has produced results.
+        self.initial_load.mark_completed();
+
         match event.kind {
             Kind::TextNote => {
                 let current_loading_more_state = self.timeline.is_loading_more_for_tab(tab_type);
@@ -120,7 +146,24 @@ mod tests {
 
         assert_eq!(state.timeline.len(), 0);
         assert!(!state.editor.is_active());
-        assert!(state.timeline.is_loading());
+        assert!(state.initial_load.is_loading());
+    }
+
+    #[test]
+    fn test_initial_load_default_is_loading() {
+        let initial_load = InitialLoad::default();
+        assert!(initial_load.is_loading());
+    }
+
+    #[test]
+    fn test_initial_load_mark_completed() {
+        let mut initial_load = InitialLoad::default();
+        initial_load.mark_completed();
+        assert!(!initial_load.is_loading());
+
+        // mark_completed is idempotent
+        initial_load.mark_completed();
+        assert!(!initial_load.is_loading());
     }
 
     #[test]
@@ -190,7 +233,7 @@ mod tests {
         let mut state = AppState::new(current_user_pubkey);
 
         // Use pre-loaded timeline for testing
-        state.timeline = Timeline::new_loaded();
+        state.timeline = Timeline::default();
 
         // Ensure Home tab is active.
         let _ = state
@@ -234,7 +277,7 @@ mod tests {
         let mut state = AppState::new(current_user_pubkey);
 
         // Use pre-loaded timeline for testing
-        state.timeline = Timeline::new_loaded();
+        state.timeline = Timeline::default();
 
         let author_keys = Keys::generate();
         let author_pubkey = author_keys.public_key();

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -150,12 +150,6 @@ mod tests {
     }
 
     #[test]
-    fn test_initial_load_default_is_loading() {
-        let initial_load = InitialLoad::default();
-        assert!(initial_load.is_loading());
-    }
-
-    #[test]
     fn test_initial_load_mark_completed() {
         let mut initial_load = InitialLoad::default();
         initial_load.mark_completed();

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -52,28 +52,6 @@ pub enum Message {
     PreviousTabSelected,
 }
 
-impl Message {
-    /// Check if this message represents a user operation
-    ///
-    /// User operations are navigation and selection actions that should be blocked during loading.
-    /// Data updates (notes, reactions, etc.) and tab management (adding/removing tabs) are not
-    /// considered user operations and are allowed during loading.
-    pub fn is_user_operation(&self) -> bool {
-        matches!(
-            self,
-            Message::PreviousItemSelected
-                | Message::NextItemSelected
-                | Message::FirstItemSelected
-                | Message::LastItemSelected
-                | Message::ItemSelected { .. }
-                | Message::ItemSelectionCleared
-                | Message::TabSelected { .. }
-                | Message::NextTabSelected
-                | Message::PreviousTabSelected
-        )
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Timeline {
     // Tab management
@@ -83,9 +61,6 @@ pub struct Timeline {
     // Centralized event storage (shared across all tabs)
     // Each event is stored once here and referenced by EventId from tabs
     notes: HashMap<EventId, TextNote>,
-
-    // Loading state for initial load
-    is_loading: bool,
 }
 
 impl Timeline {
@@ -107,11 +82,6 @@ impl Timeline {
     /// Get the active tab index
     pub fn active_tab_index(&self) -> usize {
         self.active_tab_index
-    }
-
-    /// Check if timeline is loading
-    pub fn is_loading(&self) -> bool {
-        self.is_loading
     }
 
     /// Get the last tab index
@@ -193,16 +163,8 @@ impl Timeline {
     }
 
     pub fn update(&mut self, message: Message) -> Command<AppMsg> {
-        // Block user operations during initial loading
-        if self.is_loading && message.is_user_operation() {
-            return Command::none();
-        }
-
         match message {
             Message::NoteAddedToTab { event, tab_type } => {
-                // Mark initial loading as complete when first note arrives
-                self.is_loading = false;
-
                 // Find the tab index for the specified tab type
                 let tab_index = match self.find_tab_by_type(&tab_type) {
                     Some(index) => index,
@@ -330,22 +292,6 @@ impl Default for Timeline {
             tabs: vec![TimelineTab::new_home()],
             active_tab_index: 0,
             notes: HashMap::new(),
-            is_loading: true,
-        }
-    }
-}
-
-#[cfg(test)]
-impl Timeline {
-    /// Create a Timeline for testing with loading completed
-    ///
-    /// This is a convenience method for tests that don't need to test loading behavior.
-    pub fn new_loaded() -> Self {
-        Self {
-            tabs: vec![TimelineTab::new_home()],
-            active_tab_index: 0,
-            notes: HashMap::new(),
-            is_loading: false,
         }
     }
 }
@@ -405,7 +351,6 @@ mod tests {
         assert_eq!(timeline.len(), 0);
         assert!(timeline.is_empty());
         assert_eq!(timeline.selected_index(), None);
-        assert!(timeline.is_loading());
     }
 
     #[test]
@@ -457,7 +402,6 @@ mod tests {
         assert!(!timeline.is_empty());
         assert!(timeline.notes.contains_key(&event_id));
         assert_eq!(timeline.oldest_timestamp(), Some(Timestamp::from(1000)));
-        assert!(!timeline.is_loading());
     }
 
     #[test]
@@ -961,7 +905,7 @@ mod tests {
 
     #[test]
     fn test_tab_selected() {
-        let mut timeline = Timeline::new_loaded();
+        let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
@@ -989,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_next_tab_selected() {
-        let mut timeline = Timeline::new_loaded();
+        let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
@@ -1011,7 +955,7 @@ mod tests {
 
     #[test]
     fn test_previous_tab_selected() {
-        let mut timeline = Timeline::new_loaded();
+        let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
@@ -1089,200 +1033,5 @@ mod tests {
         });
 
         assert_eq!(timeline.last_tab_index(), 1);
-    }
-
-    #[test]
-    fn test_is_loading_changes_on_first_note() {
-        let mut timeline = Timeline::default();
-        assert!(timeline.is_loading());
-
-        let event = create_test_event(1000, 1, "First note");
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event,
-            tab_type: TimelineTabType::Home,
-        });
-
-        assert!(!timeline.is_loading());
-    }
-
-    #[test]
-    fn test_is_loading_remains_false_after_first_note() {
-        let mut timeline = Timeline::default();
-
-        // Add first note
-        let event1 = create_test_event(1000, 1, "First note");
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event: event1,
-            tab_type: TimelineTabType::Home,
-        });
-
-        assert!(!timeline.is_loading());
-
-        // Add second note
-        let event2 = create_test_event(2000, 2, "Second note");
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event: event2,
-            tab_type: TimelineTabType::Home,
-        });
-
-        assert!(!timeline.is_loading());
-    }
-
-    #[test]
-    fn test_user_operations_blocked_when_loading() {
-        let mut timeline = Timeline::default();
-        // Timeline starts in loading state
-        assert!(timeline.is_loading());
-
-        // Try to select an item - should be ignored
-        let _ = timeline.update(Message::ItemSelected { index: 0 });
-        assert_eq!(timeline.selected_index(), None);
-
-        // Try to navigate - should be ignored
-        let _ = timeline.update(Message::PreviousItemSelected);
-        assert_eq!(timeline.selected_index(), None);
-
-        let _ = timeline.update(Message::NextItemSelected);
-        assert_eq!(timeline.selected_index(), None);
-
-        // Try to select first/last - should be ignored
-        let _ = timeline.update(Message::FirstItemSelected);
-        assert_eq!(timeline.selected_index(), None);
-
-        let _ = timeline.update(Message::LastItemSelected);
-        assert_eq!(timeline.selected_index(), None);
-    }
-
-    #[test]
-    fn test_user_operations_allowed_after_loading() {
-        let mut timeline = Timeline::new_loaded();
-
-        // Add a note so we have something to select
-        let event = create_test_event(1000, 1, "Test note");
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event,
-            tab_type: TimelineTabType::Home,
-        });
-
-        assert!(!timeline.is_loading());
-
-        // Now user operations should work
-        let _ = timeline.update(Message::ItemSelected { index: 0 });
-        assert_eq!(timeline.selected_index(), Some(0));
-    }
-
-    #[test]
-    fn test_tab_selection_blocked_when_loading() {
-        let mut timeline = Timeline::default();
-        assert!(timeline.is_loading());
-
-        let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-
-        // Add tab should work during loading (it's data management)
-        let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
-        });
-        assert_eq!(timeline.tabs().len(), 2); // Home + new tab
-
-        // But tab selection should be blocked
-        let original_index = timeline.active_tab_index();
-        let _ = timeline.update(Message::TabSelected { index: 0 });
-        assert_eq!(timeline.active_tab_index(), original_index);
-
-        // Tab navigation should also be blocked
-        let _ = timeline.update(Message::NextTabSelected);
-        assert_eq!(timeline.active_tab_index(), original_index);
-
-        let _ = timeline.update(Message::PreviousTabSelected);
-        assert_eq!(timeline.active_tab_index(), original_index);
-    }
-
-    #[test]
-    fn test_data_updates_allowed_when_loading() {
-        let mut timeline = Timeline::default();
-        assert!(timeline.is_loading());
-
-        // Data updates should work even during loading
-        let event = create_test_event(1000, 1, "Test note");
-        let event_id = event.id;
-
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event,
-            tab_type: TimelineTabType::Home,
-        });
-
-        // Note should be added
-        assert_eq!(timeline.len(), 1);
-        assert!(timeline.notes.contains_key(&event_id));
-
-        // And loading should now be complete
-        assert!(!timeline.is_loading());
-    }
-
-    #[test]
-    fn test_reactions_allowed_when_loading() {
-        let mut timeline = Timeline::default();
-
-        // Add a note first (stops loading)
-        let text_event = create_test_event(1000, 1, "Original note");
-        let text_event_id = text_event.id;
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event: text_event.clone(),
-            tab_type: TimelineTabType::Home,
-        });
-
-        // Manually set back to loading state for testing
-        timeline.is_loading = true;
-
-        // Reaction should still work during loading
-        let reaction_event = create_reaction_event(&text_event, 1001);
-        let _ = timeline.update(Message::ReactionAdded {
-            event: reaction_event,
-        });
-
-        let note = timeline
-            .notes
-            .get(&text_event_id)
-            .expect("Note should exist");
-        assert_eq!(note.reactions_count(), 1);
-    }
-
-    #[test]
-    fn test_message_is_user_operation() {
-        // User operations (should return true)
-        assert!(Message::PreviousItemSelected.is_user_operation());
-        assert!(Message::NextItemSelected.is_user_operation());
-        assert!(Message::FirstItemSelected.is_user_operation());
-        assert!(Message::LastItemSelected.is_user_operation());
-        assert!(Message::ItemSelected { index: 0 }.is_user_operation());
-        assert!(Message::ItemSelectionCleared.is_user_operation());
-        assert!(Message::TabSelected { index: 0 }.is_user_operation());
-        assert!(Message::NextTabSelected.is_user_operation());
-        assert!(Message::PreviousTabSelected.is_user_operation());
-
-        // Data operations (should return false)
-        let event = create_test_event(1000, 1, "Test");
-        assert!(!Message::NoteAddedToTab {
-            event: event.clone(),
-            tab_type: TimelineTabType::Home,
-        }
-        .is_user_operation());
-        assert!(!Message::ReactionAdded {
-            event: event.clone(),
-        }
-        .is_user_operation());
-        assert!(!Message::RepostAdded {
-            event: event.clone(),
-        }
-        .is_user_operation());
-        assert!(!Message::ZapReceiptAdded { event }.is_user_operation());
-
-        // Tab management (should return false)
-        let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        assert!(!Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
-        }
-        .is_user_operation());
-        assert!(!Message::TabRemoved { index: 0 }.is_user_operation());
     }
 }

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_render_switching_tabs() {
-        let mut timeline = Timeline::new_loaded();
+        let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
         // Add a user timeline tab


### PR DESCRIPTION
## Summary

The "ignore timeline operations while the initial load is in progress" responsibility lived inside `Timeline` as an `is_loading` flag plus a `Message::is_user_operation` gate. This was misplaced (SRP review item #1):

- The side effect the feature exists to protect — the `loading...` status message — is cleared **unconditionally** at the top of `handle_timeline_msg` (app layer), which runs **upstream** of the model-level gate. So pressing `j`/`k`/`h`/`l` during loading still wiped `loading...`, defeating the feature.
- `Timeline.is_loading` was also redundant state: notes are never removed, so in production it was equivalent to "no event has arrived yet".

This PR relocates the concern to the layer that owns the relevant side effects and input routing.

## Changes

- Add `InitialLoad` to `AppState` — a small value object whose `Default` starts in the loading state (so `AppState`'s derived `Default` keeps working).
- Gate the **entire** `handle_timeline_msg` while loading, returning **before** the status is cleared. Quitting goes through `SystemMsg`, not this handler, so `q` / `Ctrl-c` keep working.
- Mark the load completed when the first event is ingested, in `process_nostr_event_for_tab` (replacing the old per-`TextNote` flag flip inside `Timeline`).
- Remove `Timeline::is_loading`, its getter, the in-`update` gate, `Message::is_user_operation`, and the `new_loaded` test helper.

## Behavior notes

- The `loading...` status is now genuinely preserved during loading — this is the bug the feature was meant to fix.
- Completion is unified to "first event of any kind", instead of the previously split "first `TextNote` flips the flag / first any-event shows the status".
- All user-initiated timeline operations (including react/repost/tab ops) are now ignored while loading. This is simpler than the old curated `is_user_operation` subset and closes its gaps. Relay-sourced data (reactions/reposts/zaps) is still ingested normally — only user input is gated.
- Pre-existing latent issue **not** addressed here (deliberately): a genuinely empty timeline (relay returns no events) leaves the app in the loading state. This is deferred to a follow-up that handles EOSE as the authoritative completion signal.

## Verification

- `just build` — ok
- `just test` — 347 passed, 0 failed
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)