### PR TITLE
refactor: rename InitialLoad to Startup to match its semantics

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -306,10 +306,10 @@ impl<'a> TearsApp<'a> {
 
     /// Handle timeline messages
     fn handle_timeline_msg(&mut self, msg: TimelineMsg) -> Command<AppMsg> {
-        // Ignore timeline operations while the initial load is in progress, so the
-        // "loading..." status message is preserved until the first event arrives.
+        // Ignore timeline operations while the application is still starting up, so
+        // the "loading..." status message is preserved until the first event arrives.
         // Quitting is handled via SystemMsg and is unaffected by this gate.
-        if self.state.initial_load.is_loading() {
+        if self.state.startup.is_in_progress() {
             return Command::none();
         }
 
@@ -677,7 +677,7 @@ impl<'a> TearsApp<'a> {
                         event,
                     } = message
                     {
-                        if self.state.initial_load.is_loading() {
+                        if self.state.startup.is_in_progress() {
                             let tab_title = self
                                 .state
                                 .timeline
@@ -860,11 +860,11 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_ops_ignored_while_initial_loading() {
+    fn test_timeline_ops_ignored_during_startup() {
         let mut app = create_test_app();
-        assert!(app.state.initial_load.is_loading());
+        assert!(app.state.startup.is_in_progress());
 
-        // Simulate the "loading..." status message shown during initial load
+        // Simulate the "loading..." status message shown during startup
         app.state
             .status_bar
             .update(StatusBarMessage::MessageChanged {
@@ -872,14 +872,14 @@ mod tests {
                 message: "loading...".to_owned(),
             });
 
-        // While loading, a timeline operation is ignored and the status message
+        // During startup, a timeline operation is ignored and the status message
         // is preserved (the gate returns before clearing it).
         let _ = app.update(AppMsg::Timeline(TimelineMsg::Deselect));
         assert_eq!(app.state.status_bar.message(), Some("[Home] loading..."));
 
-        // Once the initial load completes, the same operation goes through and
+        // Once startup completes, the same operation goes through and
         // clears the status message.
-        app.state.initial_load.mark_completed();
+        app.state.startup.mark_completed();
         let _ = app.update(AppMsg::Timeline(TimelineMsg::Deselect));
         assert_eq!(app.state.status_bar.message(), None);
     }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -18,23 +18,24 @@ pub mod user;
 
 pub use user::UserState;
 
-/// Tracks whether the initial timeline load is still in progress.
+/// Tracks whether the application is still starting up.
 ///
-/// While loading, the application ignores timeline operations so the
-/// "loading..." status message is preserved until the first event arrives.
-/// `Default` starts in the loading state.
+/// Startup lasts from launch until the first event arrives. While starting up,
+/// the application ignores timeline operations so the "loading..." status
+/// message is preserved. This is a startup indicator, not a data-completeness
+/// signal (it does not wait for EOSE). `Default` starts in the startup state.
 #[derive(Debug, Clone, Default)]
-pub struct InitialLoad {
+pub struct Startup {
     completed: bool,
 }
 
-impl InitialLoad {
-    /// Whether the initial load is still in progress
-    pub fn is_loading(&self) -> bool {
+impl Startup {
+    /// Whether the application is still starting up
+    pub fn is_in_progress(&self) -> bool {
         !self.completed
     }
 
-    /// Mark the initial load as completed (idempotent)
+    /// Mark startup as completed (idempotent)
     pub fn mark_completed(&mut self) {
         self.completed = true;
     }
@@ -50,7 +51,7 @@ pub struct AppState<'a> {
     pub config: ConfigState,
     pub fps: Fps,
     pub status_bar: StatusBar,
-    pub initial_load: InitialLoad,
+    pub startup: Startup,
 }
 
 /// Configuration state - holds all user-configurable settings
@@ -84,8 +85,8 @@ impl<'a> AppState<'a> {
         event: Event,
         tab_type: &TimelineTabType,
     ) -> Command<AppMsg> {
-        // Receiving any event means the initial load has produced results.
-        self.initial_load.mark_completed();
+        // Receiving any event means startup has produced its first results.
+        self.startup.mark_completed();
 
         match event.kind {
             Kind::TextNote => {
@@ -146,18 +147,18 @@ mod tests {
 
         assert_eq!(state.timeline.len(), 0);
         assert!(!state.editor.is_active());
-        assert!(state.initial_load.is_loading());
+        assert!(state.startup.is_in_progress());
     }
 
     #[test]
-    fn test_initial_load_mark_completed() {
-        let mut initial_load = InitialLoad::default();
-        initial_load.mark_completed();
-        assert!(!initial_load.is_loading());
+    fn test_startup_mark_completed() {
+        let mut startup = Startup::default();
+        startup.mark_completed();
+        assert!(!startup.is_in_progress());
 
         // mark_completed is idempotent
-        initial_load.mark_completed();
-        assert!(!initial_load.is_loading());
+        startup.mark_completed();
+        assert!(!startup.is_in_progress());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`InitialLoad` (added in #428) tracks "has the app received its first event since launch". This is a **startup indicator**, not a data-load-completion signal: it does not wait for EOSE and completes on the first event of any kind. Naming it `InitialLoad` / `is_loading` overstated it as "loading until done", which set the wrong expectation.

This renames the concept to reflect what it actually is. The user-facing `loading...` / `loaded` status strings are intentionally kept — they read naturally as a startup message.

## Changes

- `InitialLoad` → `Startup`, field `initial_load` → `startup`, `is_loading()` → `is_in_progress()`. `mark_completed()` is unchanged.
- Update doc comments to describe a startup indicator (and note it deliberately does not wait for EOSE).
- Rename the related tests accordingly.

Pure rename; behavior is identical.

## Context

This replaces the originally-considered "EOSE-based load completion" follow-up: EOSE is unnecessary for a startup indicator. A separate, lighter improvement (also completing startup on a timeout, to avoid a permanent input lock if no event ever arrives) is planned as a follow-up.

## Verification

- `just build` — ok
- `just test` — 346 passed, 0 failed
- `just lint` (clippy `-D warnings`) — clean
- `just fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)