### PR TITLE
feat: always include own posts in home timeline

### DIFF
--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -120,8 +120,18 @@ impl NostrEvents {
             .get_contact_list_public_keys(Duration::from_secs(DEFAULT_CONTACT_LIST_TIMEOUT_SECS))
             .await
         {
-            Ok(followings) => {
-                // Cache the contact list for future use
+            Ok(mut followings) => {
+                // Always include the user's own posts in the home timeline,
+                // even if they don't follow themselves.
+                if let Ok(signer) = client.signer().await {
+                    if let Ok(own_pubkey) = signer.get_public_key().await {
+                        if !followings.contains(&own_pubkey) {
+                            followings.push(own_pubkey);
+                        }
+                    }
+                }
+
+                // Cache the contact list (including own pubkey) for future use
                 {
                     let mut cache = contact_list_cache.write().await;
                     *cache = Some(followings.clone());


### PR DESCRIPTION
## Summary

The home timeline filter is built solely from the contact list returned by `get_contact_list_public_keys`, which does not include the user themselves. As a result, users who do not follow their own account never see their own posts in the home feed.

This change appends the user's own public key (obtained from the client signer) to the followings list before caching it, so that:

- the initial home subscription (backward / forward filters) includes the user's own posts, and
- subsequent `LoadMoreTimeline` requests (which reuse the cached contact list) also include them.

## Changes

- `src/infrastructure/subscription/nostr.rs`: in `initialize_timeline`, push the own pubkey into `followings` (deduplicated) before caching.

## Notes

- The behavior is fixed (no config option) per the issue discussion.
- The own pubkey is resolved from `client.signer()`, which is always set (either `Keys` or `PublicKeySigner`), so no additional state needs to be threaded through.

Related to #93. Intentionally not using a `Closes` keyword: it is unclear whether this fully resolves the original report, so the issue is kept open for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)