### PR TITLE
refactor: extract pure timeline filter construction into the domain layer

### DIFF
--- a/src/domain/nostr.rs
+++ b/src/domain/nostr.rs
@@ -3,6 +3,7 @@ pub mod nip10;
 pub mod nip27;
 pub mod nip38;
 mod profile;
+pub mod timeline_filter;
 
 pub use event::{find_event_id_from_last_e_tag, SortableEventId};
 pub use profile::Profile;

--- a/src/domain/nostr/timeline_filter.rs
+++ b/src/domain/nostr/timeline_filter.rs
@@ -1,0 +1,216 @@
+//! Pure timeline filter construction.
+//!
+//! This module isolates the logic that decides *which* Nostr events a timeline
+//! should request (kinds, author set, time window, limit) from the I/O that
+//! actually performs the subscription. The functions here are pure and free of
+//! any `Client` or framework dependency, which makes the filter rules
+//! unit-testable.
+//!
+//! These builders are intentionally agnostic of UI/model concepts such as tab
+//! types: the caller is responsible for mapping a tab to the appropriate
+//! builder. This keeps the domain layer free of dependencies on outer layers.
+
+use nostr_sdk::prelude::*;
+
+/// Maximum number of events fetched per timeline page.
+pub const DEFAULT_TIMELINE_LIMIT: usize = 50;
+
+/// Event kinds shown in the home timeline.
+pub const HOME_TIMELINE_KINDS: [Kind; 4] = [
+    Kind::TextNote,
+    Kind::Repost,
+    Kind::Reaction,
+    Kind::ZapReceipt,
+];
+
+/// Event kinds shown in a single user's timeline.
+pub const USER_TIMELINE_KINDS: [Kind; 2] = [Kind::TextNote, Kind::Repost];
+
+/// Ensure the user's own pubkey is part of the author set so that their posts
+/// always appear in the home timeline, even when they do not follow themselves.
+pub fn with_own_pubkey(mut authors: Vec<PublicKey>, own_pubkey: PublicKey) -> Vec<PublicKey> {
+    if !authors.contains(&own_pubkey) {
+        authors.push(own_pubkey);
+    }
+    authors
+}
+
+/// Build the three home-timeline subscription filters.
+///
+/// Returns `[backward, forward, profile]`:
+/// - `backward`: historical events up to `now` (bounded by the page limit)
+/// - `forward`: real-time events from `now` onward
+/// - `profile`: metadata for the same author set
+pub fn home_timeline_filters(authors: Vec<PublicKey>, now: Timestamp) -> [Filter; 3] {
+    let backward = Filter::new()
+        .authors(authors.clone())
+        .kinds(HOME_TIMELINE_KINDS)
+        .until(now)
+        .limit(DEFAULT_TIMELINE_LIMIT);
+    let forward = Filter::new()
+        .authors(authors.clone())
+        .kinds(HOME_TIMELINE_KINDS)
+        .since(now);
+    let profile = Filter::new().authors(authors).kinds([Kind::Metadata]);
+
+    [backward, forward, profile]
+}
+
+/// Build the backward + forward subscription filters for a user timeline.
+///
+/// Returns `[backward, forward]`:
+/// - `backward`: historical events up to `now` (bounded by the page limit)
+/// - `forward`: real-time events from `now` onward
+pub fn user_timeline_filters(pubkey: PublicKey, now: Timestamp) -> [Filter; 2] {
+    let backward = Filter::new()
+        .authors(vec![pubkey])
+        .kinds(USER_TIMELINE_KINDS)
+        .until(now)
+        .limit(DEFAULT_TIMELINE_LIMIT);
+    let forward = Filter::new()
+        .authors(vec![pubkey])
+        .kinds(USER_TIMELINE_KINDS)
+        .since(now);
+
+    [backward, forward]
+}
+
+/// Build the "load more" filter for paginating older home-timeline events
+/// before `since`, using the given author set.
+pub fn home_load_more_filter(authors: Vec<PublicKey>, since: Timestamp) -> Filter {
+    Filter::new()
+        .authors(authors)
+        .kinds(HOME_TIMELINE_KINDS)
+        .until(since)
+        .limit(DEFAULT_TIMELINE_LIMIT)
+}
+
+/// Build the "load more" filter for paginating older events before `since` on a
+/// single user's timeline.
+pub fn user_load_more_filter(pubkey: PublicKey, since: Timestamp) -> Filter {
+    Filter::new()
+        .authors(vec![pubkey])
+        .kinds(USER_TIMELINE_KINDS)
+        .until(since)
+        .limit(DEFAULT_TIMELINE_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pubkey(byte: u8) -> PublicKey {
+        PublicKey::from_slice(&[byte; 32]).expect("valid public key")
+    }
+
+    #[test]
+    fn test_with_own_pubkey_appends_when_absent() {
+        let own = pubkey(1);
+        let authors = vec![pubkey(2), pubkey(3)];
+
+        assert_eq!(
+            with_own_pubkey(authors, own),
+            vec![pubkey(2), pubkey(3), own]
+        );
+    }
+
+    #[test]
+    fn test_with_own_pubkey_keeps_unchanged_when_present() {
+        let own = pubkey(1);
+        let authors = vec![pubkey(2), own, pubkey(3)];
+
+        assert_eq!(
+            with_own_pubkey(authors, own),
+            vec![pubkey(2), own, pubkey(3)]
+        );
+    }
+
+    #[test]
+    fn test_with_own_pubkey_on_empty_authors() {
+        let own = pubkey(1);
+
+        assert_eq!(with_own_pubkey(Vec::new(), own), vec![own]);
+    }
+
+    #[test]
+    fn test_home_timeline_filters() {
+        let authors = vec![pubkey(1), pubkey(2)];
+        let now = Timestamp::from(1000);
+
+        let [backward, forward, profile] = home_timeline_filters(authors.clone(), now);
+
+        assert_eq!(
+            backward,
+            Filter::new()
+                .authors(authors.clone())
+                .kinds(HOME_TIMELINE_KINDS)
+                .until(now)
+                .limit(DEFAULT_TIMELINE_LIMIT)
+        );
+        assert_eq!(
+            forward,
+            Filter::new()
+                .authors(authors.clone())
+                .kinds(HOME_TIMELINE_KINDS)
+                .since(now)
+        );
+        assert_eq!(
+            profile,
+            Filter::new().authors(authors).kinds([Kind::Metadata])
+        );
+    }
+
+    #[test]
+    fn test_user_timeline_filters() {
+        let author = pubkey(7);
+        let now = Timestamp::from(2000);
+
+        let [backward, forward] = user_timeline_filters(author, now);
+
+        assert_eq!(
+            backward,
+            Filter::new()
+                .authors(vec![author])
+                .kinds(USER_TIMELINE_KINDS)
+                .until(now)
+                .limit(DEFAULT_TIMELINE_LIMIT)
+        );
+        assert_eq!(
+            forward,
+            Filter::new()
+                .authors(vec![author])
+                .kinds(USER_TIMELINE_KINDS)
+                .since(now)
+        );
+    }
+
+    #[test]
+    fn test_home_load_more_filter() {
+        let authors = vec![pubkey(1), pubkey(2)];
+        let since = Timestamp::from(500);
+
+        assert_eq!(
+            home_load_more_filter(authors.clone(), since),
+            Filter::new()
+                .authors(authors)
+                .kinds(HOME_TIMELINE_KINDS)
+                .until(since)
+                .limit(DEFAULT_TIMELINE_LIMIT)
+        );
+    }
+
+    #[test]
+    fn test_user_load_more_filter() {
+        let author = pubkey(9);
+        let since = Timestamp::from(500);
+
+        assert_eq!(
+            user_load_more_filter(author, since),
+            Filter::new()
+                .authors(vec![author])
+                .kinds(USER_TIMELINE_KINDS)
+                .until(since)
+                .limit(DEFAULT_TIMELINE_LIMIT)
+        );
+    }
+}

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -9,16 +9,13 @@ use nostr_sdk::prelude::*;
 use tears::{SubscriptionId, SubscriptionSource};
 use tokio::sync::{broadcast, mpsc, RwLock};
 
+use crate::domain::nostr::timeline_filter::{
+    home_load_more_filter, home_timeline_filters, user_load_more_filter, user_timeline_filters,
+    with_own_pubkey,
+};
 use crate::model::timeline::tab::TimelineTabType;
 
 const DEFAULT_CONTACT_LIST_TIMEOUT_SECS: u64 = 10;
-const DEFAULT_TIMELINE_LIMIT: usize = 50;
-const TIMELINE_KINDS: [Kind; 4] = [
-    Kind::TextNote,
-    Kind::Repost,
-    Kind::Reaction,
-    Kind::ZapReceipt,
-];
 
 /// Commands that can be sent to the Nostr subscription
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,9 +122,7 @@ impl NostrEvents {
                 // even if they don't follow themselves.
                 if let Ok(signer) = client.signer().await {
                     if let Ok(own_pubkey) = signer.get_public_key().await {
-                        if !followings.contains(&own_pubkey) {
-                            followings.push(own_pubkey);
-                        }
+                        followings = with_own_pubkey(followings, own_pubkey);
                     }
                 }
 
@@ -137,16 +132,8 @@ impl NostrEvents {
                     *cache = Some(followings.clone());
                 }
 
-                let timeline_backward_filter = Filter::new()
-                    .authors(followings.clone())
-                    .kinds(TIMELINE_KINDS)
-                    .until(Timestamp::now())
-                    .limit(DEFAULT_TIMELINE_LIMIT);
-                let timeline_forward_filter = Filter::new()
-                    .authors(followings.clone())
-                    .kinds(TIMELINE_KINDS)
-                    .since(Timestamp::now());
-                let profile_filter = Filter::new().authors(followings).kinds([Kind::Metadata]);
+                let [timeline_backward_filter, timeline_forward_filter, profile_filter] =
+                    home_timeline_filters(followings, Timestamp::now());
 
                 // Subscribe to both timeline and profile data concurrently
                 let result = tokio::try_join!(
@@ -226,32 +213,20 @@ impl NostrEvents {
                 }
             }
             NostrCommand::LoadMoreTimeline { tab_type, since } => {
-                // Load more timeline events before the specified timestamp
+                // Load more timeline events before the specified timestamp.
+                // Map the tab to the appropriate domain filter builder; the home
+                // timeline reuses the contact list cached at init time.
                 let filter = match &tab_type {
-                    TimelineTabType::Home => {
-                        // Use cached contact list from initialization
-                        let followings = {
-                            let cache = contact_list_cache.read().await;
-                            match cache.as_ref() {
-                                Some(list) => list.clone(),
-                                None => {
-                                    log::warn!("Contact list not cached, cannot load more events");
-                                    return;
-                                }
-                            }
-                        };
-
-                        Filter::new()
-                            .authors(followings)
-                            .kinds(TIMELINE_KINDS)
-                            .until(since) // flipped
-                            .limit(DEFAULT_TIMELINE_LIMIT)
+                    TimelineTabType::Home => match contact_list_cache.read().await.clone() {
+                        Some(authors) => home_load_more_filter(authors, since),
+                        None => {
+                            log::warn!("Contact list not cached, cannot load more events");
+                            return;
+                        }
+                    },
+                    TimelineTabType::UserTimeline { pubkey } => {
+                        user_load_more_filter(*pubkey, since)
                     }
-                    TimelineTabType::UserTimeline { pubkey } => Filter::new()
-                        .authors(vec![*pubkey])
-                        .kinds(vec![Kind::TextNote, Kind::Repost])
-                        .until(since) // flipped
-                        .limit(DEFAULT_TIMELINE_LIMIT),
                 };
 
                 match client.subscribe(filter, None).await {
@@ -276,16 +251,8 @@ impl NostrEvents {
                     }
                     TimelineTabType::UserTimeline { pubkey } => {
                         // Subscribe to both backward (historical) and forward (real-time) events
-                        let backward_filter = Filter::new()
-                            .authors(vec![*pubkey])
-                            .kinds(vec![Kind::TextNote, Kind::Repost])
-                            .until(Timestamp::now())
-                            .limit(DEFAULT_TIMELINE_LIMIT);
-
-                        let forward_filter = Filter::new()
-                            .authors(vec![*pubkey])
-                            .kinds(vec![Kind::TextNote, Kind::Repost])
-                            .since(Timestamp::now());
+                        let [backward_filter, forward_filter] =
+                            user_timeline_filters(*pubkey, Timestamp::now());
 
                         // Subscribe to both filters concurrently
                         let result = tokio::try_join!(


### PR DESCRIPTION
## Summary

Extracts the Nostr timeline filter logic out of the async, `Client`-coupled
methods in `infrastructure/subscription/nostr.rs` into a pure module in the
**domain layer** (`domain/nostr/timeline_filter`):

- `with_own_pubkey` — ensures the user's own pubkey is part of the home author set
- `home_timeline_filters` / `user_timeline_filters` — build the backward/forward (and profile) filters for a given author set and `now`
- `home_load_more_filter` / `user_load_more_filter` — build the pagination filters

## Motivation

These rules (which event kinds, the page limit, the `until`/`since` windows, and
the "always include own posts" merge) are pure functions of their inputs, but
they were embedded inside `initialize_timeline` and `handle_command`, where they
could only be run against a live `Client`. As a result the filter rules —
including the recently added "include own posts in the home feed" behavior — had
**no unit coverage**.

Filter construction is pure Nostr logic with no I/O, so it belongs in the domain
layer rather than under `infrastructure/subscription`, which exists for the tears
subscription sources. The builders are kept free of any dependency on outer
layers: the previous `load_more_filter` took a `TimelineTabType` (a model
concept), which would have forced a `domain -> model` dependency, so it is split
into tab-agnostic `home_load_more_filter` / `user_load_more_filter`, with the tab
dispatch staying in the subscription layer where tab routing already lives.

## Behavior

No behavior change. The refactor is mechanical; the constructed filters are
identical to before.

## Tests

Adds unit tests for the own-pubkey merge (absent / present / empty), the home and
user timeline filter sets, and the home/user load-more filters.

`just lint`, `just test`, and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)