### PR TITLE
refactor: move created_at formatting from model to widget

### DIFF
--- a/src/model/timeline/text_note.rs
+++ b/src/model/timeline/text_note.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Local};
 use nostr_sdk::prelude::*;
 
 use crate::domain::collections::EventSet;
@@ -49,12 +48,8 @@ impl TextNote {
         &self.event.content
     }
 
-    pub fn created_at(&self) -> String {
-        DateTime::from_timestamp(self.event.created_at.as_secs() as i64, 0)
-            .expect("Invalid created_at")
-            .with_timezone(&Local)
-            .format("%T")
-            .to_string()
+    pub fn created_at(&self) -> Timestamp {
+        self.event.created_at
     }
 
     pub fn reactions_count(&self) -> usize {
@@ -166,6 +161,7 @@ mod tests {
         assert_eq!(text_note.id(), event.id);
         assert_eq!(text_note.author_pubkey(), event.pubkey);
         assert_eq!(text_note.content(), &event.content);
+        assert_eq!(text_note.created_at(), event.created_at);
         assert_eq!(text_note.reactions_count(), 0);
         assert_eq!(text_note.reposts_count(), 0);
         assert_eq!(text_note.zap_amount(), 0);
@@ -180,19 +176,6 @@ mod tests {
 
         let bech32 = text_note.bech32_id();
         assert!(bech32.starts_with("note1"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_created_at_format() -> Result<(), Box<dyn Error>> {
-        let event = create_test_event("Test")?;
-        let text_note = TextNote::new(event);
-
-        let created_at = text_note.created_at();
-        // Format should be HH:MM:SS
-        assert!(created_at.contains(':'));
-        assert_eq!(created_at.len(), 8);
 
         Ok(())
     }

--- a/src/presentation/widgets/text_note.rs
+++ b/src/presentation/widgets/text_note.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 
+use chrono::{DateTime, Local};
 use nostr_sdk::prelude::*;
 use ratatui::{
     prelude::*,
@@ -45,6 +46,16 @@ impl<'a> TextNoteWidget<'a> {
                     })
             })
             .collect()
+    }
+
+    /// Format this note's creation time for display as a local `HH:MM:SS`
+    /// wall-clock.
+    fn formatted_created_at(&self) -> String {
+        DateTime::from_timestamp(self.text_note.created_at().as_secs() as i64, 0)
+            .expect("Invalid created_at")
+            .with_timezone(&Local)
+            .format("%T")
+            .to_string()
     }
 
     pub fn calculate_height(&self, area: &Rect, padding: Padding) -> u16 {
@@ -114,11 +125,10 @@ impl<'a> Widget for TextNoteWidget<'a> {
         .into();
         text.extend(content);
 
+        let created_at = self.formatted_created_at();
         let meta = match self.text_note.find_client_tag() {
-            Some(TagStandard::Client { name, .. }) => {
-                format!("{} | via {name}", self.text_note.created_at())
-            }
-            _ => self.text_note.created_at(),
+            Some(TagStandard::Client { name, .. }) => format!("{created_at} | via {name}"),
+            _ => created_at,
         };
         text.extend(Text::from(Line::styled(
             meta,
@@ -167,6 +177,29 @@ mod tests {
             Metadata::new().name(name)
         };
         Profile::new(keys.public_key(), Timestamp::now(), metadata)
+    }
+
+    #[test]
+    fn test_formatted_created_at_produces_wall_clock() -> Result<(), Box<dyn Error>> {
+        let event = create_test_event("Test")?;
+        let text_note = TextNote::new(event);
+
+        let profiles = HashMap::new();
+        let ctx = ViewContext {
+            profiles: &profiles,
+            live_status: None,
+            selected: false,
+        };
+        let widget = TextNoteWidget::new(text_note, ctx);
+
+        // Local-timezone formatting varies by machine, so assert the stable
+        // HH:MM:SS shape rather than an exact wall-clock value.
+        let formatted = widget.formatted_created_at();
+
+        assert_eq!(formatted.len(), 8);
+        assert_eq!(formatted.match_indices(':').count(), 2);
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TextNote::created_at` (in `model/timeline/text_note.rs`) returned a
locale/timezone-dependent `HH:MM:SS` string. This mixed a presentation concern
into the model layer, pulled a `chrono` dependency into the model, and made the
value impossible to test without depending on the machine's timezone.

This change:

- Has the model expose the raw `Timestamp` (`created_at(&self) -> Timestamp`).
- Moves the local `%T` wall-clock formatting into `TextNoteWidget` as a
  `formatted_created_at` method, alongside the other view logic.
- Drops the `chrono` dependency from the model layer.

## Behavior

No visible behavior change — the rendered timestamp is formatted exactly as
before (local timezone, `HH:MM:SS`).

## Tests

- Folds a `created_at` assertion into the existing `test_new_text_note` whole-object check.
- Removes the old model-level format test (it asserted presentation output).
- Adds a widget-level test for `formatted_created_at` asserting the stable
  `HH:MM:SS` shape (an exact wall-clock value would be timezone-dependent).

`just lint`, `just test`, and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)