### PR TITLE
refactor: delegate tab open/close coordination to AppState

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,6 @@ use crate::model::editor::Message as EditorMessage;
 use crate::model::fps::Message as FpsMessage;
 use crate::model::nostr::Message as NostrMessage;
 use crate::model::status_bar::Message as StatusBarMessage;
-use crate::model::timeline::tab::TimelineTabType;
 use crate::model::timeline::Message as TimelineMessage;
 use crate::presentation::components::Components;
 use crate::presentation::config::keybindings::Action as KeyAction;
@@ -435,70 +434,17 @@ impl<'a> TearsApp<'a> {
             }
             TimelineMsg::OpenAuthorTimeline => {
                 // Open author timeline for the selected note's author
-                if let Some(event) = self.state.timeline.selected_note() {
-                    let author_pubkey = event.author_pubkey();
-                    let Ok(author_npub) = author_pubkey.to_bech32();
-                    let tab_type = TimelineTabType::UserTimeline {
-                        pubkey: author_pubkey,
-                    };
-
-                    // Check if tab already exists
-                    if let Some(index) = self.state.timeline.find_tab_by_type(&tab_type) {
-                        // Tab exists, just switch to it
-                        let _ = self
-                            .state
-                            .timeline
-                            .update(TimelineMessage::TabSelected { index });
-                    } else {
-                        // Tab doesn't exist, create a new one
-                        let _ = self.state.timeline.update(TimelineMessage::TabAdded {
-                            tab_type: tab_type.clone(),
-                        });
-
-                        if let Some(_index) = self.state.timeline.find_tab_by_type(&tab_type) {
-                            log::info!("Created new author timeline for {author_npub}");
-
-                            // Send subscription command
-                            self.state
-                                .nostr
-                                .update(NostrMessage::SubscriptionRequested { tab_type });
-
-                            log::info!("Sent SubscribeTimeline command for user: {author_npub}");
-
-                            self.state
-                                .status_bar
-                                .update(StatusBarMessage::MessageChanged {
-                                    label: author_npub,
-                                    message: "loading...".to_owned(),
-                                });
-                        } else {
-                            log::error!("Failed to create author timeline");
-                            self.state
-                                .status_bar
-                                .update(StatusBarMessage::ErrorMessageChanged {
-                                    label: author_npub,
-                                    message: "failed to open tab".to_owned(),
-                                });
-                        }
-                    }
+                let author_pubkey = self
+                    .state
+                    .timeline
+                    .selected_note()
+                    .map(|note| note.author_pubkey());
+                if let Some(author_pubkey) = author_pubkey {
+                    return self.state.open_author_timeline(author_pubkey);
                 }
             }
             TimelineMsg::CloseCurrentTab => {
-                // Close the current tab (only if it's not the Home tab)
-                let current_index = self.state.timeline.active_tab_index();
-
-                // Get the tab type before closing
-                let tab_type = self.state.timeline.active_tab().tab_type().clone();
-
-                // Close the tab
-                let _ = self.state.timeline.update(TimelineMessage::TabRemoved {
-                    index: current_index,
-                });
-
-                // Unsubscribe subscriptions associated with this tab.
-                self.state
-                    .nostr
-                    .update(NostrMessage::SubscriptionClosed { tab_type });
+                return self.state.close_current_tab();
             }
         }
         Command::none()
@@ -774,6 +720,7 @@ impl<'a> TearsApp<'a> {
 mod tests {
     use super::*;
     use crate::infrastructure::config::Config;
+    use crate::model::timeline::tab::TimelineTabType;
 
     /// Create a test app instance
     fn create_test_app() -> TearsApp<'static> {

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -8,7 +8,7 @@ use crate::{
     model::{
         editor::Editor,
         fps::Fps,
-        nostr::Nostr,
+        nostr::{Message as NostrMessage, Nostr},
         status_bar::{Message, StatusBar},
         timeline::{tab::TimelineTabType, Message as TimelineMessage, Timeline},
     },
@@ -127,6 +127,71 @@ impl<'a> AppState<'a> {
                 .update(TimelineMessage::ZapReceiptAdded { event }),
             _ => Command::none(),
         }
+    }
+
+    /// Open (or switch to) the author timeline tab for the given pubkey.
+    ///
+    /// If a tab for this author already exists, it is selected. Otherwise a new
+    /// tab is created, a subscription is requested, and a "loading" status
+    /// message is shown (or an error message if the tab could not be created).
+    pub fn open_author_timeline(&mut self, author_pubkey: PublicKey) -> Command<AppMsg> {
+        let Ok(author_npub) = author_pubkey.to_bech32();
+        let tab_type = TimelineTabType::UserTimeline {
+            pubkey: author_pubkey,
+        };
+
+        // Tab already open: just switch to it.
+        if let Some(index) = self.timeline.find_tab_by_type(&tab_type) {
+            let _ = self.timeline.update(TimelineMessage::TabSelected { index });
+            return Command::none();
+        }
+
+        // Otherwise create it, then subscribe and show the loading status.
+        let _ = self.timeline.update(TimelineMessage::TabAdded {
+            tab_type: tab_type.clone(),
+        });
+
+        if self.timeline.find_tab_by_type(&tab_type).is_some() {
+            log::info!("Created new author timeline for {author_npub}");
+
+            self.nostr
+                .update(NostrMessage::SubscriptionRequested { tab_type });
+
+            self.status_bar.update(Message::MessageChanged {
+                label: author_npub,
+                message: "loading...".to_owned(),
+            });
+        } else {
+            log::error!("Failed to create author timeline");
+
+            self.status_bar.update(Message::ErrorMessageChanged {
+                label: author_npub,
+                message: "failed to open tab".to_owned(),
+            });
+        }
+
+        Command::none()
+    }
+
+    /// Close the currently active tab and unsubscribe from its subscriptions.
+    ///
+    /// The Home tab cannot be closed; the [`Timeline`] enforces this, so calling
+    /// this while Home is active is a no-op apart from the (no-op) unsubscribe.
+    pub fn close_current_tab(&mut self) -> Command<AppMsg> {
+        let current_index = self.timeline.active_tab_index();
+
+        // Capture the tab type before removing the tab.
+        let tab_type = self.timeline.active_tab().tab_type().clone();
+
+        let _ = self.timeline.update(TimelineMessage::TabRemoved {
+            index: current_index,
+        });
+
+        // Unsubscribe the subscriptions associated with the closed tab.
+        self.nostr
+            .update(NostrMessage::SubscriptionClosed { tab_type });
+
+        Command::none()
     }
 }
 
@@ -357,5 +422,89 @@ mod tests {
         assert_eq!(state.user.profile_count(), 0);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_open_author_timeline_switches_to_existing_tab() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let author_pubkey = Keys::generate().public_key();
+        let tab_type = TimelineTabType::UserTimeline {
+            pubkey: author_pubkey,
+        };
+
+        // Pre-create the author tab, then move focus back to Home.
+        let _ = state.timeline.update(TimelineMessage::TabAdded {
+            tab_type: tab_type.clone(),
+        });
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabSelected { index: 0 });
+        assert_eq!(state.timeline.active_tab_index(), 0);
+
+        let _ = state.open_author_timeline(author_pubkey);
+
+        // Switches to the existing tab instead of creating a duplicate.
+        assert_eq!(state.timeline.tabs().len(), 2);
+        assert_eq!(state.timeline.active_tab().tab_type(), &tab_type);
+    }
+
+    #[test]
+    fn test_open_author_timeline_creates_new_tab_and_shows_loading() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let author_pubkey = Keys::generate().public_key();
+        let Ok(author_npub) = author_pubkey.to_bech32();
+        let tab_type = TimelineTabType::UserTimeline {
+            pubkey: author_pubkey,
+        };
+
+        let _ = state.open_author_timeline(author_pubkey);
+
+        // A new author tab is created, focused, and a loading status is shown.
+        assert_eq!(state.timeline.tabs().len(), 2);
+        assert_eq!(state.timeline.active_tab().tab_type(), &tab_type);
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[{author_npub}] loading...").as_str())
+        );
+    }
+
+    #[test]
+    fn test_close_current_tab_removes_active_tab() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let author_pubkey = Keys::generate().public_key();
+        let tab_type = TimelineTabType::UserTimeline {
+            pubkey: author_pubkey,
+        };
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabAdded { tab_type });
+        assert_eq!(state.timeline.active_tab_index(), 1);
+
+        let _ = state.close_current_tab();
+
+        // The active author tab is removed and focus falls back to Home.
+        assert_eq!(state.timeline.tabs().len(), 1);
+        assert_eq!(
+            state.timeline.active_tab().tab_type(),
+            &TimelineTabType::Home
+        );
+    }
+
+    #[test]
+    fn test_close_current_tab_keeps_home_tab() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        assert_eq!(
+            state.timeline.active_tab().tab_type(),
+            &TimelineTabType::Home
+        );
+
+        let _ = state.close_current_tab();
+
+        // Home cannot be closed, so the timeline is unchanged.
+        assert_eq!(state.timeline.tabs().len(), 1);
+        assert_eq!(
+            state.timeline.active_tab().tab_type(),
+            &TimelineTabType::Home
+        );
     }
 }


### PR DESCRIPTION
## Summary

The `OpenAuthorTimeline` and `CloseCurrentTab` arms in `app.rs` carried multi-step
logic spanning the `timeline`, `nostr`, and `status_bar` subsystems. This is
contrary to `app.rs`'s role as a thin router that delegates logic to the state
layer (per the project guidelines), and it meant the coordination could only be
exercised through `app.rs`.

This change moves both flows into `AppState` methods, alongside the existing
`process_nostr_event_for_tab`:

- `open_author_timeline(author_pubkey)` — switches to an existing author tab, or
  creates one, requests a subscription, and shows the loading / error status.
- `close_current_tab()` — removes the active tab and unsubscribes from it.

`app.rs` now only extracts the selected note's author pubkey (input -> intent) and
delegates. The methods take plain data (mirroring `process_nostr_event_for_tab`),
so they can be unit-tested without driving the whole app.

## Behavior

No behavior change — the same tab/subscription/status updates happen, in the same
order.

## Tests

Adds `AppState`-level tests:
- switching to an already-open author tab (no duplicate)
- creating a new author tab with a `loading...` status
- closing the active tab (focus falls back to Home)
- the Home tab cannot be closed

The subscription side effects themselves remain covered by the existing
`model/nostr.rs` tests, so they are not re-asserted here.

`just lint`, `just test` (359 passed), and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)