### PR TITLE
refactor: delegate reaction/repost handling to AppState

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -363,44 +363,10 @@ impl<'a> TearsApp<'a> {
                 return self.load_more_timeline_events();
             }
             TimelineMsg::ReactToSelected => {
-                // React to the selected note
-                if let Some(note) = self.state.timeline.selected_note() {
-                    let note1 = note.bech32_id();
-                    log::info!("Reacting to event: {note1}");
-
-                    // Send the event
-                    let event_builder = note.reaction_builder();
-                    self.state
-                        .nostr
-                        .update(NostrMessage::EventSubmitted { event_builder });
-
-                    self.state
-                        .status_bar
-                        .update(StatusBarMessage::MessageChanged {
-                            label: "Reacted".to_string(),
-                            message: note1,
-                        });
-                }
+                return self.state.react_to_selected();
             }
             TimelineMsg::RepostSelected => {
-                // Repost the selected note
-                if let Some(note) = self.state.timeline.selected_note() {
-                    let note1 = note.bech32_id();
-                    log::info!("Reposting event: {note1}");
-
-                    // Send the event
-                    let event_builder = note.repost_builder();
-                    self.state
-                        .nostr
-                        .update(NostrMessage::EventSubmitted { event_builder });
-
-                    self.state
-                        .status_bar
-                        .update(StatusBarMessage::MessageChanged {
-                            label: "Reposted".to_owned(),
-                            message: note1,
-                        });
-                }
+                return self.state.repost_selected();
             }
             TimelineMsg::SelectTab(index) => {
                 // Select a specific tab by index

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -10,7 +10,9 @@ use crate::{
         fps::Fps,
         nostr::{Message as NostrMessage, Nostr},
         status_bar::{Message, StatusBar},
-        timeline::{tab::TimelineTabType, Message as TimelineMessage, Timeline},
+        timeline::{
+            tab::TimelineTabType, text_note::TextNote, Message as TimelineMessage, Timeline,
+        },
     },
 };
 
@@ -190,6 +192,42 @@ impl<'a> AppState<'a> {
         // Unsubscribe the subscriptions associated with the closed tab.
         self.nostr
             .update(NostrMessage::SubscriptionClosed { tab_type });
+
+        Command::none()
+    }
+
+    /// Submit a NIP-25 reaction for the currently selected note.
+    pub fn react_to_selected(&mut self) -> Command<AppMsg> {
+        self.submit_engagement_for_selected("Reacted", TextNote::reaction_builder)
+    }
+
+    /// Submit a NIP-18 repost for the currently selected note.
+    pub fn repost_selected(&mut self) -> Command<AppMsg> {
+        self.submit_engagement_for_selected("Reposted", TextNote::repost_builder)
+    }
+
+    /// Build an engagement event for the selected note with `build`, submit it,
+    /// and show `label` in the status bar. No-op when nothing is selected.
+    fn submit_engagement_for_selected(
+        &mut self,
+        label: &str,
+        build: fn(&TextNote) -> EventBuilder,
+    ) -> Command<AppMsg> {
+        let Some(note) = self.timeline.selected_note() else {
+            return Command::none();
+        };
+
+        let note_id = note.bech32_id();
+        let event_builder = build(note);
+        log::info!("{label} event: {note_id}");
+
+        self.nostr
+            .update(NostrMessage::EventSubmitted { event_builder });
+
+        self.status_bar.update(Message::MessageChanged {
+            label: label.to_owned(),
+            message: note_id,
+        });
 
         Command::none()
     }
@@ -506,5 +544,55 @@ mod tests {
             state.timeline.active_tab().tab_type(),
             &TimelineTabType::Home
         );
+    }
+
+    #[test]
+    fn test_react_to_selected_without_selection_is_noop() {
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let command = state.react_to_selected();
+
+        assert!(command.is_none());
+        assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn test_react_to_selected_sets_status() -> Result<()> {
+        let keys = Keys::generate();
+        let mut state = AppState::new(keys.public_key());
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        let _ = state.react_to_selected();
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reacted] {note1}").as_str())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repost_selected_sets_status() -> Result<()> {
+        let keys = Keys::generate();
+        let mut state = AppState::new(keys.public_key());
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        let _ = state.repost_selected();
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reposted] {note1}").as_str())
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

The `ReactToSelected` and `RepostSelected` arms in `app.rs` each read the selected
note, built an engagement event, submitted it via `nostr`, and updated the
`status_bar`. This multi-subsystem logic belongs in the state layer (per the
project guidelines), and it had no test coverage since it could only be driven
through `app.rs`.

This change moves both into `AppState`, following the pattern established by
`open_author_timeline` / `close_current_tab`:

- `react_to_selected()` / `repost_selected()` are thin wrappers over a shared
  `submit_engagement_for_selected(label, build)` helper that reads the selected
  note, builds the event, submits it, and sets the status (a no-op when nothing is
  selected). The helper also removes the duplication between the two arms.

`app.rs` now delegates each arm in a single line.

## Behavior

No behavior change — the same event submission and status update happen.

## Tests

Adds `AppState`-level tests:
- `react_to_selected` is a no-op with no selection (no status message)
- the resulting status message for both react (`[Reacted] <note1>`) and repost
  (`[Reposted] <note1>`)

The `EventSubmitted` wiring remains covered by the existing `model/nostr.rs` tests.

`just lint`, `just test` (362 passed), and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)