### PR TITLE
refactor: delegate nostr subscription handling to AppState

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -471,24 +471,7 @@ impl<'a> TearsApp<'a> {
         msg: NostrSubscriptionMessage,
     ) -> Command<AppMsg> {
         match msg {
-            NostrSubscriptionMessage::Ready { sender } => {
-                log::info!("NostrEvents subscription ready");
-                let tab_title = self
-                    .state
-                    .timeline
-                    .active_tab()
-                    .tab_title(self.state.user.profiles());
-                self.state.nostr.update(NostrMessage::ConnectionReady {
-                    command_sender: sender,
-                });
-                self.state
-                    .status_bar
-                    .update(StatusBarMessage::MessageChanged {
-                        label: tab_title,
-                        message: "loading...".to_owned(),
-                    });
-                Command::none()
-            }
+            NostrSubscriptionMessage::Ready { sender } => self.state.on_connection_ready(sender),
             NostrSubscriptionMessage::SubscriptionCreated {
                 tab_type,
                 subscription_id,
@@ -530,37 +513,8 @@ impl<'a> TearsApp<'a> {
                         event,
                     } = message
                     {
-                        if self.state.startup.is_in_progress() {
-                            let tab_title = self
-                                .state
-                                .timeline
-                                .active_tab()
-                                .tab_title(self.state.user.profiles());
-                            self.state
-                                .status_bar
-                                .update(StatusBarMessage::MessageChanged {
-                                    label: tab_title,
-                                    message: "loaded".to_owned(),
-                                });
-                        }
-
-                        // Find the tab that owns this subscription
-                        if let Some(tab_type) = self
-                            .state
-                            .nostr
-                            .find_tab_by_subscription(&subscription_id)
-                            .cloned()
-                        {
-                            log::debug!(
-                                "Routing event {} (kind: {:?}) to tab {tab_type:?}",
-                                event.id,
-                                event.kind
-                            );
-                            self.state
-                                .process_nostr_event_for_tab(event.into_owned(), &tab_type)
-                        } else {
-                            Command::none()
-                        }
+                        self.state
+                            .route_relay_event(&subscription_id, event.into_owned())
                     } else {
                         Command::none()
                     }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,11 +1,12 @@
 use nostr_sdk::prelude::*;
 use nowhear::Track;
 use tears::prelude::*;
+use tokio::sync::mpsc;
 
 use crate::{
     core::message::AppMsg,
     domain::nostr::{nip10::ReplyTagsBuilder, nip38::MusicStatus, Profile},
-    infrastructure::config::Config,
+    infrastructure::{config::Config, subscription::nostr::NostrCommand},
     model::{
         editor::{Editor, Message as EditorMessage},
         fps::Fps,
@@ -104,7 +105,7 @@ impl<'a> AppState<'a> {
 
                 if current_loading_more_state == Some(true) && new_loading_more_state == Some(false)
                 {
-                    let tab_title = self.timeline.active_tab().tab_title(self.user.profiles());
+                    let tab_title = self.active_tab_title();
                     self.status_bar.update(Message::MessageChanged {
                         label: tab_title,
                         message: "loaded more".to_owned(),
@@ -305,6 +306,64 @@ impl<'a> AppState<'a> {
         });
 
         Command::none()
+    }
+
+    /// Title of the currently active tab, resolved against known profiles.
+    fn active_tab_title(&self) -> String {
+        self.timeline.active_tab().tab_title(self.user.profiles())
+    }
+
+    /// Record that the Nostr subscription is ready and store its command sender,
+    /// then show the initial "loading" status for the active tab.
+    pub fn on_connection_ready(
+        &mut self,
+        command_sender: mpsc::UnboundedSender<NostrCommand>,
+    ) -> Command<AppMsg> {
+        log::info!("NostrEvents subscription ready");
+
+        let tab_title = self.active_tab_title();
+        self.nostr
+            .update(NostrMessage::ConnectionReady { command_sender });
+        self.status_bar.update(Message::MessageChanged {
+            label: tab_title,
+            message: "loading...".to_owned(),
+        });
+
+        Command::none()
+    }
+
+    /// Route an incoming relay event to the tab that owns its subscription.
+    ///
+    /// While still starting up, the first event flips the status to "loaded".
+    /// Events whose subscription is not tracked by any tab are ignored.
+    pub fn route_relay_event(
+        &mut self,
+        subscription_id: &SubscriptionId,
+        event: Event,
+    ) -> Command<AppMsg> {
+        if self.startup.is_in_progress() {
+            let tab_title = self.active_tab_title();
+            self.status_bar.update(Message::MessageChanged {
+                label: tab_title,
+                message: "loaded".to_owned(),
+            });
+        }
+
+        let Some(tab_type) = self
+            .nostr
+            .find_tab_by_subscription(subscription_id)
+            .cloned()
+        else {
+            return Command::none();
+        };
+
+        log::debug!(
+            "Routing event {} (kind: {:?}) to tab {tab_type:?}",
+            event.id,
+            event.kind
+        );
+
+        self.process_nostr_event_for_tab(event, &tab_type)
     }
 }
 
@@ -774,5 +833,55 @@ mod tests {
         let _ = state.publish_music_status(create_track(""));
 
         assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn test_on_connection_ready_marks_ready_and_shows_loading() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let _ = state.on_connection_ready(tx);
+
+        assert!(state.nostr.is_ready());
+        assert_eq!(state.status_bar.message(), Some("[Home] loading..."));
+    }
+
+    #[test]
+    fn test_route_relay_event_routes_to_owning_tab() -> Result<()> {
+        let keys = Keys::generate();
+        let mut state = AppState::new(keys.public_key());
+
+        // Associate a subscription with the Home tab.
+        let sub_id = SubscriptionId::new("home_sub");
+        state.nostr.update(NostrMessage::SubscriptionCreated {
+            tab_type: TimelineTabType::Home,
+            sub_id: sub_id.clone(),
+        });
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let _ = state.route_relay_event(&sub_id, event);
+
+        // The event is routed to the Home tab, and the first event ends startup.
+        assert_eq!(state.timeline.len(), 1);
+        assert!(!state.startup.is_in_progress());
+        assert_eq!(state.status_bar.message(), Some("[Home] loaded"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_route_relay_event_ignores_untracked_subscription() -> Result<()> {
+        let keys = Keys::generate();
+        let mut state = AppState::new(keys.public_key());
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let _ = state.route_relay_event(&SubscriptionId::new("unknown"), event);
+
+        // No tab owns the subscription, so the event is dropped, but the
+        // "loaded" status is still shown while starting up.
+        assert_eq!(state.timeline.len(), 0);
+        assert_eq!(state.status_bar.message(), Some("[Home] loaded"));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

PR C (final) of the `app.rs` -> state delegation series (after #438, #439).

Applied **partially**, as agreed: only the data-bearing sub-arms of
`handle_nostr_subscription_message` move to the state layer. The enum match and
the thin pass-throughs (`SubscriptionCreated`, `Shutdown`, `Error`, the
logged-only `Event` notification) stay in `app.rs` as routing.

Moves the two sub-arms that carry logic into `AppState`:

- `on_connection_ready(sender)` — stores the command sender and shows the initial
  `loading...` status for the active tab.
- `route_relay_event(subscription_id, event)` — flips the status to `loaded`
  during startup, finds the tab owning the subscription, and forwards the event
  (ignoring events for untracked subscriptions).

Also extracts a private `active_tab_title` helper for the active-tab title lookup
that was duplicated across these flows and `process_nostr_event_for_tab`.

`app.rs` now delegates the `Ready` and relay-`Event` arms in a single line each.

## Behavior

No behavior change.

## Tests

Adds `AppState`-level tests:
- `on_connection_ready` marks the connection ready and shows `[Home] loading...`
- `route_relay_event` routes an event to its owning tab (and ends startup)
- `route_relay_event` drops an event for an untracked subscription while still
  showing the `[Home] loaded` startup status

`just lint`, `just test` (371 passed), and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)