### PR TITLE
refactor: move load-more pagination into AppState

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -358,7 +358,7 @@ impl<'a> TearsApp<'a> {
             }
             // Load more older events
             TimelineMsg::LoadMore => {
-                return self.load_more_timeline_events();
+                return self.state.load_more_timeline();
             }
             TimelineMsg::ReactToSelected => {
                 return self.state.react_to_selected();
@@ -540,40 +540,6 @@ impl<'a> TearsApp<'a> {
                 Command::none()
             }
         }
-    }
-
-    /// Load more older timeline events for the active tab
-    fn load_more_timeline_events(&mut self) -> Command<AppMsg> {
-        log::info!("Loading more timeline events");
-
-        // Get the oldest timestamp from the active timeline
-        let since = match self.state.timeline.oldest_timestamp() {
-            Some(ts) => ts,
-            None => {
-                log::warn!("No oldest timestamp available, cannot load more");
-                return Command::none();
-            }
-        };
-
-        // Get the active tab type
-        let tab = self.state.timeline.active_tab();
-        let tab_type = tab.tab_type().clone();
-        let tab_title = tab.tab_title(self.state.user.profiles());
-
-        // Mark loading started
-        self.state
-            .nostr
-            .update(NostrMessage::HistoryRequested { tab_type, since });
-
-        // Set appropriate status message
-        self.state
-            .status_bar
-            .update(StatusBarMessage::MessageChanged {
-                label: tab_title,
-                message: "loading more...".to_owned(),
-            });
-
-        Command::none()
     }
 }
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -365,6 +365,30 @@ impl<'a> AppState<'a> {
 
         self.process_nostr_event_for_tab(event, &tab_type)
     }
+
+    /// Request older events for the active tab, paginating before its oldest
+    /// known timestamp. No-op when the active timeline has no events yet.
+    pub fn load_more_timeline(&mut self) -> Command<AppMsg> {
+        log::info!("Loading more timeline events");
+
+        let Some(since) = self.timeline.oldest_timestamp() else {
+            log::warn!("No oldest timestamp available, cannot load more");
+            return Command::none();
+        };
+
+        let tab_type = self.timeline.active_tab().tab_type().clone();
+        let tab_title = self.active_tab_title();
+
+        self.nostr
+            .update(NostrMessage::HistoryRequested { tab_type, since });
+
+        self.status_bar.update(Message::MessageChanged {
+            label: tab_title,
+            message: "loading more...".to_owned(),
+        });
+
+        Command::none()
+    }
 }
 
 #[cfg(test)]
@@ -865,6 +889,31 @@ mod tests {
         assert_eq!(state.timeline.len(), 1);
         assert!(!state.startup.is_in_progress());
         assert_eq!(state.status_bar.message(), Some("[Home] loaded"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_more_timeline_without_events_is_noop() {
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        // No events => no oldest timestamp => nothing to paginate.
+        let _ = state.load_more_timeline();
+
+        assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn test_load_more_timeline_sets_loading_status() -> Result<()> {
+        let keys = Keys::generate();
+        let mut state = AppState::new(keys.public_key());
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+
+        let _ = state.load_more_timeline();
+
+        assert_eq!(state.status_bar.message(), Some("[Home] loading more..."));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

`load_more_timeline_events` lived in `app.rs` but coordinated the timeline
(`oldest_timestamp` / active tab), `nostr` (`HistoryRequested`), and `status_bar`,
and carried the "no oldest timestamp" guard — logic that belongs in the state
layer (per the project guidelines) and had no test coverage.

This moves it to `AppState::load_more_timeline()`, reusing the `active_tab_title`
helper added in #440, and delegates the `LoadMore` arm to it in one line. The
standalone `app.rs` method is removed.

## Behavior

No behavior change.

## Tests

Adds `AppState`-level tests:
- no events => no oldest timestamp => no-op (no status message)
- with events, the active tab shows `[Home] loading more...`

`just lint`, `just test` (373 passed), and `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)