### PR TITLE
test: clean up tests to follow the project test conventions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -723,25 +723,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_p_submits_note_in_composing_mode() {
-        let mut app = create_test_app();
-
-        // Start composing mode with some content
-        app.state.editor.update(EditorMessage::ComposingStarted);
-
-        // Note: In real usage, content would be set via ProcessTextAreaInput messages
-        // For this test, we're just verifying the key handling produces the right command
-
-        // Ctrl+P should submit note
-        let ctrl_p_key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
-        let _cmd = app.handle_key_input(ctrl_p_key);
-
-        // Should produce SubmitNote command
-        // Note: Actual submission requires nostr connection, but we can verify
-        // the key handling produces the right command
-    }
-
-    #[test]
     fn test_select_tab() {
         let mut app = create_test_app();
 

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -389,158 +389,20 @@ mod tests {
     use super::*;
     use futures::StreamExt;
 
-    #[test]
-    fn test_nostr_events_creation() {
-        let client = Arc::new(Client::default());
-        let _nostr_events = NostrEvents::new(client);
-    }
-
     #[tokio::test]
-    async fn test_ready_message_provides_sender() {
+    async fn test_first_message_is_ready() {
         let client = Arc::new(Client::default());
         let nostr_events = NostrEvents::new(client);
 
         let mut stream = nostr_events.stream();
 
-        // First message should be Ready with command sender
-        if let Some(Message::Ready { sender }) = stream.next().await {
-            // Verify we can use the sender
-            assert!(sender.send(NostrCommand::Shutdown).is_ok());
-        } else {
-            panic!("Expected Ready message as first message");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_command_sender_can_be_cloned() {
-        let client = Arc::new(Client::default());
-        let nostr_events = NostrEvents::new(client);
-
-        let mut stream = nostr_events.stream();
-
-        // Get the command sender from Ready message
-        if let Some(Message::Ready { sender }) = stream.next().await {
-            let sender1 = sender.clone();
-            let sender2 = sender;
-
-            // Both senders should work
-            assert!(sender1.send(NostrCommand::Shutdown).is_ok());
-            assert!(sender2.send(NostrCommand::Shutdown).is_ok());
-        } else {
-            panic!("Expected Ready message");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_various_commands() {
-        let client = Arc::new(Client::default());
-        let nostr_events = NostrEvents::new(client);
-
-        let mut stream = nostr_events.stream();
-
-        // Get the command sender
-        if let Some(Message::Ready { sender }) = stream.next().await {
-            // Test sending various commands
-            assert!(sender
-                .send(NostrCommand::AddRelay {
-                    url: "wss://relay.example.com".to_string()
-                })
-                .is_ok());
-
-            assert!(sender
-                .send(NostrCommand::RemoveRelay {
-                    url: "wss://relay.example.com".to_string()
-                })
-                .is_ok());
-
-            assert!(sender.send(NostrCommand::Shutdown).is_ok());
-        } else {
-            panic!("Expected Ready message");
-        }
-    }
-
-    #[tokio::test]
-    async fn test_error_messages() -> Result<()> {
-        let client = Arc::new(Client::default());
-        let nostr_events = NostrEvents::new(client);
-
-        let mut stream = nostr_events.stream();
-
-        // Get the command sender
-        if let Some(Message::Ready { sender }) = stream.next().await {
-            // Try to add an invalid relay (should produce an error)
-            sender.send(NostrCommand::AddRelay {
-                url: "invalid-url".to_string(),
-            })?;
-
-            // Should receive an error message
-            // Note: Since this is async and depends on relay operations,
-            // we just verify the error variant exists
-            // In real usage, users would handle Message::Error { error } in their message loop
-        } else {
-            panic!("Expected Ready message");
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_command_error_types() {
-        // Test that error types can be constructed and matched
-        let error = CommandError::SendEventFailed {
-            error: "test error".to_string(),
-        };
-
-        match error {
-            CommandError::SendEventFailed { error } => {
-                assert_eq!(error, "test error");
-            }
-            _ => panic!("Wrong error variant"),
-        }
-
-        let error = CommandError::AddRelayFailed {
-            url: "wss://relay.test".to_string(),
-            error: "connection failed".to_string(),
-        };
-
-        match error {
-            CommandError::AddRelayFailed { url, error } => {
-                assert_eq!(url, "wss://relay.test");
-                assert_eq!(error, "connection failed");
-            }
-            _ => panic!("Wrong error variant"),
-        }
-    }
-
-    #[test]
-    fn test_message_variants() {
-        // Test that all message variants can be matched
-        let (tx, _rx) = mpsc::unbounded_channel();
-
-        // Test Ready variant
-        let msg = Message::Ready { sender: tx };
-        match msg {
-            Message::Ready { .. } => {} // OK
-            _ => panic!("Expected Ready variant"),
-        }
-
-        // Test Notification variant with Shutdown
-        let msg = Message::Notification(Box::new(RelayPoolNotification::Shutdown));
-        match msg {
-            Message::Notification(notif) if matches!(*notif, RelayPoolNotification::Shutdown) => {} // OK
-            _ => panic!("Expected Notification(Shutdown) variant"),
-        }
-
-        // Test Error variant
-        let msg = Message::Error {
-            error: CommandError::SendEventFailed {
-                error: "test".to_string(),
-            },
-        };
-        match msg {
-            Message::Error { .. } => {} // OK
-            _ => panic!("Expected Error variant"),
-        }
+        // The subscription emits a Ready message (carrying the command sender)
+        // before anything else.
+        let first = stream
+            .next()
+            .await
+            .expect("subscription should emit a first message");
+        assert!(matches!(first, Message::Ready { .. }));
     }
 
     #[test]

--- a/src/model/timeline/text_note.rs
+++ b/src/model/timeline/text_note.rs
@@ -302,14 +302,11 @@ mod tests {
         )?;
 
         let text_note = TextNote::new(reply_event);
-        let reply_tag = text_note.find_reply_tag();
 
-        assert!(reply_tag.is_some());
-        if let Some(TagStandard::Event { event_id, .. }) = reply_tag {
-            assert_eq!(*event_id, original_event.id);
-        } else {
-            panic!("Expected Event tag");
-        }
+        assert!(matches!(
+            text_note.find_reply_tag(),
+            Some(TagStandard::Event { event_id, .. }) if *event_id == original_event.id
+        ));
 
         Ok(())
     }

--- a/src/presentation/components/home/list.rs
+++ b/src/presentation/components/home/list.rs
@@ -91,22 +91,6 @@ mod tests {
     use nostr_sdk::prelude::*;
 
     #[test]
-    fn test_list_component_creation() {
-        let list = HomeListComponent::new();
-        let default_list = HomeListComponent;
-
-        assert_eq!(format!("{list:?}"), format!("{default_list:?}"));
-    }
-
-    #[test]
-    fn test_list_is_stateless() {
-        let list1 = HomeListComponent::new();
-        let list2 = HomeListComponent::new();
-
-        assert_eq!(format!("{list1:?}"), format!("{list2:?}"));
-    }
-
-    #[test]
     fn test_multibyte_character_rendering() -> Result<()> {
         use ratatui::backend::TestBackend;
         use ratatui::Terminal;

--- a/src/presentation/widgets/status_bar.rs
+++ b/src/presentation/widgets/status_bar.rs
@@ -86,31 +86,6 @@ mod tests {
     }
 
     #[test]
-    fn test_view_context_clone() {
-        let pubkey = create_test_pubkey();
-        let profile = create_test_profile(pubkey, Some("Alice"), None);
-        let ctx = ViewContext {
-            user_pubkey: pubkey,
-            user_profile: Some(&profile),
-        };
-        let cloned = ctx.clone();
-        assert_eq!(ctx, cloned);
-    }
-
-    #[test]
-    fn test_view_context_debug() {
-        let pubkey = create_test_pubkey();
-        let ctx = ViewContext {
-            user_pubkey: pubkey,
-            user_profile: None,
-        };
-        let debug_str = format!("{ctx:?}");
-        assert!(debug_str.contains("ViewContext"));
-        assert!(debug_str.contains("user_pubkey"));
-        assert!(debug_str.contains("user_profile"));
-    }
-
-    #[test]
     fn test_status_bar_widget_new() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();

--- a/src/presentation/widgets/text_note.rs
+++ b/src/presentation/widgets/text_note.rs
@@ -226,44 +226,6 @@ mod tests {
     }
 
     #[test]
-    fn test_view_context_equality() {
-        let profiles = HashMap::new();
-
-        let ctx1 = ViewContext {
-            profiles: &profiles,
-            live_status: None,
-            selected: false,
-        };
-
-        let ctx2 = ViewContext {
-            profiles: &profiles,
-            live_status: None,
-            selected: false,
-        };
-
-        assert_eq!(ctx1, ctx2);
-    }
-
-    #[test]
-    fn test_view_context_with_selection() {
-        let profiles = HashMap::new();
-
-        let ctx_selected = ViewContext {
-            profiles: &profiles,
-            live_status: None,
-            selected: true,
-        };
-
-        let ctx_not_selected = ViewContext {
-            profiles: &profiles,
-            live_status: None,
-            selected: false,
-        };
-
-        assert_ne!(ctx_selected, ctx_not_selected);
-    }
-
-    #[test]
     fn test_mentioned_names_with_profiles() -> Result<(), Box<dyn Error>> {
         let mentioned_keys = Keys::generate();
         let p_tag = Tag::public_key(mentioned_keys.public_key());


### PR DESCRIPTION
## Summary

Final cleanup of the test suite against the guidelines in `.agents.md`
(no `panic!`, no derive-only tests, no assertion-less tests).

### Removed derive-only tests
These exercised only derived `Debug` / `Clone` / `PartialEq`:
- `HomeListComponent`: `test_list_component_creation`, `test_list_is_stateless`
- `StatusBarWidget` `ViewContext`: `test_view_context_clone`, `test_view_context_debug`
- `TextNoteWidget` `ViewContext`: `test_view_context_equality`, `test_view_context_with_selection`

### Removed vacuous / assertion-less / `panic!`-based tests in `nostr.rs`
`test_nostr_events_creation`, `test_command_sender_can_be_cloned`,
`test_various_commands`, `test_error_messages`, `test_command_error_types`,
`test_message_variants` — these exercised tokio mpsc or enum construction rather
than our own logic, and several relied on `panic!` in an `else` branch. The
meaningful "first message is Ready" check is kept as `test_first_message_is_ready`,
now using `expect` on the stream item plus `assert!(matches!(...))`.

### Other
- Removed the assertion-less `test_ctrl_p_submits_note_in_composing_mode` in
  `app.rs` (the Ctrl+P -> `SubmitNote` routing is trivial and `submit_note` is
  covered by `state.rs` tests).
- Rewrote `test_find_reply_tag` to assert with `matches!` instead of
  `if let ... else { panic!(...) }`.

After this, there are no `panic!` calls left in test code.

## Behavior

No production code changes. `just lint`, `just test` (360 passed), and `just fmt`
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)