### PR TITLE
refactor: invert Nostr gateway dependency (DIP)

### DIFF
--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -6,7 +6,7 @@
 use crossterm::event::KeyEvent;
 use nowhear::{MediaEvent, MediaSourceError};
 
-use crate::infrastructure::subscription::nostr::Message as NostrSubscriptionMessage;
+use crate::model::nostr_gateway::Message as NostrSubscriptionMessage;
 
 /// Main application message type for tears
 #[derive(Debug, Clone)]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -8,11 +8,11 @@ use crate::{
     application::config::Config,
     application::message::AppMsg,
     domain::nostr::{nip10::ReplyTagsBuilder, nip38::MusicStatus, Profile},
-    infrastructure::subscription::nostr::{CommandError, NostrCommand},
     model::{
         editor::{Editor, Message as EditorMessage},
         fps::{Fps, Message as FpsMessage},
         nostr::{Message as NostrMessage, Nostr},
+        nostr_gateway::{CommandError, NostrCommand},
         status_bar::{Message, StatusBar},
         timeline::{
             tab::TimelineTabType, text_note::TextNote, Message as TimelineMessage, Timeline,

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -13,64 +13,10 @@ use crate::domain::nostr::timeline_filter::{
     home_load_more_filter, home_timeline_filters, user_load_more_filter, user_timeline_filters,
     with_own_pubkey,
 };
+use crate::model::nostr_gateway::{CommandError, Message, NostrCommand};
 use crate::model::timeline::tab::TimelineTabType;
 
 const DEFAULT_CONTACT_LIST_TIMEOUT_SECS: u64 = 10;
-
-/// Commands that can be sent to the Nostr subscription
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NostrCommand {
-    /// Send an event to relays
-    SendEventBuilder { event_builder: EventBuilder },
-    /// Add a new relay
-    AddRelay { url: String },
-    /// Remove a relay
-    RemoveRelay { url: String },
-    /// Load more timeline events before the specified timestamp for a specific tab
-    LoadMoreTimeline {
-        tab_type: TimelineTabType,
-        since: Timestamp,
-    },
-    /// Subscribe to a specific timeline tab
-    SubscribeTimeline { tab_type: TimelineTabType },
-    /// Unsubscribe from multiple subscriptions
-    Unsubscribe {
-        subscription_ids: Vec<nostr_sdk::SubscriptionId>,
-    },
-    /// Shutdown the subscription and disconnect from all relays
-    Shutdown,
-}
-
-/// Errors that can occur during command execution
-#[derive(Debug, Clone)]
-pub enum CommandError {
-    /// Failed to send event to relays
-    SendEventFailed { error: String },
-    /// Failed to add relay
-    AddRelayFailed { url: String, error: String },
-    /// Failed to connect to relay
-    ConnectRelayFailed { url: String, error: String },
-    /// Failed to remove relay
-    RemoveRelayFailed { url: String, error: String },
-}
-
-/// Messages emitted by the Nostr subscription
-#[derive(Debug, Clone)]
-pub enum Message {
-    /// Subscription is ready, provides command sender for user to send commands
-    Ready {
-        sender: mpsc::UnboundedSender<NostrCommand>,
-    },
-    /// A notification from the relay pool
-    Notification(Box<RelayPoolNotification>),
-    /// An error occurred during command execution
-    Error { error: CommandError },
-    /// A subscription was created for a specific tab
-    SubscriptionCreated {
-        tab_type: TimelineTabType,
-        subscription_id: nostr_sdk::SubscriptionId,
-    },
-}
 
 #[derive(Debug, Clone)]
 pub struct NostrEvents {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 pub mod editor;
 pub mod fps;
 pub mod nostr;
+pub mod nostr_gateway;
 pub mod status_bar;
 pub mod timeline;

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -2,9 +2,8 @@ use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
-use crate::{
-    infrastructure::subscription::nostr::NostrCommand, model::timeline::tab::TimelineTabType,
-};
+use crate::model::nostr_gateway::NostrCommand;
+use crate::model::timeline::tab::TimelineTabType;
 
 pub enum Message {
     ConnectionReady {

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -1,0 +1,73 @@
+//! Nostr subscription gateway contract
+//!
+//! Protocol types exchanged between the application/model and the Nostr
+//! subscription adapter (`infrastructure::subscription::nostr`):
+//! - `NostrCommand`: commands sent to the subscription worker
+//! - `CommandError`: errors that can occur while executing a command
+//! - `Message`: messages emitted by the subscription back to the application
+//!
+//! These types live in `model` (not `domain`) because they reference
+//! `TimelineTabType`, a UI/model concept that the domain layer is intentionally
+//! kept free of. The adapter in `infrastructure` depends inward on this
+//! contract, inverting what used to be an `application`/`model` -> `infrastructure`
+//! dependency.
+
+use nostr_sdk::prelude::*;
+use tokio::sync::mpsc;
+
+use crate::model::timeline::tab::TimelineTabType;
+
+/// Commands that can be sent to the Nostr subscription
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NostrCommand {
+    /// Send an event to relays
+    SendEventBuilder { event_builder: EventBuilder },
+    /// Add a new relay
+    AddRelay { url: String },
+    /// Remove a relay
+    RemoveRelay { url: String },
+    /// Load more timeline events before the specified timestamp for a specific tab
+    LoadMoreTimeline {
+        tab_type: TimelineTabType,
+        since: Timestamp,
+    },
+    /// Subscribe to a specific timeline tab
+    SubscribeTimeline { tab_type: TimelineTabType },
+    /// Unsubscribe from multiple subscriptions
+    Unsubscribe {
+        subscription_ids: Vec<nostr_sdk::SubscriptionId>,
+    },
+    /// Shutdown the subscription and disconnect from all relays
+    Shutdown,
+}
+
+/// Errors that can occur during command execution
+#[derive(Debug, Clone)]
+pub enum CommandError {
+    /// Failed to send event to relays
+    SendEventFailed { error: String },
+    /// Failed to add relay
+    AddRelayFailed { url: String, error: String },
+    /// Failed to connect to relay
+    ConnectRelayFailed { url: String, error: String },
+    /// Failed to remove relay
+    RemoveRelayFailed { url: String, error: String },
+}
+
+/// Messages emitted by the Nostr subscription
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Subscription is ready, provides command sender for user to send commands
+    Ready {
+        sender: mpsc::UnboundedSender<NostrCommand>,
+    },
+    /// A notification from the relay pool
+    Notification(Box<RelayPoolNotification>),
+    /// An error occurred during command execution
+    Error { error: CommandError },
+    /// A subscription was created for a specific tab
+    SubscriptionCreated {
+        tab_type: TimelineTabType,
+        subscription_id: nostr_sdk::SubscriptionId,
+    },
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,9 +15,8 @@ use crate::application::config::Config;
 use crate::application::message::{AppMsg, EditorMsg, NostrMsg, SystemMsg, TimelineMsg};
 use crate::application::state::AppState;
 use crate::infrastructure::subscription::media::MediaEvents;
-use crate::infrastructure::subscription::nostr::{
-    Message as NostrSubscriptionMessage, NostrEvents,
-};
+use crate::infrastructure::subscription::nostr::NostrEvents;
+use crate::model::nostr_gateway::Message as NostrSubscriptionMessage;
 use crate::presentation::components::Components;
 use crate::presentation::config::keybindings::Action as KeyAction;
 


### PR DESCRIPTION
## Summary

Breaks the cross-layer cycles around the Nostr subscription gateway.

`NostrCommand`, `CommandError`, and the subscription `Message` were defined in `infrastructure::subscription::nostr` but consumed by `application` (`state`, `message`) and `model::nostr`. That created upward `application -> infrastructure` and `model -> infrastructure` dependencies — cycles, since infrastructure depends back on `model`/`domain`.

This moves those contract types into a new `model::nostr_gateway` module and makes the infrastructure adapter depend **inward** on them. The adapter (`NostrEvents`, the `SubscriptionSource` impl) stays in `infrastructure`.

## Why `model`, not `domain`

The earlier plan was to put the contract in `domain`, but the code argues otherwise: the contract references `TimelineTabType`, and `domain::nostr::timeline_filter` explicitly documents that the domain layer is kept *agnostic of UI/model concepts such as tab types*. Placing the contract in `domain` would drag `TimelineTabType` (and `tokio::mpsc`) into the domain layer.

`model::nostr` is already the gateway *client* (it holds the `mpsc::UnboundedSender<NostrCommand>` and builds commands), so the protocol types belong alongside it. Keeping them in `model`:

- lets `application -> model` and `infrastructure -> model` (both already-correct **downward** edges) carry the dependency;
- requires no change to `TimelineTabType` and leaves `domain` untouched/pure.

## Result

| Edge | Before | After |
|---|---|---|
| `application -> infrastructure` | ⚠️ present | ✅ gone |
| `model -> infrastructure` | ⚠️ present | ✅ gone (only a doc-comment reference remains) |
| `infrastructure -> model::nostr_gateway` | — | ✅ downward (correct) |

Remaining upward edges (`model -> application::message`, `presentation -> application::state`) are out of scope here and are the planned follow-ups.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)