### PR TITLE
refactor: report timeline load-more via outcome instead of AppMsg

### DIFF
--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -53,8 +53,6 @@ pub enum TimelineMsg {
     SelectFirst,
     /// Select the last note in the timeline
     SelectLast,
-    /// Load more older events when reaching bottom
-    LoadMore,
     /// React to the selected note
     ReactToSelected,
     /// Repost the selected note

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -15,7 +15,9 @@ use crate::{
         nostr_gateway::{CommandError, NostrCommand},
         status_bar::{Message, StatusBar},
         timeline::{
-            tab::TimelineTabType, text_note::TextNote, Message as TimelineMessage, Timeline,
+            tab::{TimelineOutcome, TimelineTabType},
+            text_note::TextNote,
+            Message as TimelineMessage, Timeline,
         },
     },
 };
@@ -98,7 +100,7 @@ impl<'a> AppState<'a> {
             Kind::TextNote => {
                 let current_loading_more_state = self.timeline.is_loading_more_for_tab(tab_type);
 
-                let command = self.timeline.update(TimelineMessage::NoteAddedToTab {
+                let _ = self.timeline.update(TimelineMessage::NoteAddedToTab {
                     event,
                     tab_type: tab_type.clone(),
                 });
@@ -114,7 +116,7 @@ impl<'a> AppState<'a> {
                     });
                 }
 
-                command
+                Command::none()
             }
             Kind::Metadata => {
                 // Metadata is shared across all tabs
@@ -124,13 +126,22 @@ impl<'a> AppState<'a> {
                 }
                 Command::none()
             }
-            Kind::Repost => self.timeline.update(TimelineMessage::RepostAdded { event }),
-            Kind::Reaction => self
-                .timeline
-                .update(TimelineMessage::ReactionAdded { event }),
-            Kind::ZapReceipt => self
-                .timeline
-                .update(TimelineMessage::ZapReceiptAdded { event }),
+            Kind::Repost => {
+                let _ = self.timeline.update(TimelineMessage::RepostAdded { event });
+                Command::none()
+            }
+            Kind::Reaction => {
+                let _ = self
+                    .timeline
+                    .update(TimelineMessage::ReactionAdded { event });
+                Command::none()
+            }
+            Kind::ZapReceipt => {
+                let _ = self
+                    .timeline
+                    .update(TimelineMessage::ZapReceiptAdded { event });
+                Command::none()
+            }
             _ => Command::none(),
         }
     }
@@ -422,57 +433,69 @@ impl<'a> AppState<'a> {
 
     /// Move the selection to the previous timeline item.
     pub fn scroll_up(&mut self) -> Command<AppMsg> {
-        self.timeline.update(TimelineMessage::PreviousItemSelected)
+        let _ = self.timeline.update(TimelineMessage::PreviousItemSelected);
+        Command::none()
     }
 
     /// Move the selection to the next timeline item.
+    ///
+    /// When the selection is already at the bottom, the timeline reports
+    /// `LoadMoreRequested` and the application loads older events.
     pub fn scroll_down(&mut self) -> Command<AppMsg> {
-        self.timeline.update(TimelineMessage::NextItemSelected)
+        match self.timeline.update(TimelineMessage::NextItemSelected) {
+            TimelineOutcome::LoadMoreRequested => self.load_more_timeline(),
+            TimelineOutcome::None => Command::none(),
+        }
     }
 
     /// Select the timeline item at `index`.
     pub fn select_note(&mut self, index: usize) -> Command<AppMsg> {
-        self.timeline
-            .update(TimelineMessage::ItemSelected { index })
+        let _ = self
+            .timeline
+            .update(TimelineMessage::ItemSelected { index });
+        Command::none()
     }
 
     /// Clear the current timeline selection.
     pub fn deselect_note(&mut self) -> Command<AppMsg> {
-        self.timeline.update(TimelineMessage::ItemSelectionCleared)
+        let _ = self.timeline.update(TimelineMessage::ItemSelectionCleared);
+        Command::none()
     }
 
     /// Select the first timeline item.
     pub fn select_first_note(&mut self) -> Command<AppMsg> {
-        self.timeline.update(TimelineMessage::FirstItemSelected)
+        let _ = self.timeline.update(TimelineMessage::FirstItemSelected);
+        Command::none()
     }
 
     /// Select the last timeline item.
     pub fn select_last_note(&mut self) -> Command<AppMsg> {
-        self.timeline.update(TimelineMessage::LastItemSelected)
+        let _ = self.timeline.update(TimelineMessage::LastItemSelected);
+        Command::none()
     }
 
     /// Switch to the tab at `index`.
     pub fn select_tab(&mut self, index: usize) -> Command<AppMsg> {
-        let command = self.timeline.update(TimelineMessage::TabSelected { index });
+        let _ = self.timeline.update(TimelineMessage::TabSelected { index });
         log::debug!("Selected tab index: {}", self.timeline.active_tab_index());
-        command
+        Command::none()
     }
 
     /// Switch to the next tab (wraps around).
     pub fn next_tab(&mut self) -> Command<AppMsg> {
-        let command = self.timeline.update(TimelineMessage::NextTabSelected);
+        let _ = self.timeline.update(TimelineMessage::NextTabSelected);
         log::debug!("Switched to next tab: {}", self.timeline.active_tab_index());
-        command
+        Command::none()
     }
 
     /// Switch to the previous tab (wraps around).
     pub fn prev_tab(&mut self) -> Command<AppMsg> {
-        let command = self.timeline.update(TimelineMessage::PreviousTabSelected);
+        let _ = self.timeline.update(TimelineMessage::PreviousTabSelected);
         log::debug!(
             "Switched to previous tab: {}",
             self.timeline.active_tab_index()
         );
-        command
+        Command::none()
     }
 
     /// Start composing a new note.

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -6,13 +6,11 @@ pub mod text_note;
 use std::collections::HashMap;
 
 use nostr_sdk::prelude::*;
-use tears::Command;
 
 use crate::{
-    application::message::AppMsg,
     domain::nostr::{find_event_id_from_last_e_tag, SortableEventId},
     model::timeline::{
-        tab::{Message as TabMessage, TimelineTab, TimelineTabType},
+        tab::{Message as TabMessage, TimelineOutcome, TimelineTab, TimelineTabType},
         text_note::{Message as TextNoteMessage, TextNote},
     },
 };
@@ -162,7 +160,7 @@ impl Timeline {
         tab.is_at_bottom()
     }
 
-    pub fn update(&mut self, message: Message) -> Command<AppMsg> {
+    pub fn update(&mut self, message: Message) -> TimelineOutcome {
         match message {
             Message::NoteAddedToTab { event, tab_type } => {
                 // Find the tab index for the specified tab type
@@ -171,7 +169,7 @@ impl Timeline {
                     None => {
                         // Tab not found - cannot add note
                         log::warn!("Cannot add note: tab {tab_type:?} not found");
-                        return Command::none();
+                        return TimelineOutcome::None;
                     }
                 };
 
@@ -226,7 +224,7 @@ impl Timeline {
                 // Check if a tab with the same type already exists
                 if self.find_tab_by_type(&tab_type).is_some() {
                     log::warn!("Tab with this type already exists");
-                    return Command::none();
+                    return TimelineOutcome::None;
                 }
 
                 // Create and add the new tab
@@ -240,13 +238,13 @@ impl Timeline {
                 // Validate index
                 if index >= self.tabs.len() {
                     log::warn!("Tab index out of bounds");
-                    return Command::none();
+                    return TimelineOutcome::None;
                 }
 
                 // Cannot remove the Home tab
                 if matches!(self.tabs[index].tab_type(), TimelineTabType::Home) {
                     log::warn!("Cannot remove the Home tab");
-                    return Command::none();
+                    return TimelineOutcome::None;
                 }
 
                 // Remove the tab
@@ -282,7 +280,7 @@ impl Timeline {
             }
         }
 
-        Command::none()
+        TimelineOutcome::None
     }
 }
 

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -15,20 +15,30 @@ use std::{cmp::Reverse, collections::HashMap};
 
 use nostr_sdk::prelude::*;
 use sorted_vec::{FindOrInsert, ReverseSortedSet};
-use tears::Command;
 
-use crate::{
-    application::message::{AppMsg, TimelineMsg},
-    domain::{
-        nostr::{Profile, SortableEventId},
-        text::shorten_npub,
-    },
+use crate::domain::{
+    nostr::{Profile, SortableEventId},
+    text::shorten_npub,
 };
 
 use super::{
     pagination::{Message as PaginationMessage, Pagination},
     selection::{Message as SelectionMessage, Selection},
 };
+
+/// Follow-up action the application layer must take after a timeline update.
+///
+/// Timeline state objects are side-effect free, like the rest of `model`: their
+/// `update` methods mutate state and return this outcome instead of issuing a
+/// `Command`/`AppMsg`. The application layer decides which effect to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TimelineOutcome {
+    /// No follow-up action is required.
+    #[default]
+    None,
+    /// The selection reached the bottom; older events should be loaded.
+    LoadMoreRequested,
+}
 
 /// Represents the type of timeline tab
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -169,7 +179,7 @@ impl TimelineTab {
     /// ### NextItemSelected
     /// When the user tries to scroll down at the bottom of the timeline:
     /// - Updates pagination state to "loading more"
-    /// - Returns a LoadMore command to trigger data fetching
+    /// - Returns `TimelineOutcome::LoadMoreRequested` so the application can fetch older events
     ///
     /// ### NoteAdded
     /// When a new note arrives, coordinates three child components:
@@ -181,7 +191,7 @@ impl TimelineTab {
     /// The coordination logic lives here because it's TimelineTab's responsibility
     /// to maintain consistency across its children, not the responsibility of
     /// Selection or Pagination themselves.
-    pub fn update(&mut self, message: Message) -> Command<AppMsg> {
+    pub fn update(&mut self, message: Message) -> TimelineOutcome {
         match message {
             // Selection-related messages - simple delegation
             Message::ItemSelected(index) => {
@@ -207,7 +217,7 @@ impl TimelineTab {
                                 self.pagination
                                     .update(PaginationMessage::LoadingMoreStarted { since });
 
-                                return Command::message(AppMsg::Timeline(TimelineMsg::LoadMore));
+                                return TimelineOutcome::LoadMoreRequested;
                             }
                         }
                     } else {
@@ -259,7 +269,7 @@ impl TimelineTab {
             }
         };
 
-        Command::none()
+        TimelineOutcome::None
     }
 }
 
@@ -304,17 +314,17 @@ mod tests {
         // Test ItemSelected - no command should be issued for selection changes
         let cmd = tab.update(Message::ItemSelected(5));
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Test SelectionCleared
         let cmd = tab.update(Message::SelectionCleared);
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Test FirstItemSelected
         let cmd = tab.update(Message::FirstItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Add some notes first so LastItemSelected and NextItemSelected work properly
         for i in 0..11 {
@@ -326,17 +336,17 @@ mod tests {
         let _ = tab.update(Message::ItemSelected(5));
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), Some(10));
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Test PreviousItemSelected
         let cmd = tab.update(Message::PreviousItemSelected);
         assert_eq!(tab.selected_index(), Some(9));
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Test NextItemSelected (not at bottom, so no LoadMore)
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), Some(10));
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
     }
 
     #[test]
@@ -357,7 +367,7 @@ mod tests {
         // Try to scroll down at bottom - should trigger loading more and return LoadMore command
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert!(cmd.is_some()); // LoadMore command was issued
+        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested); // LoadMore command was issued
     }
 
     #[test]
@@ -374,12 +384,12 @@ mod tests {
         // First scroll-down at bottom triggers loading more
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert!(cmd.is_some());
+        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested);
 
         // A subsequent scroll-down while already loading must not re-trigger it
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert!(cmd.is_none()); // No duplicate LoadMore command
+        assert_eq!(cmd, TimelineOutcome::None); // No duplicate LoadMore command
     }
 
     #[test]
@@ -390,7 +400,7 @@ mod tests {
         // Should do nothing when there are no notes (no oldest_timestamp)
         let cmd = tab.update(Message::NextItemSelected);
         assert!(!tab.is_loading_more());
-        assert!(cmd.is_none()); // No command should be issued
+        assert_eq!(cmd, TimelineOutcome::None); // No command should be issued
     }
 
     #[test]
@@ -403,7 +413,7 @@ mod tests {
         assert_eq!(tab.len(), 1);
         assert!(!tab.is_empty());
         assert_eq!(tab.oldest_timestamp(), Some(Timestamp::from(1000)));
-        assert!(cmd.is_none()); // NoteAdded should not issue commands
+        assert_eq!(cmd, TimelineOutcome::None); // NoteAdded should not issue commands
     }
 
     #[test]
@@ -478,7 +488,7 @@ mod tests {
         // Selection should be adjusted to index 2 to maintain the same item selected
         assert_eq!(tab.selected_index(), Some(2));
         assert_eq!(tab.len(), 3);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
     }
 
     #[test]
@@ -502,7 +512,7 @@ mod tests {
         // Selection should not change because the new item was inserted after
         assert_eq!(tab.selected_index(), Some(0));
         assert_eq!(tab.len(), 3);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
     }
 
     #[test]
@@ -594,12 +604,12 @@ mod tests {
         // NextItemSelected on empty timeline should do nothing
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // LastItemSelected on empty timeline should do nothing
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
     }
 
     #[test]
@@ -614,7 +624,7 @@ mod tests {
         // because Selection's logic requires max_index > 0 for initial selection
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
 
         // Select the item manually
         let _ = tab.update(Message::ItemSelected(0));
@@ -623,13 +633,13 @@ mod tests {
         // Can't go beyond the only item - but at bottom with single item, should trigger LoadMore
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), Some(0));
-        assert!(cmd.is_some()); // LoadMore command issued when at bottom
+        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested); // LoadMore command issued when at bottom
 
         // LastItemSelected should select index 0
         let _ = tab.update(Message::SelectionCleared);
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), Some(0));
-        assert!(cmd.is_none());
+        assert_eq!(cmd, TimelineOutcome::None);
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -310,7 +310,6 @@ impl<'a> TearsApp<'a> {
             TimelineMsg::Deselect => self.state.deselect_note(),
             TimelineMsg::SelectFirst => self.state.select_first_note(),
             TimelineMsg::SelectLast => self.state.select_last_note(),
-            TimelineMsg::LoadMore => self.state.load_more_timeline(),
             TimelineMsg::ReactToSelected => self.state.react_to_selected(),
             TimelineMsg::RepostSelected => self.state.repost_selected(),
             TimelineMsg::SelectTab(index) => self.state.select_tab(index),


### PR DESCRIPTION
## Summary

Removes the last `model -> application` upward dependency, completing `model` as a clean inner layer.

`TimelineTab::update` / `Timeline::update` returned `Command<AppMsg>` and built `AppMsg::Timeline(TimelineMsg::LoadMore)` directly. That made `model` import `application::message` — an upward dependency and a cycle, since `application` (`AppState`) aggregates `model`.

## Approach (outcome, not `Command::map`)

Introduce a small, model-local `TimelineOutcome`:

```rust
pub enum TimelineOutcome { None, LoadMoreRequested }
```

`TimelineTab::update` / `Timeline::update` now return it instead of `Command<AppMsg>`. This is consistent with the rest of `model`, whose `update` methods are side-effect free (8 of 10 already returned `()`); these two were the only ones reaching for `Command`/`AppMsg`. The **application** layer owns effects: `AppState::scroll_down` calls `load_more_timeline()` directly when the timeline reports `LoadMoreRequested`.

I deliberately avoided the textbook `Command::map` child→parent wiring because it would introduce a mapping pattern not used elsewhere in `model`; the outcome value matches the existing `is_at_bottom()` / `is_loading_more()` query style.

## Also removed: the load-more message round-trip

`TimelineMsg::LoadMore` was produced only by the line being replaced and consumed only by a single runtime handler that called `load_more_timeline()`. With `scroll_down` calling that method directly, the variant and its handler are now dead, so both are deleted. No keybinding referenced it.

## Result

| Edge | Before | After |
|---|---|---|
| `model -> application::message` | ⚠️ present | ✅ gone |
| `model` depends on | domain, application | **domain only** |

The remaining `presentation -> application::state` edge is the separate, planned follow-up (PR4). No behavior change.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)