### PR TITLE
refactor: extract feed identity into domain::nostr::FeedKind

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 use crate::{
     application::config::Config,
     application::message::AppMsg,
-    domain::nostr::{nip10::ReplyTagsBuilder, nip38::MusicStatus, Profile},
+    domain::nostr::{nip10::ReplyTagsBuilder, nip38::MusicStatus, FeedKind, Profile},
     model::{
         editor::{Editor, Message as EditorMessage},
         fps::{Fps, Message as FpsMessage},
@@ -15,9 +15,7 @@ use crate::{
         nostr_gateway::{CommandError, NostrCommand},
         status_bar::{Message, StatusBar},
         timeline::{
-            tab::{TimelineOutcome, TimelineTabType},
-            text_note::TextNote,
-            Message as TimelineMessage, Timeline,
+            tab::TimelineOutcome, text_note::TextNote, Message as TimelineMessage, Timeline,
         },
     },
 };
@@ -91,21 +89,21 @@ impl<'a> AppState<'a> {
     pub fn process_nostr_event_for_tab(
         &mut self,
         event: Event,
-        tab_type: &TimelineTabType,
+        feed: &FeedKind,
     ) -> Command<AppMsg> {
         // Receiving any event means startup has produced its first results.
         self.startup.mark_completed();
 
         match event.kind {
             Kind::TextNote => {
-                let current_loading_more_state = self.timeline.is_loading_more_for_tab(tab_type);
+                let current_loading_more_state = self.timeline.is_loading_more_for_feed(feed);
 
                 let _ = self.timeline.update(TimelineMessage::NoteAddedToTab {
                     event,
-                    tab_type: tab_type.clone(),
+                    feed: feed.clone(),
                 });
 
-                let new_loading_more_state = self.timeline.is_loading_more_for_tab(tab_type);
+                let new_loading_more_state = self.timeline.is_loading_more_for_feed(feed);
 
                 if current_loading_more_state == Some(true) && new_loading_more_state == Some(false)
                 {
@@ -153,26 +151,26 @@ impl<'a> AppState<'a> {
     /// message is shown (or an error message if the tab could not be created).
     pub fn open_author_timeline(&mut self, author_pubkey: PublicKey) -> Command<AppMsg> {
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let tab_type = TimelineTabType::UserTimeline {
+        let feed = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
 
         // Tab already open: just switch to it.
-        if let Some(index) = self.timeline.find_tab_by_type(&tab_type) {
+        if let Some(index) = self.timeline.find_tab_by_feed(&feed) {
             let _ = self.timeline.update(TimelineMessage::TabSelected { index });
             return Command::none();
         }
 
         // Otherwise create it, then subscribe and show the loading status.
-        let _ = self.timeline.update(TimelineMessage::TabAdded {
-            tab_type: tab_type.clone(),
-        });
+        let _ = self
+            .timeline
+            .update(TimelineMessage::TabAdded { feed: feed.clone() });
 
-        if self.timeline.find_tab_by_type(&tab_type).is_some() {
+        if self.timeline.find_tab_by_feed(&feed).is_some() {
             log::info!("Created new author timeline for {author_npub}");
 
             self.nostr
-                .update(NostrMessage::SubscriptionRequested { tab_type });
+                .update(NostrMessage::SubscriptionRequested { feed });
 
             self.status_bar.update(Message::MessageChanged {
                 label: author_npub,
@@ -197,16 +195,15 @@ impl<'a> AppState<'a> {
     pub fn close_current_tab(&mut self) -> Command<AppMsg> {
         let current_index = self.timeline.active_tab_index();
 
-        // Capture the tab type before removing the tab.
-        let tab_type = self.timeline.active_tab().tab_type().clone();
+        // Capture the feed before removing the tab.
+        let feed = self.timeline.active_tab().feed().clone();
 
         let _ = self.timeline.update(TimelineMessage::TabRemoved {
             index: current_index,
         });
 
         // Unsubscribe the subscriptions associated with the closed tab.
-        self.nostr
-            .update(NostrMessage::SubscriptionClosed { tab_type });
+        self.nostr.update(NostrMessage::SubscriptionClosed { feed });
 
         Command::none()
     }
@@ -362,7 +359,7 @@ impl<'a> AppState<'a> {
             });
         }
 
-        let Some(tab_type) = self
+        let Some(feed) = self
             .nostr
             .find_tab_by_subscription(subscription_id)
             .cloned()
@@ -371,12 +368,12 @@ impl<'a> AppState<'a> {
         };
 
         log::debug!(
-            "Routing event {} (kind: {:?}) to tab {tab_type:?}",
+            "Routing event {} (kind: {:?}) to tab {feed:?}",
             event.id,
             event.kind
         );
 
-        self.process_nostr_event_for_tab(event, &tab_type)
+        self.process_nostr_event_for_tab(event, &feed)
     }
 
     /// Request older events for the active tab, paginating before its oldest
@@ -389,11 +386,11 @@ impl<'a> AppState<'a> {
             return Command::none();
         };
 
-        let tab_type = self.timeline.active_tab().tab_type().clone();
+        let feed = self.timeline.active_tab().feed().clone();
         let tab_title = self.active_tab_title();
 
         self.nostr
-            .update(NostrMessage::HistoryRequested { tab_type, since });
+            .update(NostrMessage::HistoryRequested { feed, since });
 
         self.status_bar.update(Message::MessageChanged {
             label: tab_title,
@@ -526,12 +523,12 @@ impl<'a> AppState<'a> {
     /// Track a subscription that the relay layer created for a tab.
     pub fn track_subscription_created(
         &mut self,
-        tab_type: TimelineTabType,
+        feed: FeedKind,
         subscription_id: SubscriptionId,
     ) -> Command<AppMsg> {
-        log::info!("Subscription created for {tab_type:?}: {subscription_id:?}");
+        log::info!("Subscription created for {feed:?}: {subscription_id:?}");
         self.nostr.update(NostrMessage::SubscriptionCreated {
-            tab_type,
+            feed,
             sub_id: subscription_id,
         });
         Command::none()
@@ -620,11 +617,11 @@ mod tests {
         // Add a user timeline tab first (before adding any events)
         let author_keys = Keys::generate();
         let author_pubkey = author_keys.public_key();
-        let user_tab = TimelineTabType::UserTimeline {
+        let user_tab = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
         let _ = state.timeline.update(TimelineMessage::TabAdded {
-            tab_type: user_tab.clone(),
+            feed: user_tab.clone(),
         });
 
         // Add event only to user timeline tab (this also stops loading)
@@ -653,7 +650,7 @@ mod tests {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let event = create_text_note(&Keys::generate(), "hello", Timestamp::from(1000))?;
-        let command = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let command = state.process_nostr_event_for_tab(event, &FeedKind::Home);
 
         // The command returned by the timeline update is propagated to the caller
         // rather than discarded. Adding a note currently issues no follow-up command.
@@ -679,27 +676,23 @@ mod tests {
         // Insert an initial note so oldest_timestamp exists.
         let keys = Keys::generate();
         let event1 = create_text_note(&keys, "newer", Timestamp::from(1000))?;
-        let _ = state.process_nostr_event_for_tab(event1, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event1, &FeedKind::Home);
 
         // Start loading more. (loading_more_since = oldest_timestamp = 1000)
         let _ = state.timeline.update(TimelineMessage::LastItemSelected);
         let _ = state.timeline.update(TimelineMessage::NextItemSelected);
         assert_eq!(
-            state
-                .timeline
-                .is_loading_more_for_tab(&TimelineTabType::Home),
+            state.timeline.is_loading_more_for_feed(&FeedKind::Home),
             Some(true)
         );
 
         // An older event completes the LoadMore operation.
         let event2 = create_text_note(&keys, "older", Timestamp::from(500))?;
-        let _ = state.process_nostr_event_for_tab(event2, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event2, &FeedKind::Home);
 
         assert_eq!(state.status_bar.message(), Some("[Home] loaded more"));
         assert_eq!(
-            state
-                .timeline
-                .is_loading_more_for_tab(&TimelineTabType::Home),
+            state.timeline.is_loading_more_for_feed(&FeedKind::Home),
             Some(false)
         );
 
@@ -718,11 +711,11 @@ mod tests {
         let author_keys = Keys::generate();
         let author_pubkey = author_keys.public_key();
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let user_tab = TimelineTabType::UserTimeline {
+        let user_tab = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
         let _ = state.timeline.update(TimelineMessage::TabAdded {
-            tab_type: user_tab.clone(),
+            feed: user_tab.clone(),
         });
 
         // Insert an initial note so oldest_timestamp exists.
@@ -732,7 +725,7 @@ mod tests {
         let _ = state.timeline.update(TimelineMessage::LastItemSelected);
         let _ = state.timeline.update(TimelineMessage::NextItemSelected);
         assert_eq!(
-            state.timeline.is_loading_more_for_tab(&user_tab),
+            state.timeline.is_loading_more_for_feed(&user_tab),
             Some(true)
         );
 
@@ -745,7 +738,7 @@ mod tests {
             Some(format!("[{}] loaded more", shorten_npub(author_npub)).as_ref())
         );
         assert_eq!(
-            state.timeline.is_loading_more_for_tab(&user_tab),
+            state.timeline.is_loading_more_for_feed(&user_tab),
             Some(false)
         );
 
@@ -765,7 +758,7 @@ mod tests {
             .custom_created_at(Timestamp::from(1000))
             .sign_with_keys(&author_keys)?;
 
-        let _ = state.process_nostr_event_for_tab(metadata_event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(metadata_event, &FeedKind::Home);
 
         let stored = state
             .user
@@ -792,7 +785,7 @@ mod tests {
             .custom_created_at(Timestamp::from(1000))
             .sign_with_keys(&author_keys)?;
 
-        let _ = state.process_nostr_event_for_tab(invalid_metadata_event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(invalid_metadata_event, &FeedKind::Home);
 
         assert_eq!(state.user.get_profile(&author_pubkey), None);
         assert_eq!(state.user.profile_count(), 0);
@@ -804,14 +797,14 @@ mod tests {
     fn test_open_author_timeline_switches_to_existing_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
-        let tab_type = TimelineTabType::UserTimeline {
+        let feed = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
 
         // Pre-create the author tab, then move focus back to Home.
-        let _ = state.timeline.update(TimelineMessage::TabAdded {
-            tab_type: tab_type.clone(),
-        });
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabAdded { feed: feed.clone() });
         let _ = state
             .timeline
             .update(TimelineMessage::TabSelected { index: 0 });
@@ -821,7 +814,7 @@ mod tests {
 
         // Switches to the existing tab instead of creating a duplicate.
         assert_eq!(state.timeline.tabs().len(), 2);
-        assert_eq!(state.timeline.active_tab().tab_type(), &tab_type);
+        assert_eq!(state.timeline.active_tab().feed(), &feed);
     }
 
     #[test]
@@ -829,7 +822,7 @@ mod tests {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let tab_type = TimelineTabType::UserTimeline {
+        let feed = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
 
@@ -837,7 +830,7 @@ mod tests {
 
         // A new author tab is created, focused, and a loading status is shown.
         assert_eq!(state.timeline.tabs().len(), 2);
-        assert_eq!(state.timeline.active_tab().tab_type(), &tab_type);
+        assert_eq!(state.timeline.active_tab().feed(), &feed);
         assert_eq!(
             state.status_bar.message(),
             Some(format!("[{author_npub}] loading...").as_str())
@@ -848,40 +841,29 @@ mod tests {
     fn test_close_current_tab_removes_active_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
-        let tab_type = TimelineTabType::UserTimeline {
+        let feed = FeedKind::UserTimeline {
             pubkey: author_pubkey,
         };
-        let _ = state
-            .timeline
-            .update(TimelineMessage::TabAdded { tab_type });
+        let _ = state.timeline.update(TimelineMessage::TabAdded { feed });
         assert_eq!(state.timeline.active_tab_index(), 1);
 
         let _ = state.close_current_tab();
 
         // The active author tab is removed and focus falls back to Home.
         assert_eq!(state.timeline.tabs().len(), 1);
-        assert_eq!(
-            state.timeline.active_tab().tab_type(),
-            &TimelineTabType::Home
-        );
+        assert_eq!(state.timeline.active_tab().feed(), &FeedKind::Home);
     }
 
     #[test]
     fn test_close_current_tab_keeps_home_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
-        assert_eq!(
-            state.timeline.active_tab().tab_type(),
-            &TimelineTabType::Home
-        );
+        assert_eq!(state.timeline.active_tab().feed(), &FeedKind::Home);
 
         let _ = state.close_current_tab();
 
         // Home cannot be closed, so the timeline is unchanged.
         assert_eq!(state.timeline.tabs().len(), 1);
-        assert_eq!(
-            state.timeline.active_tab().tab_type(),
-            &TimelineTabType::Home
-        );
+        assert_eq!(state.timeline.active_tab().feed(), &FeedKind::Home);
     }
 
     #[test]
@@ -901,7 +883,7 @@ mod tests {
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
-        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.react_to_selected();
@@ -921,7 +903,7 @@ mod tests {
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
-        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.repost_selected();
@@ -950,7 +932,7 @@ mod tests {
         let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
-        let _ = state.process_nostr_event_for_tab(event.clone(), &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event.clone(), &FeedKind::Home);
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.start_reply();
@@ -989,7 +971,7 @@ mod tests {
 
         // Select a note and start replying to it.
         let event = create_text_note(&keys, "original", Timestamp::from(1000))?;
-        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
         let _ = state.start_reply();
 
@@ -1044,7 +1026,7 @@ mod tests {
         // Associate a subscription with the Home tab.
         let sub_id = SubscriptionId::new("home_sub");
         state.nostr.update(NostrMessage::SubscriptionCreated {
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
             sub_id: sub_id.clone(),
         });
 
@@ -1075,7 +1057,7 @@ mod tests {
         let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
-        let _ = state.process_nostr_event_for_tab(event, &TimelineTabType::Home);
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
 
         let _ = state.load_more_timeline();
 

--- a/src/domain/nostr.rs
+++ b/src/domain/nostr.rs
@@ -1,4 +1,5 @@
 mod event;
+mod feed;
 pub mod nip10;
 pub mod nip27;
 pub mod nip38;
@@ -6,4 +7,5 @@ mod profile;
 pub mod timeline_filter;
 
 pub use event::{find_event_id_from_last_e_tag, SortableEventId};
+pub use feed::FeedKind;
 pub use profile::Profile;

--- a/src/domain/nostr/feed.rs
+++ b/src/domain/nostr/feed.rs
@@ -1,0 +1,16 @@
+//! Feed identity.
+//!
+//! A *feed* defines **what** content a timeline shows — the author set and event
+//! kinds to request — independent of any UI. A `timeline` (in `model`) is the
+//! stateful surface that materialises and displays a feed.
+
+use nostr_sdk::prelude::*;
+
+/// Identifies which feed a timeline displays.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FeedKind {
+    /// The home feed (the followed authors, plus the user themselves).
+    Home,
+    /// A single author's feed.
+    UserTimeline { pubkey: PublicKey },
+}

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -13,8 +13,8 @@ use crate::domain::nostr::timeline_filter::{
     home_load_more_filter, home_timeline_filters, user_load_more_filter, user_timeline_filters,
     with_own_pubkey,
 };
+use crate::domain::nostr::FeedKind;
 use crate::model::nostr_gateway::{CommandError, Message, NostrCommand};
-use crate::model::timeline::tab::TimelineTabType;
 
 const DEFAULT_CONTACT_LIST_TIMEOUT_SECS: u64 = 10;
 
@@ -90,17 +90,17 @@ impl NostrEvents {
 
                 if let Ok((sub_id1, sub_id2, sub_id3)) = result {
                     // Send SubscriptionCreated messages for NostrState to track
-                    let tab_type = TimelineTabType::Home;
+                    let feed = FeedKind::Home;
                     let _ = msg_tx.send(Message::SubscriptionCreated {
-                        tab_type: tab_type.clone(),
+                        feed: feed.clone(),
                         subscription_id: sub_id1.val,
                     });
                     let _ = msg_tx.send(Message::SubscriptionCreated {
-                        tab_type: tab_type.clone(),
+                        feed: feed.clone(),
                         subscription_id: sub_id2.val,
                     });
                     let _ = msg_tx.send(Message::SubscriptionCreated {
-                        tab_type,
+                        feed,
                         subscription_id: sub_id3.val,
                     });
                 }
@@ -158,28 +158,26 @@ impl NostrEvents {
                     });
                 }
             }
-            NostrCommand::LoadMoreTimeline { tab_type, since } => {
+            NostrCommand::LoadMoreTimeline { feed, since } => {
                 // Load more timeline events before the specified timestamp.
                 // Map the tab to the appropriate domain filter builder; the home
                 // timeline reuses the contact list cached at init time.
-                let filter = match &tab_type {
-                    TimelineTabType::Home => match contact_list_cache.read().await.clone() {
+                let filter = match &feed {
+                    FeedKind::Home => match contact_list_cache.read().await.clone() {
                         Some(authors) => home_load_more_filter(authors, since),
                         None => {
                             log::warn!("Contact list not cached, cannot load more events");
                             return;
                         }
                     },
-                    TimelineTabType::UserTimeline { pubkey } => {
-                        user_load_more_filter(*pubkey, since)
-                    }
+                    FeedKind::UserTimeline { pubkey } => user_load_more_filter(*pubkey, since),
                 };
 
                 match client.subscribe(filter, None).await {
                     Ok(sub_id) => {
                         // Send SubscriptionCreated to track this load-more subscription
                         let _ = msg_tx.send(Message::SubscriptionCreated {
-                            tab_type,
+                            feed,
                             subscription_id: sub_id.val,
                         });
                     }
@@ -188,14 +186,14 @@ impl NostrEvents {
                     }
                 }
             }
-            NostrCommand::SubscribeTimeline { tab_type } => {
-                match &tab_type {
-                    TimelineTabType::Home => {
+            NostrCommand::SubscribeTimeline { feed } => {
+                match &feed {
+                    FeedKind::Home => {
                         log::warn!(
                             "Home timeline should be initialized, not subscribed via command"
                         );
                     }
-                    TimelineTabType::UserTimeline { pubkey } => {
+                    FeedKind::UserTimeline { pubkey } => {
                         // Subscribe to both backward (historical) and forward (real-time) events
                         let [backward_filter, forward_filter] =
                             user_timeline_filters(*pubkey, Timestamp::now());
@@ -210,11 +208,11 @@ impl NostrEvents {
                             Ok((sub_id1, sub_id2)) => {
                                 // Send SubscriptionCreated messages for both subscriptions
                                 let _ = msg_tx.send(Message::SubscriptionCreated {
-                                    tab_type: tab_type.clone(),
+                                    feed: feed.clone(),
                                     subscription_id: sub_id1.val,
                                 });
                                 let _ = msg_tx.send(Message::SubscriptionCreated {
-                                    tab_type,
+                                    feed,
                                     subscription_id: sub_id2.val,
                                 });
                             }

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -2,8 +2,8 @@ use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
+use crate::domain::nostr::FeedKind;
 use crate::model::nostr_gateway::NostrCommand;
-use crate::model::timeline::tab::TimelineTabType;
 
 pub enum Message {
     ConnectionReady {
@@ -13,17 +13,17 @@ pub enum Message {
         event_builder: EventBuilder,
     },
     SubscriptionRequested {
-        tab_type: TimelineTabType,
+        feed: FeedKind,
     },
     SubscriptionCreated {
-        tab_type: TimelineTabType,
+        feed: FeedKind,
         sub_id: SubscriptionId,
     },
     SubscriptionClosed {
-        tab_type: TimelineTabType,
+        feed: FeedKind,
     },
     HistoryRequested {
-        tab_type: TimelineTabType,
+        feed: FeedKind,
         since: Timestamp,
     },
     ConnectionClosed,
@@ -38,7 +38,7 @@ pub struct Nostr {
     /// Track subscription IDs for each timeline tab
     /// Home tab has 3 subscriptions (backward, forward, profile)
     /// User timelines have 1 subscription
-    timeline_subscriptions: HashMap<TimelineTabType, Vec<nostr_sdk::SubscriptionId>>,
+    timeline_subscriptions: HashMap<FeedKind, Vec<nostr_sdk::SubscriptionId>>,
 }
 
 impl Nostr {
@@ -50,21 +50,18 @@ impl Nostr {
         self.command_sender.is_some()
     }
 
-    pub fn is_subscribed(&self, tab_type: &TimelineTabType) -> bool {
+    pub fn is_subscribed(&self, feed: &FeedKind) -> bool {
         self.timeline_subscriptions
-            .get(tab_type)
+            .get(feed)
             .is_some_and(|subs| !subs.is_empty())
     }
 
-    /// Find the tab type that owns a specific subscription ID
-    pub fn find_tab_by_subscription(
-        &self,
-        subscription_id: &SubscriptionId,
-    ) -> Option<&TimelineTabType> {
+    /// Find the feed that owns a specific subscription ID
+    pub fn find_tab_by_subscription(&self, subscription_id: &SubscriptionId) -> Option<&FeedKind> {
         self.timeline_subscriptions
             .iter()
             .find(|(_, sub_ids)| sub_ids.contains(subscription_id))
-            .map(|(tab_type, _)| tab_type)
+            .map(|(feed, _)| feed)
     }
 
     pub fn update(&mut self, message: Message) {
@@ -77,42 +74,39 @@ impl Nostr {
                     let _ = sender.send(NostrCommand::SendEventBuilder { event_builder });
                 }
             }
-            Message::SubscriptionRequested { tab_type } => {
-                if matches!(tab_type, TimelineTabType::Home) {
+            Message::SubscriptionRequested { feed } => {
+                if matches!(feed, FeedKind::Home) {
                     return;
                 }
 
-                if self.timeline_subscriptions.contains_key(&tab_type) {
+                if self.timeline_subscriptions.contains_key(&feed) {
                     // Already subscribed or in-flight.
                     return;
                 }
 
                 if let Some(sender) = self.command_sender.as_ref() {
                     // Mark as in-flight before sending, so repeated calls are rejected.
-                    self.timeline_subscriptions
-                        .insert(tab_type.clone(), Vec::new());
+                    self.timeline_subscriptions.insert(feed.clone(), Vec::new());
 
                     if sender
-                        .send(NostrCommand::SubscribeTimeline {
-                            tab_type: tab_type.clone(),
-                        })
+                        .send(NostrCommand::SubscribeTimeline { feed: feed.clone() })
                         .is_err()
                     {
                         // NOTE: Avoid leaving an "in-flight" mark when the command didn't go through.
-                        self.timeline_subscriptions.remove(&tab_type);
+                        self.timeline_subscriptions.remove(&feed);
                     }
                 }
             }
-            Message::SubscriptionCreated { tab_type, sub_id } => {
+            Message::SubscriptionCreated { feed, sub_id } => {
                 self.timeline_subscriptions
-                    .entry(tab_type)
+                    .entry(feed)
                     .or_default()
                     .push(sub_id);
             }
-            Message::SubscriptionClosed { tab_type } => {
+            Message::SubscriptionClosed { feed } => {
                 let subscription_ids = self
                     .timeline_subscriptions
-                    .remove(&tab_type)
+                    .remove(&feed)
                     .unwrap_or_default();
 
                 if !subscription_ids.is_empty() {
@@ -121,11 +115,11 @@ impl Nostr {
                     }
                 }
 
-                self.timeline_subscriptions.remove(&tab_type);
+                self.timeline_subscriptions.remove(&feed);
             }
-            Message::HistoryRequested { tab_type, since } => {
+            Message::HistoryRequested { feed, since } => {
                 if let Some(sender) = self.command_sender.as_ref() {
-                    let _ = sender.send(NostrCommand::LoadMoreTimeline { tab_type, since });
+                    let _ = sender.send(NostrCommand::LoadMoreTimeline { feed, since });
                 }
             }
             Message::ConnectionClosed => {
@@ -144,8 +138,8 @@ impl Nostr {
 mod tests {
     use super::*;
 
-    fn create_test_tab_type() -> TimelineTabType {
-        TimelineTabType::UserTimeline {
+    fn create_test_tab_type() -> FeedKind {
+        FeedKind::UserTimeline {
             pubkey: PublicKey::from_slice(&[0u8; 32]).expect("valid public key"),
         }
     }
@@ -178,35 +172,35 @@ mod tests {
     #[test]
     fn test_is_subscribed_returns_false_when_no_subscription() {
         let nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
 
-        assert!(!nostr.is_subscribed(&tab_type));
+        assert!(!nostr.is_subscribed(&feed));
     }
 
     #[test]
     fn test_is_subscribed_returns_false_when_subscription_list_is_empty() {
         let mut nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
 
         nostr
             .timeline_subscriptions
-            .insert(tab_type.clone(), Vec::new());
+            .insert(feed.clone(), Vec::new());
 
-        assert!(!nostr.is_subscribed(&tab_type));
+        assert!(!nostr.is_subscribed(&feed));
     }
 
     #[test]
     fn test_is_subscribed_returns_true_when_subscription_exists() {
         let mut nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id,
         });
 
-        assert!(nostr.is_subscribed(&tab_type));
+        assert!(nostr.is_subscribed(&feed));
     }
 
     #[test]
@@ -218,17 +212,17 @@ mod tests {
     }
 
     #[test]
-    fn test_find_tab_by_subscription_returns_tab_type_when_found() {
+    fn test_find_tab_by_subscription_returns_feed_when_found() {
         let mut nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
 
-        assert_eq!(nostr.find_tab_by_subscription(&sub_id), Some(&tab_type));
+        assert_eq!(nostr.find_tab_by_subscription(&sub_id), Some(&feed));
     }
 
     #[test]
@@ -280,60 +274,54 @@ mod tests {
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
         nostr.update(Message::SubscriptionRequested {
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // No command should be sent for Home tab
         assert!(rx.try_recv().is_err());
-        assert!(!nostr
-            .timeline_subscriptions
-            .contains_key(&TimelineTabType::Home));
+        assert!(!nostr.timeline_subscriptions.contains_key(&FeedKind::Home));
     }
 
     #[test]
     fn test_update_subscription_requested_creates_subscription() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
-        nostr.update(Message::SubscriptionRequested {
-            tab_type: tab_type.clone(),
-        });
+        nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
         // Verify in-flight mark was set
-        assert!(nostr.timeline_subscriptions.contains_key(&tab_type));
+        assert!(nostr.timeline_subscriptions.contains_key(&feed));
         assert_eq!(
             nostr
                 .timeline_subscriptions
-                .get(&tab_type)
+                .get(&feed)
                 .expect("subscription exists"),
             &Vec::<SubscriptionId>::new()
         );
 
         // Verify command was sent
         let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::SubscribeTimeline { tab_type }));
+        assert_eq!(received, Ok(NostrCommand::SubscribeTimeline { feed }));
     }
 
     #[test]
     fn test_update_subscription_requested_ignores_duplicate_request() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
-        nostr.update(Message::SubscriptionRequested {
-            tab_type: tab_type.clone(),
-        });
+        nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
         // First command should be sent
         assert!(rx.try_recv().is_ok());
 
         // Second request should be ignored
-        nostr.update(Message::SubscriptionRequested { tab_type });
+        nostr.update(Message::SubscriptionRequested { feed });
 
         // No second command should be sent
         assert!(rx.try_recv().is_err());
@@ -342,17 +330,17 @@ mod tests {
     #[test]
     fn test_update_subscription_created_adds_subscription_id() {
         let mut nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
 
         let subs = nostr
             .timeline_subscriptions
-            .get(&tab_type)
+            .get(&feed)
             .expect("subscription exists");
         assert_eq!(subs, &vec![sub_id]);
     }
@@ -360,23 +348,23 @@ mod tests {
     #[test]
     fn test_update_subscription_created_appends_to_existing_subscriptions() {
         let mut nostr = Nostr::new();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id1 = SubscriptionId::new("test_sub1");
         let sub_id2 = SubscriptionId::new("test_sub2");
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id: sub_id1.clone(),
         });
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id: sub_id2.clone(),
         });
 
         let subs = nostr
             .timeline_subscriptions
-            .get(&tab_type)
+            .get(&feed)
             .expect("subscription exists");
         assert_eq!(subs, &vec![sub_id1, sub_id2]);
     }
@@ -385,22 +373,20 @@ mod tests {
     fn test_update_subscription_closed_removes_subscription_and_sends_unsubscribe() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
         nostr.update(Message::SubscriptionCreated {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
 
-        nostr.update(Message::SubscriptionClosed {
-            tab_type: tab_type.clone(),
-        });
+        nostr.update(Message::SubscriptionClosed { feed: feed.clone() });
 
         // Verify subscription was removed
-        assert!(!nostr.timeline_subscriptions.contains_key(&tab_type));
+        assert!(!nostr.timeline_subscriptions.contains_key(&feed));
 
         // Verify unsubscribe command was sent
         let received = rx.try_recv();
@@ -416,11 +402,11 @@ mod tests {
     fn test_update_subscription_closed_handles_non_existent_subscription() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
-        nostr.update(Message::SubscriptionClosed { tab_type });
+        nostr.update(Message::SubscriptionClosed { feed });
 
         // No unsubscribe command should be sent for empty subscription list
         assert!(rx.try_recv().is_err());
@@ -430,34 +416,31 @@ mod tests {
     fn test_update_history_requested_sends_load_more_command() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let since = Timestamp::from(1234567890);
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
         nostr.update(Message::HistoryRequested {
-            tab_type: tab_type.clone(),
+            feed: feed.clone(),
             since,
         });
 
         // Verify command was sent
         let received = rx.try_recv();
-        assert_eq!(
-            received,
-            Ok(NostrCommand::LoadMoreTimeline { tab_type, since })
-        );
+        assert_eq!(received, Ok(NostrCommand::LoadMoreTimeline { feed, since }));
     }
 
     #[test]
     fn test_update_connection_closed_clears_state_and_sends_shutdown() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let tab_type = create_test_tab_type();
+        let feed = create_test_tab_type();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
-        nostr.update(Message::SubscriptionCreated { tab_type, sub_id });
+        nostr.update(Message::SubscriptionCreated { feed, sub_id });
 
         nostr.update(Message::ConnectionClosed);
 

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -7,7 +7,7 @@
 //! - `Message`: messages emitted by the subscription back to the application
 //!
 //! These types live in `model` (not `domain`) because they reference
-//! `TimelineTabType`, a UI/model concept that the domain layer is intentionally
+//! `FeedKind`, a UI/model concept that the domain layer is intentionally
 //! kept free of. The adapter in `infrastructure` depends inward on this
 //! contract, inverting what used to be an `application`/`model` -> `infrastructure`
 //! dependency.
@@ -15,7 +15,7 @@
 use nostr_sdk::prelude::*;
 use tokio::sync::mpsc;
 
-use crate::model::timeline::tab::TimelineTabType;
+use crate::domain::nostr::FeedKind;
 
 /// Commands that can be sent to the Nostr subscription
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,12 +27,9 @@ pub enum NostrCommand {
     /// Remove a relay
     RemoveRelay { url: String },
     /// Load more timeline events before the specified timestamp for a specific tab
-    LoadMoreTimeline {
-        tab_type: TimelineTabType,
-        since: Timestamp,
-    },
+    LoadMoreTimeline { feed: FeedKind, since: Timestamp },
     /// Subscribe to a specific timeline tab
-    SubscribeTimeline { tab_type: TimelineTabType },
+    SubscribeTimeline { feed: FeedKind },
     /// Unsubscribe from multiple subscriptions
     Unsubscribe {
         subscription_ids: Vec<nostr_sdk::SubscriptionId>,
@@ -67,7 +64,7 @@ pub enum Message {
     Error { error: CommandError },
     /// A subscription was created for a specific tab
     SubscriptionCreated {
-        tab_type: TimelineTabType,
+        feed: FeedKind,
         subscription_id: nostr_sdk::SubscriptionId,
     },
 }

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -8,44 +8,27 @@ use std::collections::HashMap;
 use nostr_sdk::prelude::*;
 
 use crate::{
-    domain::nostr::{find_event_id_from_last_e_tag, SortableEventId},
+    domain::nostr::{find_event_id_from_last_e_tag, FeedKind, SortableEventId},
     model::timeline::{
-        tab::{Message as TabMessage, TimelineOutcome, TimelineTab, TimelineTabType},
+        tab::{Message as TabMessage, TimelineOutcome, TimelineTab},
         text_note::{Message as TextNoteMessage, TextNote},
     },
 };
 
 pub enum Message {
-    NoteAddedToTab {
-        event: Event,
-        tab_type: TimelineTabType,
-    },
-    ReactionAdded {
-        event: Event,
-    },
-    RepostAdded {
-        event: Event,
-    },
-    ZapReceiptAdded {
-        event: Event,
-    },
+    NoteAddedToTab { event: Event, feed: FeedKind },
+    ReactionAdded { event: Event },
+    RepostAdded { event: Event },
+    ZapReceiptAdded { event: Event },
     PreviousItemSelected,
     NextItemSelected,
     FirstItemSelected,
     LastItemSelected,
-    ItemSelected {
-        index: usize,
-    },
+    ItemSelected { index: usize },
     ItemSelectionCleared,
-    TabAdded {
-        tab_type: TimelineTabType,
-    },
-    TabRemoved {
-        index: usize,
-    },
-    TabSelected {
-        index: usize,
-    },
+    TabAdded { feed: FeedKind },
+    TabRemoved { index: usize },
+    TabSelected { index: usize },
     NextTabSelected,
     PreviousTabSelected,
 }
@@ -107,10 +90,10 @@ impl Timeline {
             .expect("BUG: active_tab_index is out of bounds")
     }
 
-    /// Find a tab by its type
+    /// Find a tab by its feed
     /// Returns the index of the tab if found, or None if not found
-    pub fn find_tab_by_type(&self, tab_type: &TimelineTabType) -> Option<usize> {
-        self.tabs.iter().position(|tab| tab.tab_type() == tab_type)
+    pub fn find_tab_by_feed(&self, feed: &FeedKind) -> Option<usize> {
+        self.tabs.iter().position(|tab| tab.feed() == feed)
     }
 
     /// Get the length of the active timeline
@@ -144,8 +127,8 @@ impl Timeline {
     }
 
     /// Check if currently loading more events
-    pub fn is_loading_more_for_tab(&self, tab_type: &TimelineTabType) -> Option<bool> {
-        self.find_tab_by_type(tab_type)
+    pub fn is_loading_more_for_feed(&self, feed: &FeedKind) -> Option<bool> {
+        self.find_tab_by_feed(feed)
             .map(|index| self.tabs[index].is_loading_more())
     }
 
@@ -162,13 +145,13 @@ impl Timeline {
 
     pub fn update(&mut self, message: Message) -> TimelineOutcome {
         match message {
-            Message::NoteAddedToTab { event, tab_type } => {
-                // Find the tab index for the specified tab type
-                let tab_index = match self.find_tab_by_type(&tab_type) {
+            Message::NoteAddedToTab { event, feed } => {
+                // Find the tab index for the specified feed
+                let tab_index = match self.find_tab_by_feed(&feed) {
                     Some(index) => index,
                     None => {
                         // Tab not found - cannot add note
-                        log::warn!("Cannot add note: tab {tab_type:?} not found");
+                        log::warn!("Cannot add note: tab {feed:?} not found");
                         return TimelineOutcome::None;
                     }
                 };
@@ -220,15 +203,15 @@ impl Timeline {
                 let tab = self.active_tab_mut();
                 return tab.update(TabMessage::SelectionCleared);
             }
-            Message::TabAdded { tab_type } => {
-                // Check if a tab with the same type already exists
-                if self.find_tab_by_type(&tab_type).is_some() {
+            Message::TabAdded { feed } => {
+                // Check if a tab for the same feed already exists
+                if self.find_tab_by_feed(&feed).is_some() {
                     log::warn!("Tab with this type already exists");
                     return TimelineOutcome::None;
                 }
 
                 // Create and add the new tab
-                let new_tab = TimelineTab::new(tab_type);
+                let new_tab = TimelineTab::new(feed);
                 self.tabs.push(new_tab);
 
                 // Switch to the new tab
@@ -242,7 +225,7 @@ impl Timeline {
                 }
 
                 // Cannot remove the Home tab
-                if matches!(self.tabs[index].tab_type(), TimelineTabType::Home) {
+                if matches!(self.tabs[index].feed(), FeedKind::Home) {
                     log::warn!("Cannot remove the Home tab");
                     return TimelineOutcome::None;
                 }
@@ -356,31 +339,31 @@ mod tests {
         let timeline = Timeline::default();
         let active_tab = timeline.active_tab();
 
-        assert_eq!(active_tab.tab_type(), &TimelineTabType::Home);
+        assert_eq!(active_tab.feed(), &FeedKind::Home);
         assert_eq!(active_tab.len(), 0);
     }
 
     #[test]
-    fn test_find_tab_by_type() {
+    fn test_find_tab_by_feed() {
         let mut timeline = Timeline::default();
 
         // Home tab should be at index 0
-        assert_eq!(timeline.find_tab_by_type(&TimelineTabType::Home), Some(0));
+        assert_eq!(timeline.find_tab_by_feed(&FeedKind::Home), Some(0));
 
         // Non-existent tab should return None
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         assert_eq!(
-            timeline.find_tab_by_type(&TimelineTabType::UserTimeline { pubkey }),
+            timeline.find_tab_by_feed(&FeedKind::UserTimeline { pubkey }),
             None
         );
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         assert_eq!(
-            timeline.find_tab_by_type(&TimelineTabType::UserTimeline { pubkey }),
+            timeline.find_tab_by_feed(&FeedKind::UserTimeline { pubkey }),
             Some(1)
         );
     }
@@ -393,7 +376,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         assert_eq!(timeline.len(), 1);
@@ -410,7 +393,7 @@ mod tests {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Note should not be added
@@ -425,12 +408,12 @@ mod tests {
 
         // Add a note only to a non-active tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
         let event = create_test_event(1000, 1, "Note");
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // The active tab (UserTimeline) has the note
@@ -451,7 +434,7 @@ mod tests {
         // Add a user timeline tab
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Add the same event to both tabs
@@ -460,12 +443,12 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event.clone(),
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Event should be stored only once in centralized storage
@@ -488,17 +471,17 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event2,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event1,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event3,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         assert_eq!(timeline.len(), 3);
@@ -515,7 +498,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: text_event.clone(),
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Add a reaction to the text note
@@ -558,7 +541,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: text_event.clone(),
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Add a repost
@@ -585,7 +568,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event: text_event,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Add a zap receipt
@@ -609,7 +592,7 @@ mod tests {
             let event = create_test_event(1000 + i, i as u8, &format!("Note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::Home,
+                feed: FeedKind::Home,
             });
         }
 
@@ -631,7 +614,7 @@ mod tests {
             let event = create_test_event(1000 + i, i as u8, &format!("Note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::Home,
+                feed: FeedKind::Home,
             });
         }
 
@@ -661,7 +644,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         let _ = timeline.update(Message::ItemSelected { index: 0 });
@@ -683,7 +666,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         let note = timeline.note_by_index(0);
@@ -703,7 +686,7 @@ mod tests {
             let event = create_test_event(1000 + i, i as u8, &format!("Note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::Home,
+                feed: FeedKind::Home,
             });
         }
 
@@ -715,7 +698,7 @@ mod tests {
         let _ = timeline.update(Message::NextItemSelected);
 
         // Verify loading state
-        let is_loading = timeline.is_loading_more_for_tab(&TimelineTabType::Home);
+        let is_loading = timeline.is_loading_more_for_feed(&FeedKind::Home);
         assert_eq!(is_loading, Some(true));
     }
 
@@ -727,14 +710,14 @@ mod tests {
         let event1 = create_test_event(2000, 1, "Recent note");
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event1,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Select the last item and scroll down to trigger loading more
         let _ = timeline.update(Message::LastItemSelected);
         let _ = timeline.update(Message::NextItemSelected);
         assert_eq!(
-            timeline.is_loading_more_for_tab(&TimelineTabType::Home),
+            timeline.is_loading_more_for_feed(&FeedKind::Home),
             Some(true)
         );
 
@@ -742,12 +725,12 @@ mod tests {
         let event2 = create_test_event(1000, 2, "Older note");
         let _ = timeline.update(Message::NoteAddedToTab {
             event: event2,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Loading should complete automatically
         assert_eq!(
-            timeline.is_loading_more_for_tab(&TimelineTabType::Home),
+            timeline.is_loading_more_for_feed(&FeedKind::Home),
             Some(false)
         );
     }
@@ -764,7 +747,7 @@ mod tests {
             let event = create_test_event(1000 + i, i as u8, &format!("Note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::Home,
+                feed: FeedKind::Home,
             });
         }
 
@@ -784,14 +767,14 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         assert_eq!(timeline.tabs().len(), 2);
         assert_eq!(timeline.active_tab_index(), 1); // Should switch to new tab
         assert_eq!(
-            timeline.active_tab().tab_type(),
-            &TimelineTabType::UserTimeline { pubkey }
+            timeline.active_tab().feed(),
+            &FeedKind::UserTimeline { pubkey }
         );
     }
 
@@ -801,12 +784,12 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Try to add the same tab again
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Should still have only 2 tabs (Home + UserTimeline)
@@ -819,7 +802,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         assert_eq!(timeline.tabs().len(), 2);
@@ -841,7 +824,7 @@ mod tests {
 
         // Home tab should still exist
         assert_eq!(timeline.tabs().len(), 1);
-        assert_eq!(timeline.active_tab().tab_type(), &TimelineTabType::Home);
+        assert_eq!(timeline.active_tab().feed(), &FeedKind::Home);
     }
 
     #[test]
@@ -863,10 +846,10 @@ mod tests {
         let pubkey2 = PublicKey::from_slice(&[2u8; 32]).expect("Valid pubkey");
 
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey: pubkey1 },
+            feed: FeedKind::UserTimeline { pubkey: pubkey1 },
         });
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey: pubkey2 },
+            feed: FeedKind::UserTimeline { pubkey: pubkey2 },
         });
 
         // Now we have: [Home, User1, User2], active = 2
@@ -887,7 +870,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Active tab is now the user timeline (index 1)
@@ -907,7 +890,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Switch to Home tab
@@ -935,7 +918,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Start at Home (index 0)
@@ -957,7 +940,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Start at user timeline (index 1)
@@ -979,7 +962,7 @@ mod tests {
         // Add a user timeline tab
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Add notes to Home tab
@@ -988,7 +971,7 @@ mod tests {
             let event = create_test_event(1000 + i, i as u8, &format!("Home note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::Home,
+                feed: FeedKind::Home,
             });
         }
 
@@ -997,7 +980,7 @@ mod tests {
             let event = create_test_event(2000 + i, i as u8, &format!("User note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                tab_type: TimelineTabType::UserTimeline { pubkey },
+                feed: FeedKind::UserTimeline { pubkey },
             });
         }
 
@@ -1027,7 +1010,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         assert_eq!(timeline.last_tab_index(), 1);

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -17,7 +17,7 @@ use nostr_sdk::prelude::*;
 use sorted_vec::{FindOrInsert, ReverseSortedSet};
 
 use crate::domain::{
-    nostr::{Profile, SortableEventId},
+    nostr::{FeedKind, Profile, SortableEventId},
     text::shorten_npub,
 };
 
@@ -38,15 +38,6 @@ pub enum TimelineOutcome {
     None,
     /// The selection reached the bottom; older events should be loaded.
     LoadMoreRequested,
-}
-
-/// Represents the type of timeline tab
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum TimelineTabType {
-    /// Home timeline (global feed)
-    Home,
-    /// User timeline (specific author's posts)
-    UserTimeline { pubkey: PublicKey },
 }
 
 /// Messages that can be sent to update the timeline tab state
@@ -80,7 +71,7 @@ pub enum Message {
 /// Represents a single timeline tab with its own state
 #[derive(Debug, Clone)]
 pub struct TimelineTab {
-    tab_type: TimelineTabType,
+    feed: FeedKind,
     /// Sorted list of event IDs (newest first)
     /// The actual event data is stored in TimelineState::events
     notes: ReverseSortedSet<SortableEventId>,
@@ -90,9 +81,9 @@ pub struct TimelineTab {
 
 impl TimelineTab {
     /// Create a new timeline tab with the specified type
-    pub fn new(tab_type: TimelineTabType) -> Self {
+    pub fn new(feed: FeedKind) -> Self {
         Self {
-            tab_type,
+            feed,
             notes: ReverseSortedSet::new(),
             selection: Selection::new(),
             pagination: Pagination::new(),
@@ -101,17 +92,17 @@ impl TimelineTab {
 
     /// Create a new Home timeline tab
     pub fn new_home() -> Self {
-        Self::new(TimelineTabType::Home)
+        Self::new(FeedKind::Home)
     }
 
-    pub fn tab_type(&self) -> &TimelineTabType {
-        &self.tab_type
+    pub fn feed(&self) -> &FeedKind {
+        &self.feed
     }
 
     pub fn tab_title(&self, profiles: &HashMap<PublicKey, Profile>) -> String {
-        match self.tab_type {
-            TimelineTabType::Home => "Home".to_string(),
-            TimelineTabType::UserTimeline { pubkey } => profiles
+        match self.feed {
+            FeedKind::Home => "Home".to_string(),
+            FeedKind::UserTimeline { pubkey } => profiles
                 .get(&pubkey)
                 .and_then(|profile| profile.handle())
                 .unwrap_or_else(|| {
@@ -298,13 +289,13 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_tab_type() {
+    fn test_timeline_feed() {
         let home_tab = TimelineTab::new_home();
-        assert_eq!(home_tab.tab_type, TimelineTabType::Home);
+        assert_eq!(home_tab.feed, FeedKind::Home);
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let user_tab = TimelineTab::new(TimelineTabType::UserTimeline { pubkey });
-        assert_eq!(user_tab.tab_type, TimelineTabType::UserTimeline { pubkey });
+        let user_tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
+        assert_eq!(user_tab.feed, FeedKind::UserTimeline { pubkey });
     }
 
     #[test]
@@ -653,7 +644,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_with_handle() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(TimelineTabType::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
 
         let mut metadata = Metadata::new();
         metadata = metadata.name("alice");
@@ -668,7 +659,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_with_empty_name() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(TimelineTabType::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
 
         let mut metadata = Metadata::new();
         metadata = metadata.name("");
@@ -685,7 +676,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_without_profile() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(TimelineTabType::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
 
         let profiles = HashMap::new();
 

--- a/src/presentation/components/home/list.rs
+++ b/src/presentation/components/home/list.rs
@@ -85,7 +85,8 @@ impl Default for HomeListComponent {
 
 #[cfg(test)]
 mod tests {
-    use crate::model::timeline::{tab::TimelineTabType, Message};
+    use crate::domain::nostr::FeedKind;
+    use crate::model::timeline::Message;
 
     use super::*;
     use nostr_sdk::prelude::*;
@@ -106,7 +107,7 @@ mod tests {
         let event = EventBuilder::text_note(japanese_text).sign_with_keys(&note_keys)?;
         let _ = state.timeline.update(Message::NoteAddedToTab {
             event,
-            tab_type: TimelineTabType::Home,
+            feed: FeedKind::Home,
         });
 
         // Render the note

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -48,9 +48,9 @@ impl<'a> Widget for TabBarWidget<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::nostr::Profile;
+    use crate::domain::nostr::{FeedKind, Profile};
     use crate::model::timeline::Message;
-    use crate::model::timeline::{tab::TimelineTabType, Timeline};
+    use crate::model::timeline::Timeline;
     use nostr_sdk::nostr::Metadata;
 
     fn create_test_pubkey() -> PublicKey {
@@ -114,7 +114,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         let profiles = HashMap::new();
@@ -137,7 +137,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         let mut profiles = HashMap::new();
@@ -164,7 +164,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         let mut profiles = HashMap::new();
@@ -187,7 +187,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         let mut profiles = HashMap::new();
@@ -213,10 +213,10 @@ mod tests {
 
         // Add two user timeline tabs
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey: pubkey1 },
+            feed: FeedKind::UserTimeline { pubkey: pubkey1 },
         });
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey: pubkey2 },
+            feed: FeedKind::UserTimeline { pubkey: pubkey2 },
         });
 
         let mut profiles = HashMap::new();
@@ -263,7 +263,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         let mut profiles = HashMap::new();
@@ -296,7 +296,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Active tab should be the newly added tab (index 1)
@@ -366,7 +366,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            tab_type: TimelineTabType::UserTimeline { pubkey },
+            feed: FeedKind::UserTimeline { pubkey },
         });
 
         // Switch to Home tab

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -379,11 +379,9 @@ impl<'a> TearsApp<'a> {
         match msg {
             NostrSubscriptionMessage::Ready { sender } => self.state.on_connection_ready(sender),
             NostrSubscriptionMessage::SubscriptionCreated {
-                tab_type,
+                feed,
                 subscription_id,
-            } => self
-                .state
-                .track_subscription_created(tab_type, subscription_id),
+            } => self.state.track_subscription_created(feed, subscription_id),
             NostrSubscriptionMessage::Notification(notif) => match *notif {
                 // NOTE: We use `RelayPoolNotification::Message` instead of `RelayPoolNotification::Event`
                 // because:
@@ -433,9 +431,9 @@ impl<'a> TearsApp<'a> {
 mod tests {
     use super::*;
     use crate::application::config::Config;
+    use crate::domain::nostr::FeedKind;
     use crate::model::editor::Message as EditorMessage;
     use crate::model::status_bar::Message as StatusBarMessage;
-    use crate::model::timeline::tab::TimelineTabType;
     use crate::model::timeline::Message as TimelineMessage;
 
     /// Create a test app instance
@@ -466,7 +464,7 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event, &FeedKind::Home);
 
         // Set selection and status message
         let _ = app
@@ -500,7 +498,7 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event, &FeedKind::Home);
 
         // Set selection and status message
         let _ = app
@@ -561,10 +559,10 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event1, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event1, &FeedKind::Home);
         let _ = app
             .state
-            .process_nostr_event_for_tab(event2, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event2, &FeedKind::Home);
 
         // Select somewhere in the middle
         let _ = app
@@ -593,10 +591,10 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event1, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event1, &FeedKind::Home);
         let _ = app
             .state
-            .process_nostr_event_for_tab(event2, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event2, &FeedKind::Home);
 
         // Start with no selection
         let _ = app
@@ -623,7 +621,7 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event, &FeedKind::Home);
 
         // Directly test the delegation by calling SelectFirst
         let _ = app.update(AppMsg::Timeline(TimelineMsg::SelectFirst));
@@ -646,10 +644,10 @@ mod tests {
             .expect("Failed to sign test event");
         let _ = app
             .state
-            .process_nostr_event_for_tab(event1, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event1, &FeedKind::Home);
         let _ = app
             .state
-            .process_nostr_event_for_tab(event2, &TimelineTabType::Home);
+            .process_nostr_event_for_tab(event2, &FeedKind::Home);
 
         // Directly test the delegation by calling SelectLast
         let _ = app.update(AppMsg::Timeline(TimelineMsg::SelectLast));


### PR DESCRIPTION
## Summary

This is **PR-A** of the FeedKind extraction (PR1+PR2 merged, as agreed). It separates two ideas that `TimelineTabType` conflated:

- a **feed** — *what* content to show (which authors, which kinds): a domain concept;
- a **timeline** — the stateful UI surface that materialises and displays a feed.

`TimelineTabType` (`Home` / a single author) lived in `model::timeline::tab`. It is now `domain::nostr::FeedKind`, and all references migrate to it.

## Vocabulary established

| Word | Meaning | Layer |
| --- | --- | --- |
| `feed` (`FeedKind`) | which feed — the identity/definition of the content | `domain` |
| `timeline` | the UI surface that displays a feed (`Timeline`, `TimelineTab`, `model::timeline`, `TimelineMsg`) | `model` |

Concrete renames:

- `tab_type` field/params → `feed` (incl. the Nostr gateway/message fields).
- `Timeline::find_tab_by_type` → `find_tab_by_feed`; `is_loading_more_for_tab` → `is_loading_more_for_feed`.
- Operation names that act on a timeline (`SubscribeTimeline`, `LoadMoreTimeline`) keep their `timeline` wording — only the parameter becomes `feed`.

## Scope notes

- `domain::nostr::timeline_filter` is **unchanged** (out of scope, as agreed): it stays parametric and is matched on `FeedKind` by the infrastructure adapter. The Home/User filters differ in kinds and in how the author set is resolved (Home resolves it via I/O), so they are not unified.
- The enum variant is still `UserTimeline { pubkey }`; renaming it to `Author(PublicKey)` is the separate follow-up **PR-B**.
- `FeedKind` only depends on `nostr_sdk` (a pure domain leaf), so `domain` stays pure and every consumer (`model`, `application`, `infrastructure`, `presentation`, `runtime`) depends on it **downward**.

No behavior change — pure relocation + rename.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅
- `typos` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)