### PR TITLE
refactor: rename FeedKind variant UserTimeline -> Author

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -151,9 +151,7 @@ impl<'a> AppState<'a> {
     /// message is shown (or an error message if the tab could not be created).
     pub fn open_author_timeline(&mut self, author_pubkey: PublicKey) -> Command<AppMsg> {
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let feed = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let feed = FeedKind::Author(author_pubkey);
 
         // Tab already open: just switch to it.
         if let Some(index) = self.timeline.find_tab_by_feed(&feed) {
@@ -617,9 +615,7 @@ mod tests {
         // Add a user timeline tab first (before adding any events)
         let author_keys = Keys::generate();
         let author_pubkey = author_keys.public_key();
-        let user_tab = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let user_tab = FeedKind::Author(author_pubkey);
         let _ = state.timeline.update(TimelineMessage::TabAdded {
             feed: user_tab.clone(),
         });
@@ -711,9 +707,7 @@ mod tests {
         let author_keys = Keys::generate();
         let author_pubkey = author_keys.public_key();
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let user_tab = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let user_tab = FeedKind::Author(author_pubkey);
         let _ = state.timeline.update(TimelineMessage::TabAdded {
             feed: user_tab.clone(),
         });
@@ -797,9 +791,7 @@ mod tests {
     fn test_open_author_timeline_switches_to_existing_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
-        let feed = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let feed = FeedKind::Author(author_pubkey);
 
         // Pre-create the author tab, then move focus back to Home.
         let _ = state
@@ -822,9 +814,7 @@ mod tests {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
         let Ok(author_npub) = author_pubkey.to_bech32();
-        let feed = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let feed = FeedKind::Author(author_pubkey);
 
         let _ = state.open_author_timeline(author_pubkey);
 
@@ -841,9 +831,7 @@ mod tests {
     fn test_close_current_tab_removes_active_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
-        let feed = FeedKind::UserTimeline {
-            pubkey: author_pubkey,
-        };
+        let feed = FeedKind::Author(author_pubkey);
         let _ = state.timeline.update(TimelineMessage::TabAdded { feed });
         assert_eq!(state.timeline.active_tab_index(), 1);
 

--- a/src/domain/nostr/feed.rs
+++ b/src/domain/nostr/feed.rs
@@ -12,5 +12,5 @@ pub enum FeedKind {
     /// The home feed (the followed authors, plus the user themselves).
     Home,
     /// A single author's feed.
-    UserTimeline { pubkey: PublicKey },
+    Author(PublicKey),
 }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -170,7 +170,7 @@ impl NostrEvents {
                             return;
                         }
                     },
-                    FeedKind::UserTimeline { pubkey } => user_load_more_filter(*pubkey, since),
+                    FeedKind::Author(pubkey) => user_load_more_filter(*pubkey, since),
                 };
 
                 match client.subscribe(filter, None).await {
@@ -193,7 +193,7 @@ impl NostrEvents {
                             "Home timeline should be initialized, not subscribed via command"
                         );
                     }
-                    FeedKind::UserTimeline { pubkey } => {
+                    FeedKind::Author(pubkey) => {
                         // Subscribe to both backward (historical) and forward (real-time) events
                         let [backward_filter, forward_filter] =
                             user_timeline_filters(*pubkey, Timestamp::now());

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -138,10 +138,8 @@ impl Nostr {
 mod tests {
     use super::*;
 
-    fn create_test_tab_type() -> FeedKind {
-        FeedKind::UserTimeline {
-            pubkey: PublicKey::from_slice(&[0u8; 32]).expect("valid public key"),
-        }
+    fn create_test_feed() -> FeedKind {
+        FeedKind::Author(PublicKey::from_slice(&[0u8; 32]).expect("valid public key"))
     }
 
     #[test]
@@ -172,7 +170,7 @@ mod tests {
     #[test]
     fn test_is_subscribed_returns_false_when_no_subscription() {
         let nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
 
         assert!(!nostr.is_subscribed(&feed));
     }
@@ -180,7 +178,7 @@ mod tests {
     #[test]
     fn test_is_subscribed_returns_false_when_subscription_list_is_empty() {
         let mut nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
 
         nostr
             .timeline_subscriptions
@@ -192,7 +190,7 @@ mod tests {
     #[test]
     fn test_is_subscribed_returns_true_when_subscription_exists() {
         let mut nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
@@ -214,7 +212,7 @@ mod tests {
     #[test]
     fn test_find_tab_by_subscription_returns_feed_when_found() {
         let mut nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
@@ -286,7 +284,7 @@ mod tests {
     fn test_update_subscription_requested_creates_subscription() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
@@ -311,7 +309,7 @@ mod tests {
     fn test_update_subscription_requested_ignores_duplicate_request() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
@@ -330,7 +328,7 @@ mod tests {
     #[test]
     fn test_update_subscription_created_adds_subscription_id() {
         let mut nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::SubscriptionCreated {
@@ -348,7 +346,7 @@ mod tests {
     #[test]
     fn test_update_subscription_created_appends_to_existing_subscriptions() {
         let mut nostr = Nostr::new();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id1 = SubscriptionId::new("test_sub1");
         let sub_id2 = SubscriptionId::new("test_sub2");
 
@@ -373,7 +371,7 @@ mod tests {
     fn test_update_subscription_closed_removes_subscription_and_sends_unsubscribe() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
@@ -402,7 +400,7 @@ mod tests {
     fn test_update_subscription_closed_handles_non_existent_subscription() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
 
@@ -416,7 +414,7 @@ mod tests {
     fn test_update_history_requested_sends_load_more_command() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let since = Timestamp::from(1234567890);
 
         nostr.update(Message::ConnectionReady { command_sender: tx });
@@ -435,7 +433,7 @@ mod tests {
     fn test_update_connection_closed_clears_state_and_sends_shutdown() {
         let mut nostr = Nostr::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let feed = create_test_tab_type();
+        let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
         nostr.update(Message::ConnectionReady { command_sender: tx });

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -206,7 +206,7 @@ impl Timeline {
             Message::TabAdded { feed } => {
                 // Check if a tab for the same feed already exists
                 if self.find_tab_by_feed(&feed).is_some() {
-                    log::warn!("Tab with this type already exists");
+                    log::warn!("Tab for this feed already exists");
                     return TimelineOutcome::None;
                 }
 
@@ -352,18 +352,15 @@ mod tests {
 
         // Non-existent tab should return None
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        assert_eq!(
-            timeline.find_tab_by_feed(&FeedKind::UserTimeline { pubkey }),
-            None
-        );
+        assert_eq!(timeline.find_tab_by_feed(&FeedKind::Author(pubkey)), None);
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         assert_eq!(
-            timeline.find_tab_by_feed(&FeedKind::UserTimeline { pubkey }),
+            timeline.find_tab_by_feed(&FeedKind::Author(pubkey)),
             Some(1)
         );
     }
@@ -393,7 +390,7 @@ mod tests {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Note should not be added
@@ -408,15 +405,15 @@ mod tests {
 
         // Add a note only to a non-active tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
         let event = create_test_event(1000, 1, "Note");
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
-        // The active tab (UserTimeline) has the note
+        // The active tab (Author feed) has the note
         assert_eq!(timeline.len(), 1);
         assert!(!timeline.is_empty());
 
@@ -434,7 +431,7 @@ mod tests {
         // Add a user timeline tab
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Add the same event to both tabs
@@ -448,7 +445,7 @@ mod tests {
 
         let _ = timeline.update(Message::NoteAddedToTab {
             event,
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Event should be stored only once in centralized storage
@@ -767,15 +764,12 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         assert_eq!(timeline.tabs().len(), 2);
         assert_eq!(timeline.active_tab_index(), 1); // Should switch to new tab
-        assert_eq!(
-            timeline.active_tab().feed(),
-            &FeedKind::UserTimeline { pubkey }
-        );
+        assert_eq!(timeline.active_tab().feed(), &FeedKind::Author(pubkey));
     }
 
     #[test]
@@ -784,15 +778,15 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Try to add the same tab again
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
-        // Should still have only 2 tabs (Home + UserTimeline)
+        // Should still have only 2 tabs (Home + Author feed)
         assert_eq!(timeline.tabs().len(), 2);
     }
 
@@ -802,7 +796,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         assert_eq!(timeline.tabs().len(), 2);
@@ -846,10 +840,10 @@ mod tests {
         let pubkey2 = PublicKey::from_slice(&[2u8; 32]).expect("Valid pubkey");
 
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey: pubkey1 },
+            feed: FeedKind::Author(pubkey1),
         });
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey: pubkey2 },
+            feed: FeedKind::Author(pubkey2),
         });
 
         // Now we have: [Home, User1, User2], active = 2
@@ -870,7 +864,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Active tab is now the user timeline (index 1)
@@ -890,7 +884,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Switch to Home tab
@@ -918,7 +912,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Start at Home (index 0)
@@ -940,7 +934,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Start at user timeline (index 1)
@@ -962,7 +956,7 @@ mod tests {
         // Add a user timeline tab
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Add notes to Home tab
@@ -980,7 +974,7 @@ mod tests {
             let event = create_test_event(2000 + i, i as u8, &format!("User note {i}"));
             let _ = timeline.update(Message::NoteAddedToTab {
                 event,
-                feed: FeedKind::UserTimeline { pubkey },
+                feed: FeedKind::Author(pubkey),
             });
         }
 
@@ -1010,7 +1004,7 @@ mod tests {
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         assert_eq!(timeline.last_tab_index(), 1);

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -102,7 +102,7 @@ impl TimelineTab {
     pub fn tab_title(&self, profiles: &HashMap<PublicKey, Profile>) -> String {
         match self.feed {
             FeedKind::Home => "Home".to_string(),
-            FeedKind::UserTimeline { pubkey } => profiles
+            FeedKind::Author(pubkey) => profiles
                 .get(&pubkey)
                 .and_then(|profile| profile.handle())
                 .unwrap_or_else(|| {
@@ -294,8 +294,8 @@ mod tests {
         assert_eq!(home_tab.feed, FeedKind::Home);
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let user_tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
-        assert_eq!(user_tab.feed, FeedKind::UserTimeline { pubkey });
+        let user_tab = TimelineTab::new(FeedKind::Author(pubkey));
+        assert_eq!(user_tab.feed, FeedKind::Author(pubkey));
     }
 
     #[test]
@@ -644,7 +644,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_with_handle() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::Author(pubkey));
 
         let mut metadata = Metadata::new();
         metadata = metadata.name("alice");
@@ -659,7 +659,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_with_empty_name() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::Author(pubkey));
 
         let mut metadata = Metadata::new();
         metadata = metadata.name("");
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn test_tab_title_user_timeline_without_profile() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
-        let tab = TimelineTab::new(FeedKind::UserTimeline { pubkey });
+        let tab = TimelineTab::new(FeedKind::Author(pubkey));
 
         let profiles = HashMap::new();
 

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -114,7 +114,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         let profiles = HashMap::new();
@@ -137,7 +137,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         let mut profiles = HashMap::new();
@@ -164,7 +164,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         let mut profiles = HashMap::new();
@@ -187,7 +187,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         let mut profiles = HashMap::new();
@@ -213,10 +213,10 @@ mod tests {
 
         // Add two user timeline tabs
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey: pubkey1 },
+            feed: FeedKind::Author(pubkey1),
         });
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey: pubkey2 },
+            feed: FeedKind::Author(pubkey2),
         });
 
         let mut profiles = HashMap::new();
@@ -263,7 +263,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         let mut profiles = HashMap::new();
@@ -296,7 +296,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Active tab should be the newly added tab (index 1)
@@ -366,7 +366,7 @@ mod tests {
 
         // Add a user timeline tab
         let _ = timeline.update(Message::TabAdded {
-            feed: FeedKind::UserTimeline { pubkey },
+            feed: FeedKind::Author(pubkey),
         });
 
         // Switch to Home tab


### PR DESCRIPTION
## Summary

**PR-B** of the FeedKind work. Renames the single-author variant of `domain::nostr::FeedKind`:

```diff
 pub enum FeedKind {
     Home,
-    UserTimeline { pubkey: PublicKey },
+    Author(PublicKey),
 }
```

`UserTimeline` carried the UI-flavoured word "timeline" in what is now a pure domain value object. `Author(PublicKey)` matches the Nostr "author" terminology already used across the codebase (`author_pubkey`, `open_author_timeline`, `OpenAuthorTimeline`). The struct variant becomes a tuple variant.

Construction and match sites are updated accordingly (`FeedKind::Author(pubkey)`); stale comments/log wording referencing the old name are tidied.

Pure rename, no behavior change.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅
- `typos` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)