### PR TITLE
refactor: rename gateway commands to Subscribe/LoadMore (Tier 1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,25 +97,27 @@ Anything that makes an inner layer reference an outer one is a regression.
 Nostr- and text-domain logic with no dependency on any framework, I/O, or UI
 concept. Key modules/types:
 
-- `domain::nostr` — `Profile`, `SortableEventId`, NIP helpers (`nip10`
+- `domain::nostr` — `Profile`, `SortableEventId`, `FeedKind` (which feed a
+  timeline displays: `Home` / `Author(pubkey)`), NIP helpers (`nip10`
   `ReplyTagsBuilder`, `nip27`, `nip38` `MusicStatus`), and `timeline_filter`
   (pure functions that build subscription filters).
 - `domain::collections` — `EventSet`.
 - `domain::text` — `wrap_text`, `truncate_text`, `shorten_npub`.
 
-**Invariant:** `domain` is free of UI/model concepts. For example,
-`domain::nostr::timeline_filter` is deliberately agnostic of "tab" notions and
-takes concrete inputs (pubkeys, timestamps); the caller maps a tab to a filter.
-This keeps the filter rules pure and unit-testable.
+**Invariant:** `domain` is free of UI concepts. `FeedKind` captures *which feed*
+(a domain concept), but the layer knows nothing of "tabs" (a UI notion):
+`domain::nostr::timeline_filter` stays parametric and takes concrete inputs
+(pubkeys, timestamps); the infrastructure adapter maps a `FeedKind` to the
+appropriate filter. This keeps the filter rules pure and unit-testable.
 
 ### `model` — component state
 
 The TEA "Model" broken into components, each with its own message type and a
 side-effect-free `update`. Key modules/types:
 
-- `model::timeline` — `Timeline` and its `TimelineTab`, plus the value object
-  `TimelineTabType` (`Home` / `UserTimeline { pubkey }`) and child components
-  `selection`, `pagination`, `text_note`.
+- `model::timeline` — `Timeline` and its `TimelineTab` (the UI surface that
+  displays a `domain::nostr::FeedKind`), plus child components `selection`,
+  `pagination`, `text_note`.
 - `model::editor`, `model::status_bar`, `model::fps`.
 - `model::nostr` — connection state; owns the command sender to the gateway.
 - `model::nostr_gateway` — the **Nostr gateway contract** (see below).
@@ -207,9 +209,10 @@ flowchart LR
     infra -->|implements: consumes NostrCommand, emits Message| gw
 ```
 
-It lives in `model` rather than `domain` because it references
-`TimelineTabType`, a model/UI concept the domain layer is intentionally kept
-free of.
+It lives in `model` rather than `domain` because it carries the `tokio` command
+channel (`Message::Ready { sender }`) and relay-lifecycle commands (`AddRelay`,
+`Shutdown`) — async-runtime and I/O concerns the domain layer is kept free of.
+Its feed identity comes from `domain::nostr::FeedKind`, a downward dependency.
 
 ### Outcome reporting (model → application)
 

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -158,7 +158,7 @@ impl NostrEvents {
                     });
                 }
             }
-            NostrCommand::LoadMoreTimeline { feed, since } => {
+            NostrCommand::LoadMore { feed, since } => {
                 // Load more timeline events before the specified timestamp.
                 // Map the tab to the appropriate domain filter builder; the home
                 // timeline reuses the contact list cached at init time.
@@ -186,7 +186,7 @@ impl NostrEvents {
                     }
                 }
             }
-            NostrCommand::SubscribeTimeline { feed } => {
+            NostrCommand::Subscribe { feed } => {
                 match &feed {
                     FeedKind::Home => {
                         log::warn!(

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -89,7 +89,7 @@ impl Nostr {
                     self.timeline_subscriptions.insert(feed.clone(), Vec::new());
 
                     if sender
-                        .send(NostrCommand::SubscribeTimeline { feed: feed.clone() })
+                        .send(NostrCommand::Subscribe { feed: feed.clone() })
                         .is_err()
                     {
                         // NOTE: Avoid leaving an "in-flight" mark when the command didn't go through.
@@ -119,7 +119,7 @@ impl Nostr {
             }
             Message::HistoryRequested { feed, since } => {
                 if let Some(sender) = self.command_sender.as_ref() {
-                    let _ = sender.send(NostrCommand::LoadMoreTimeline { feed, since });
+                    let _ = sender.send(NostrCommand::LoadMore { feed, since });
                 }
             }
             Message::ConnectionClosed => {
@@ -302,7 +302,7 @@ mod tests {
 
         // Verify command was sent
         let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::SubscribeTimeline { feed }));
+        assert_eq!(received, Ok(NostrCommand::Subscribe { feed }));
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod tests {
 
         // Verify command was sent
         let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::LoadMoreTimeline { feed, since }));
+        assert_eq!(received, Ok(NostrCommand::LoadMore { feed, since }));
     }
 
     #[test]

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -26,10 +26,10 @@ pub enum NostrCommand {
     AddRelay { url: String },
     /// Remove a relay
     RemoveRelay { url: String },
-    /// Load more timeline events before the specified timestamp for a specific tab
-    LoadMoreTimeline { feed: FeedKind, since: Timestamp },
-    /// Subscribe to a specific timeline tab
-    SubscribeTimeline { feed: FeedKind },
+    /// Load more events for a feed, older than the given timestamp
+    LoadMore { feed: FeedKind, since: Timestamp },
+    /// Subscribe to a feed
+    Subscribe { feed: FeedKind },
     /// Unsubscribe from multiple subscriptions
     Unsubscribe {
         subscription_ids: Vec<nostr_sdk::SubscriptionId>,


### PR DESCRIPTION
## Summary

**Tier 1** of the feed/timeline vocabulary cleanup.

The Nostr gateway commands act on a **feed** (a relay subscription for a feed's events); the subscription worker knows nothing about the UI *timeline* surface. So the `Timeline` in `SubscribeTimeline` / `LoadMoreTimeline` was a UI-word leak into a non-UI contract.

```diff
 pub enum NostrCommand {
     ...
-    LoadMoreTimeline { feed: FeedKind, since: Timestamp },
-    SubscribeTimeline { feed: FeedKind },
+    LoadMore { feed: FeedKind, since: Timestamp },
+    Subscribe { feed: FeedKind },
     Unsubscribe { subscription_ids: Vec<SubscriptionId> },
     ...
 }
```

The noun is dropped (per discussion): the `feed` parameter already says what they act on, and `Subscribe` / `Unsubscribe` now pair naturally. Doc comments updated to feed wording.

## Docs

`docs/architecture.md` had drifted since `FeedKind` was extracted (PR #450/#451). Fixed:

- the `domain` and `model::timeline` sections now reference `domain::nostr::FeedKind` instead of the removed `TimelineTabType`;
- the gateway-placement rationale is corrected — the contract stays in `model` because it carries the `tokio` command channel (`Message::Ready { sender }`) and relay-lifecycle commands (`AddRelay`, `Shutdown`), not because of a model type. Its feed identity is now a downward dependency on `domain`.

## Scope

This PR renames only the gateway command names. The infrastructure-internal `timeline_*` names (`timeline_subscriptions`, `timeline_backward_filter`, …) are **Tier 3**, and the `domain::nostr::timeline_filter` rename is **Tier 2** — each in its own follow-up.

No behavior change.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅
- `typos` (src + docs) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)