### PR TITLE
refactor: rename domain timeline_filter to feed_filter (Tier 2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,14 +99,14 @@ concept. Key modules/types:
 
 - `domain::nostr` — `Profile`, `SortableEventId`, `FeedKind` (which feed a
   timeline displays: `Home` / `Author(pubkey)`), NIP helpers (`nip10`
-  `ReplyTagsBuilder`, `nip27`, `nip38` `MusicStatus`), and `timeline_filter`
+  `ReplyTagsBuilder`, `nip27`, `nip38` `MusicStatus`), and `feed_filter`
   (pure functions that build subscription filters).
 - `domain::collections` — `EventSet`.
 - `domain::text` — `wrap_text`, `truncate_text`, `shorten_npub`.
 
 **Invariant:** `domain` is free of UI concepts. `FeedKind` captures *which feed*
 (a domain concept), but the layer knows nothing of "tabs" (a UI notion):
-`domain::nostr::timeline_filter` stays parametric and takes concrete inputs
+`domain::nostr::feed_filter` stays parametric and takes concrete inputs
 (pubkeys, timestamps); the infrastructure adapter maps a `FeedKind` to the
 appropriate filter. This keeps the filter rules pure and unit-testable.
 

--- a/src/domain/nostr.rs
+++ b/src/domain/nostr.rs
@@ -1,10 +1,10 @@
 mod event;
 mod feed;
+pub mod feed_filter;
 pub mod nip10;
 pub mod nip27;
 pub mod nip38;
 mod profile;
-pub mod timeline_filter;
 
 pub use event::{find_event_id_from_last_e_tag, SortableEventId};
 pub use feed::FeedKind;

--- a/src/domain/nostr/feed_filter.rs
+++ b/src/domain/nostr/feed_filter.rs
@@ -1,33 +1,33 @@
-//! Pure timeline filter construction.
+//! Pure feed filter construction.
 //!
-//! This module isolates the logic that decides *which* Nostr events a timeline
+//! This module isolates the logic that decides *which* Nostr events a feed
 //! should request (kinds, author set, time window, limit) from the I/O that
 //! actually performs the subscription. The functions here are pure and free of
 //! any `Client` or framework dependency, which makes the filter rules
 //! unit-testable.
 //!
-//! These builders are intentionally agnostic of UI/model concepts such as tab
-//! types: the caller is responsible for mapping a tab to the appropriate
-//! builder. This keeps the domain layer free of dependencies on outer layers.
+//! These builders are intentionally agnostic of UI concepts such as tabs: the
+//! caller maps a `FeedKind` to the appropriate builder. This keeps the domain
+//! layer free of dependencies on outer layers.
 
 use nostr_sdk::prelude::*;
 
-/// Maximum number of events fetched per timeline page.
-pub const DEFAULT_TIMELINE_LIMIT: usize = 50;
+/// Maximum number of events fetched per feed page.
+pub const DEFAULT_FEED_LIMIT: usize = 50;
 
-/// Event kinds shown in the home timeline.
-pub const HOME_TIMELINE_KINDS: [Kind; 4] = [
+/// Event kinds shown in the home feed.
+pub const HOME_FEED_KINDS: [Kind; 4] = [
     Kind::TextNote,
     Kind::Repost,
     Kind::Reaction,
     Kind::ZapReceipt,
 ];
 
-/// Event kinds shown in a single user's timeline.
-pub const USER_TIMELINE_KINDS: [Kind; 2] = [Kind::TextNote, Kind::Repost];
+/// Event kinds shown in a single user's feed.
+pub const USER_FEED_KINDS: [Kind; 2] = [Kind::TextNote, Kind::Repost];
 
 /// Ensure the user's own pubkey is part of the author set so that their posts
-/// always appear in the home timeline, even when they do not follow themselves.
+/// always appear in the home feed, even when they do not follow themselves.
 pub fn with_own_pubkey(mut authors: Vec<PublicKey>, own_pubkey: PublicKey) -> Vec<PublicKey> {
     if !authors.contains(&own_pubkey) {
         authors.push(own_pubkey);
@@ -35,64 +35,64 @@ pub fn with_own_pubkey(mut authors: Vec<PublicKey>, own_pubkey: PublicKey) -> Ve
     authors
 }
 
-/// Build the three home-timeline subscription filters.
+/// Build the three home-feed subscription filters.
 ///
 /// Returns `[backward, forward, profile]`:
 /// - `backward`: historical events up to `now` (bounded by the page limit)
 /// - `forward`: real-time events from `now` onward
 /// - `profile`: metadata for the same author set
-pub fn home_timeline_filters(authors: Vec<PublicKey>, now: Timestamp) -> [Filter; 3] {
+pub fn home_feed_filters(authors: Vec<PublicKey>, now: Timestamp) -> [Filter; 3] {
     let backward = Filter::new()
         .authors(authors.clone())
-        .kinds(HOME_TIMELINE_KINDS)
+        .kinds(HOME_FEED_KINDS)
         .until(now)
-        .limit(DEFAULT_TIMELINE_LIMIT);
+        .limit(DEFAULT_FEED_LIMIT);
     let forward = Filter::new()
         .authors(authors.clone())
-        .kinds(HOME_TIMELINE_KINDS)
+        .kinds(HOME_FEED_KINDS)
         .since(now);
     let profile = Filter::new().authors(authors).kinds([Kind::Metadata]);
 
     [backward, forward, profile]
 }
 
-/// Build the backward + forward subscription filters for a user timeline.
+/// Build the backward + forward subscription filters for a user feed.
 ///
 /// Returns `[backward, forward]`:
 /// - `backward`: historical events up to `now` (bounded by the page limit)
 /// - `forward`: real-time events from `now` onward
-pub fn user_timeline_filters(pubkey: PublicKey, now: Timestamp) -> [Filter; 2] {
+pub fn user_feed_filters(pubkey: PublicKey, now: Timestamp) -> [Filter; 2] {
     let backward = Filter::new()
         .authors(vec![pubkey])
-        .kinds(USER_TIMELINE_KINDS)
+        .kinds(USER_FEED_KINDS)
         .until(now)
-        .limit(DEFAULT_TIMELINE_LIMIT);
+        .limit(DEFAULT_FEED_LIMIT);
     let forward = Filter::new()
         .authors(vec![pubkey])
-        .kinds(USER_TIMELINE_KINDS)
+        .kinds(USER_FEED_KINDS)
         .since(now);
 
     [backward, forward]
 }
 
-/// Build the "load more" filter for paginating older home-timeline events
+/// Build the "load more" filter for paginating older home-feed events
 /// before `since`, using the given author set.
 pub fn home_load_more_filter(authors: Vec<PublicKey>, since: Timestamp) -> Filter {
     Filter::new()
         .authors(authors)
-        .kinds(HOME_TIMELINE_KINDS)
+        .kinds(HOME_FEED_KINDS)
         .until(since)
-        .limit(DEFAULT_TIMELINE_LIMIT)
+        .limit(DEFAULT_FEED_LIMIT)
 }
 
 /// Build the "load more" filter for paginating older events before `since` on a
-/// single user's timeline.
+/// single user's feed.
 pub fn user_load_more_filter(pubkey: PublicKey, since: Timestamp) -> Filter {
     Filter::new()
         .authors(vec![pubkey])
-        .kinds(USER_TIMELINE_KINDS)
+        .kinds(USER_FEED_KINDS)
         .until(since)
-        .limit(DEFAULT_TIMELINE_LIMIT)
+        .limit(DEFAULT_FEED_LIMIT)
 }
 
 #[cfg(test)]
@@ -133,25 +133,25 @@ mod tests {
     }
 
     #[test]
-    fn test_home_timeline_filters() {
+    fn test_home_feed_filters() {
         let authors = vec![pubkey(1), pubkey(2)];
         let now = Timestamp::from(1000);
 
-        let [backward, forward, profile] = home_timeline_filters(authors.clone(), now);
+        let [backward, forward, profile] = home_feed_filters(authors.clone(), now);
 
         assert_eq!(
             backward,
             Filter::new()
                 .authors(authors.clone())
-                .kinds(HOME_TIMELINE_KINDS)
+                .kinds(HOME_FEED_KINDS)
                 .until(now)
-                .limit(DEFAULT_TIMELINE_LIMIT)
+                .limit(DEFAULT_FEED_LIMIT)
         );
         assert_eq!(
             forward,
             Filter::new()
                 .authors(authors.clone())
-                .kinds(HOME_TIMELINE_KINDS)
+                .kinds(HOME_FEED_KINDS)
                 .since(now)
         );
         assert_eq!(
@@ -161,25 +161,25 @@ mod tests {
     }
 
     #[test]
-    fn test_user_timeline_filters() {
+    fn test_user_feed_filters() {
         let author = pubkey(7);
         let now = Timestamp::from(2000);
 
-        let [backward, forward] = user_timeline_filters(author, now);
+        let [backward, forward] = user_feed_filters(author, now);
 
         assert_eq!(
             backward,
             Filter::new()
                 .authors(vec![author])
-                .kinds(USER_TIMELINE_KINDS)
+                .kinds(USER_FEED_KINDS)
                 .until(now)
-                .limit(DEFAULT_TIMELINE_LIMIT)
+                .limit(DEFAULT_FEED_LIMIT)
         );
         assert_eq!(
             forward,
             Filter::new()
                 .authors(vec![author])
-                .kinds(USER_TIMELINE_KINDS)
+                .kinds(USER_FEED_KINDS)
                 .since(now)
         );
     }
@@ -193,9 +193,9 @@ mod tests {
             home_load_more_filter(authors.clone(), since),
             Filter::new()
                 .authors(authors)
-                .kinds(HOME_TIMELINE_KINDS)
+                .kinds(HOME_FEED_KINDS)
                 .until(since)
-                .limit(DEFAULT_TIMELINE_LIMIT)
+                .limit(DEFAULT_FEED_LIMIT)
         );
     }
 
@@ -208,9 +208,9 @@ mod tests {
             user_load_more_filter(author, since),
             Filter::new()
                 .authors(vec![author])
-                .kinds(USER_TIMELINE_KINDS)
+                .kinds(USER_FEED_KINDS)
                 .until(since)
-                .limit(DEFAULT_TIMELINE_LIMIT)
+                .limit(DEFAULT_FEED_LIMIT)
         );
     }
 }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -9,8 +9,8 @@ use nostr_sdk::prelude::*;
 use tears::{SubscriptionId, SubscriptionSource};
 use tokio::sync::{broadcast, mpsc, RwLock};
 
-use crate::domain::nostr::timeline_filter::{
-    home_load_more_filter, home_timeline_filters, user_load_more_filter, user_timeline_filters,
+use crate::domain::nostr::feed_filter::{
+    home_feed_filters, home_load_more_filter, user_feed_filters, user_load_more_filter,
     with_own_pubkey,
 };
 use crate::domain::nostr::FeedKind;
@@ -79,7 +79,7 @@ impl NostrEvents {
                 }
 
                 let [timeline_backward_filter, timeline_forward_filter, profile_filter] =
-                    home_timeline_filters(followings, Timestamp::now());
+                    home_feed_filters(followings, Timestamp::now());
 
                 // Subscribe to both timeline and profile data concurrently
                 let result = tokio::try_join!(
@@ -196,7 +196,7 @@ impl NostrEvents {
                     FeedKind::Author(pubkey) => {
                         // Subscribe to both backward (historical) and forward (real-time) events
                         let [backward_filter, forward_filter] =
-                            user_timeline_filters(*pubkey, Timestamp::now());
+                            user_feed_filters(*pubkey, Timestamp::now());
 
                         // Subscribe to both filters concurrently
                         let result = tokio::try_join!(


### PR DESCRIPTION
## Summary

**Tier 2** of the feed/timeline vocabulary cleanup.

`domain::nostr::timeline_filter` builds the Nostr subscription filters that define a **feed**'s content (author set, kinds, time window). Naming these pure domain functions with the UI word *timeline* leaked a presentation concept into the domain layer.

Rename the module and its public items to feed vocabulary:

| Before | After |
| --- | --- |
| `timeline_filter` (module) | `feed_filter` |
| `home_timeline_filters` | `home_feed_filters` |
| `user_timeline_filters` | `user_feed_filters` |
| `HOME_TIMELINE_KINDS` | `HOME_FEED_KINDS` |
| `USER_TIMELINE_KINDS` | `USER_FEED_KINDS` |
| `DEFAULT_TIMELINE_LIMIT` | `DEFAULT_FEED_LIMIT` |

Doc comments switch from "timeline" to "feed", and the module note now describes mapping a `FeedKind` instead of a "tab". The `home_load_more_filter` / `user_load_more_filter` helpers already had no "timeline" in their names and are unchanged.

`docs/architecture.md` updated to reference `feed_filter`.

## Scope

Only the `timeline` → `feed` swap (the actual deviation). The `home`/`user` qualifiers are left as-is. Tier 3 (infrastructure-internal `timeline_subscriptions`, `timeline_backward_filter`, …) is the final follow-up.

No behavior change.

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅
- `typos` (src + docs) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)