### PR TITLE
refactor: rename internal timeline subscription names to feed (Tier 3)

### DIFF
--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -51,10 +51,10 @@ impl NostrEvents {
         }
     }
 
-    /// Initialize timeline subscription by fetching contact list and subscribing to filters
+    /// Initialize the home feed subscription by fetching the contact list and subscribing to filters
     /// Also caches the contact list for future use (e.g., loading more events)
     /// Sends SubscriptionCreated messages for NostrState to track
-    async fn initialize_timeline(
+    async fn initialize_home_feed(
         client: &Client,
         contact_list_cache: Arc<RwLock<Option<Vec<PublicKey>>>>,
         msg_tx: &mpsc::UnboundedSender<Message>,
@@ -64,7 +64,7 @@ impl NostrEvents {
             .await
         {
             Ok(mut followings) => {
-                // Always include the user's own posts in the home timeline,
+                // Always include the user's own posts in the home feed,
                 // even if they don't follow themselves.
                 if let Ok(signer) = client.signer().await {
                     if let Ok(own_pubkey) = signer.get_public_key().await {
@@ -78,13 +78,13 @@ impl NostrEvents {
                     *cache = Some(followings.clone());
                 }
 
-                let [timeline_backward_filter, timeline_forward_filter, profile_filter] =
+                let [feed_backward_filter, feed_forward_filter, profile_filter] =
                     home_feed_filters(followings, Timestamp::now());
 
-                // Subscribe to both timeline and profile data concurrently
+                // Subscribe to both feed and profile data concurrently
                 let result = tokio::try_join!(
-                    client.subscribe(timeline_backward_filter, None),
-                    client.subscribe(timeline_forward_filter, None),
+                    client.subscribe(feed_backward_filter, None),
+                    client.subscribe(feed_forward_filter, None),
                     client.subscribe(profile_filter, None)
                 );
 
@@ -159,9 +159,9 @@ impl NostrEvents {
                 }
             }
             NostrCommand::LoadMore { feed, since } => {
-                // Load more timeline events before the specified timestamp.
-                // Map the tab to the appropriate domain filter builder; the home
-                // timeline reuses the contact list cached at init time.
+                // Load more feed events before the specified timestamp.
+                // Map the feed to the appropriate domain filter builder; the home
+                // feed reuses the contact list cached at init time.
                 let filter = match &feed {
                     FeedKind::Home => match contact_list_cache.read().await.clone() {
                         Some(authors) => home_load_more_filter(authors, since),
@@ -189,9 +189,7 @@ impl NostrEvents {
             NostrCommand::Subscribe { feed } => {
                 match &feed {
                     FeedKind::Home => {
-                        log::warn!(
-                            "Home timeline should be initialized, not subscribed via command"
-                        );
+                        log::warn!("Home feed should be initialized, not subscribed via command");
                     }
                     FeedKind::Author(pubkey) => {
                         // Subscribe to both backward (historical) and forward (real-time) events
@@ -217,7 +215,7 @@ impl NostrEvents {
                                 });
                             }
                             Err(e) => {
-                                log::error!("Failed to subscribe to user timeline: {e}");
+                                log::error!("Failed to subscribe to author feed: {e}");
                             }
                         }
                     }
@@ -246,9 +244,9 @@ impl NostrEvents {
         msg_tx: mpsc::UnboundedSender<Message>,
         mut cmd_rx: mpsc::UnboundedReceiver<NostrCommand>,
     ) {
-        // Initialize timeline subscription
+        // Initialize the home feed subscription
         let mut notifications =
-            Self::initialize_timeline(&client, Arc::clone(&contact_list_cache), &msg_tx).await;
+            Self::initialize_home_feed(&client, Arc::clone(&contact_list_cache), &msg_tx).await;
 
         loop {
             tokio::select! {

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -35,10 +35,10 @@ pub struct Nostr {
     /// This is set when the subscription emits a Ready message
     command_sender: Option<mpsc::UnboundedSender<NostrCommand>>,
 
-    /// Track subscription IDs for each timeline tab
-    /// Home tab has 3 subscriptions (backward, forward, profile)
-    /// User timelines have 1 subscription
-    timeline_subscriptions: HashMap<FeedKind, Vec<nostr_sdk::SubscriptionId>>,
+    /// Track subscription IDs for each feed
+    /// The home feed has 3 subscriptions (backward, forward, profile)
+    /// Author feeds have 1 subscription
+    feed_subscriptions: HashMap<FeedKind, Vec<nostr_sdk::SubscriptionId>>,
 }
 
 impl Nostr {
@@ -51,14 +51,14 @@ impl Nostr {
     }
 
     pub fn is_subscribed(&self, feed: &FeedKind) -> bool {
-        self.timeline_subscriptions
+        self.feed_subscriptions
             .get(feed)
             .is_some_and(|subs| !subs.is_empty())
     }
 
     /// Find the feed that owns a specific subscription ID
     pub fn find_tab_by_subscription(&self, subscription_id: &SubscriptionId) -> Option<&FeedKind> {
-        self.timeline_subscriptions
+        self.feed_subscriptions
             .iter()
             .find(|(_, sub_ids)| sub_ids.contains(subscription_id))
             .map(|(feed, _)| feed)
@@ -79,35 +79,32 @@ impl Nostr {
                     return;
                 }
 
-                if self.timeline_subscriptions.contains_key(&feed) {
+                if self.feed_subscriptions.contains_key(&feed) {
                     // Already subscribed or in-flight.
                     return;
                 }
 
                 if let Some(sender) = self.command_sender.as_ref() {
                     // Mark as in-flight before sending, so repeated calls are rejected.
-                    self.timeline_subscriptions.insert(feed.clone(), Vec::new());
+                    self.feed_subscriptions.insert(feed.clone(), Vec::new());
 
                     if sender
                         .send(NostrCommand::Subscribe { feed: feed.clone() })
                         .is_err()
                     {
                         // NOTE: Avoid leaving an "in-flight" mark when the command didn't go through.
-                        self.timeline_subscriptions.remove(&feed);
+                        self.feed_subscriptions.remove(&feed);
                     }
                 }
             }
             Message::SubscriptionCreated { feed, sub_id } => {
-                self.timeline_subscriptions
+                self.feed_subscriptions
                     .entry(feed)
                     .or_default()
                     .push(sub_id);
             }
             Message::SubscriptionClosed { feed } => {
-                let subscription_ids = self
-                    .timeline_subscriptions
-                    .remove(&feed)
-                    .unwrap_or_default();
+                let subscription_ids = self.feed_subscriptions.remove(&feed).unwrap_or_default();
 
                 if !subscription_ids.is_empty() {
                     if let Some(sender) = self.command_sender.as_ref() {
@@ -115,7 +112,7 @@ impl Nostr {
                     }
                 }
 
-                self.timeline_subscriptions.remove(&feed);
+                self.feed_subscriptions.remove(&feed);
             }
             Message::HistoryRequested { feed, since } => {
                 if let Some(sender) = self.command_sender.as_ref() {
@@ -128,7 +125,7 @@ impl Nostr {
                 }
 
                 self.command_sender = None;
-                self.timeline_subscriptions.clear();
+                self.feed_subscriptions.clear();
             }
         }
     }
@@ -147,7 +144,7 @@ mod tests {
         let nostr = Nostr::new();
 
         assert!(nostr.command_sender.is_none());
-        assert_eq!(nostr.timeline_subscriptions, HashMap::new());
+        assert_eq!(nostr.feed_subscriptions, HashMap::new());
     }
 
     #[test]
@@ -180,9 +177,7 @@ mod tests {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
-        nostr
-            .timeline_subscriptions
-            .insert(feed.clone(), Vec::new());
+        nostr.feed_subscriptions.insert(feed.clone(), Vec::new());
 
         assert!(!nostr.is_subscribed(&feed));
     }
@@ -277,7 +272,7 @@ mod tests {
 
         // No command should be sent for Home tab
         assert!(rx.try_recv().is_err());
-        assert!(!nostr.timeline_subscriptions.contains_key(&FeedKind::Home));
+        assert!(!nostr.feed_subscriptions.contains_key(&FeedKind::Home));
     }
 
     #[test]
@@ -291,10 +286,10 @@ mod tests {
         nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
         // Verify in-flight mark was set
-        assert!(nostr.timeline_subscriptions.contains_key(&feed));
+        assert!(nostr.feed_subscriptions.contains_key(&feed));
         assert_eq!(
             nostr
-                .timeline_subscriptions
+                .feed_subscriptions
                 .get(&feed)
                 .expect("subscription exists"),
             &Vec::<SubscriptionId>::new()
@@ -337,7 +332,7 @@ mod tests {
         });
 
         let subs = nostr
-            .timeline_subscriptions
+            .feed_subscriptions
             .get(&feed)
             .expect("subscription exists");
         assert_eq!(subs, &vec![sub_id]);
@@ -361,7 +356,7 @@ mod tests {
         });
 
         let subs = nostr
-            .timeline_subscriptions
+            .feed_subscriptions
             .get(&feed)
             .expect("subscription exists");
         assert_eq!(subs, &vec![sub_id1, sub_id2]);
@@ -384,7 +379,7 @@ mod tests {
         nostr.update(Message::SubscriptionClosed { feed: feed.clone() });
 
         // Verify subscription was removed
-        assert!(!nostr.timeline_subscriptions.contains_key(&feed));
+        assert!(!nostr.feed_subscriptions.contains_key(&feed));
 
         // Verify unsubscribe command was sent
         let received = rx.try_recv();
@@ -444,7 +439,7 @@ mod tests {
 
         // Verify state was cleared
         assert!(nostr.command_sender.is_none());
-        assert_eq!(nostr.timeline_subscriptions, HashMap::new());
+        assert_eq!(nostr.feed_subscriptions, HashMap::new());
 
         // Verify shutdown command was sent
         let received = rx.try_recv();


### PR DESCRIPTION
## Summary

**Tier 3** — the final tier of the feed/timeline vocabulary cleanup. Covers the internal (non-contract) names that still used the UI word *timeline* for feed-level subscription bookkeeping:

- `model::nostr::Nostr.timeline_subscriptions` → `feed_subscriptions` (a `HashMap<FeedKind, Vec<SubscriptionId>>`).
- `infrastructure::subscription::nostr`:
  - `initialize_timeline` → `initialize_home_feed` (it sets up the home feed subscription at startup).
  - local `timeline_backward_filter` / `timeline_forward_filter` → `feed_backward_filter` / `feed_forward_filter`.

Comments and log/assert strings switch from "timeline" to "feed" accordingly.

## Kept intentionally

The remaining `timeline` names refer to the **UI timeline surface** and are correct: `model::timeline`, `Timeline`, `TimelineTab`, `TimelineMsg`, `handle_timeline_msg`, `open_author_timeline` / `OpenAuthorTimeline`, and the `test_timeline_*` names.

Internal renames only — no contract, API, or behavior change. (No `docs/architecture.md` change: these names are private and not referenced there.)

## Series complete

This finishes the feed/timeline vocabulary work: `feed` = content identity (domain), `timeline` = the UI surface that displays it.

| PR | |
| --- | --- |
| #450 | extract `FeedKind` to domain |
| #451 | variant `Author` |
| #452 | gateway `Subscribe` / `LoadMore` |
| #453 | domain `feed_filter` |
| this | internal `feed_subscriptions` / `initialize_home_feed` |

## Testing

- `cargo fmt --all -- --check` ✅
- `just lint` (clippy `-D warnings`; crate is `#![deny(warnings)]`) ✅
- `just test` (360 passed) ✅
- `typos` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)