### PR TITLE
docs: correct the model side-effect-free invariant for model::nostr

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,24 +125,33 @@ appropriate filter. This keeps the filter rules pure and unit-testable.
 
 ### `model` — component state
 
-The TEA "Model" broken into components, each with its own message type and a
-side-effect-free `update`. Key modules/types:
+The TEA "Model" broken into components, each with its own message type and an
+`update` that — with one documented exception (`model::nostr`) — is side-effect
+free. Key modules/types:
 
 - `model::timeline` — `Timeline` and its `TimelineTab` (the UI surface that
   displays a `domain::nostr::FeedKind`), plus child components `selection`,
   `pagination`, `text_note`.
 - `model::editor`, `model::status_bar`, `model::fps`.
-- `model::nostr` — connection state; owns the command sender to the gateway.
+- `model::nostr` — connection state; owns the command sender to the gateway and
+  is the one component whose `update` sends `NostrCommand`s on it directly (see
+  the invariant below).
 - `model::nostr_gateway` — the **Nostr gateway contract** (see below).
 
-**Invariant:** `model::update` methods are side-effect free. They mutate state
-and, when the application must act, **report an outcome** rather than issuing an
-effect. `TimelineTab::update` / `Timeline::update` return `TimelineOutcome`
-(`None` / `LoadMoreRequested`); the application decides what to run.
+**Invariant:** with one exception, `model::update` methods are side-effect free.
+They mutate state and, when the application must act, **report an outcome**
+rather than issuing an effect. `TimelineTab::update` / `Timeline::update` return
+`TimelineOutcome` (`None` / `LoadMoreRequested`); the application decides what to
+run. `editor`, `status_bar`, and `fps` are likewise pure.
 
-Holding the gateway **contract** (a port) and a command `sender` does not break
-this: a port is only a type definition, and the `sender` is an inert handle —
-`update` never sends on it. The application owns the act of sending.
+**The exception is `model::nostr`.** It holds the gateway `sender`, and its
+`update` issues commands on it directly — e.g. `EventSubmitted` →
+`NostrCommand::SendEventBuilder`, `HistoryRequested` → `NostrCommand::LoadMore`,
+`ConnectionClosed` → `NostrCommand::Shutdown`. These are fire-and-forget channel
+sends, not TEA `Command<AppMsg>` effects: `application::state` drives them by
+calling `self.nostr.update(…)`, but the send itself happens inside the model.
+This is a deliberate seam — the component that *owns* the sender is the one that
+sends — and the lone place a `model` `update` performs I/O.
 
 ### `application` — use cases
 
@@ -221,8 +230,8 @@ flowchart LR
     app["application::state"]
     infra["infrastructure::subscription::nostr<br/>NostrEvents"]
 
-    app -->|build and send NostrCommand| gw
-    mnostr --> gw
+    app -->|drives via nostr.update| mnostr
+    mnostr -->|holds sender, sends NostrCommand| gw
     infra -->|implements: consumes NostrCommand, emits Message| gw
 ```
 
@@ -240,8 +249,9 @@ dependency.
 
 ### Outcome reporting (model → application)
 
-`model` never issues effects. When a state transition requires an effect, the
-`update` returns a `TimelineOutcome` and the application acts on it:
+Apart from `model::nostr` (above), `model` components do not issue effects. When
+a state transition requires an effect, the `update` returns a `TimelineOutcome`
+and the application acts on it:
 
 ```rust
 // application::state
@@ -280,8 +290,9 @@ sequenceDiagram
     Ext->>RT: key / subscription event
     RT->>RT: map to AppMsg (Action, etc.)
     RT->>ST: call use case (e.g. scroll_down)
-    ST->>MD: sub-model update → TimelineOutcome
-    ST->>IN: NostrCommand (via gateway sender)
+    ST->>MD: timeline update → TimelineOutcome
+    ST->>MD: nostr update (issues NostrCommand)
+    MD->>IN: NostrCommand (via gateway sender)
     IN-->>RT: gateway Message (subscription)
     ST-->>RT: Command<AppMsg>
     RT->>ST: view reads &AppState
@@ -289,18 +300,21 @@ sequenceDiagram
 ```
 
 > [!NOTE]
-> The `ST ->> IN` arrow (`NostrCommand`) is a **channel send**, not a
-> direct call — `application` has no compile-time dependency on `infrastructure`
-> and reaches the worker only through the `model`-owned gateway sender. The
-> sequence shows message flow, not import direction.
+> The `MD ->> IN` arrow (`NostrCommand`) is a **channel send**, not a direct
+> call. `application` has no compile-time dependency on `infrastructure`: it
+> drives `model::nostr` via `update`, and that component — which holds the
+> gateway sender — performs the send. The sequence shows message flow, not
+> import direction.
 
 ## Design principles
 
 1. **Dependencies point inward.** Outer adapters depend on inner layers; never
    the reverse. Invert via inner-owned contracts when needed.
 2. **`domain` is pure.** No framework, I/O, UI, or model concepts.
-3. **`model` is side-effect free.** `update` mutates state and reports outcomes;
-   the application owns all effects.
+3. **`model` is side-effect free, save one seam.** Component `update`s mutate
+   state and report outcomes for the application to act on. The exception is
+   `model::nostr`, which owns the gateway sender and issues `NostrCommand`s on it
+   directly.
 4. **One message vocabulary.** `AppMsg` is defined in `application`; only the
    `runtime` translates the outside world into it.
 5. **Views are read-only.** `presentation` renders `AppState` and nothing more.


### PR DESCRIPTION
## Summary

Follow-up to #455. Cross-checking `docs/architecture.md` against the code surfaced one genuine discrepancy: the documented "`model` is side-effect free / never issues effects" invariant does not hold for `model::nostr`. This PR corrects the docs to match the implementation. **No code changes.**

### The discrepancy

`model::nostr::update` (`src/model/nostr.rs`) sends `NostrCommand`s on the gateway sender directly:

- `EventSubmitted` → `NostrCommand::SendEventBuilder`
- `SubscriptionRequested` → `NostrCommand::Subscribe`
- `HistoryRequested` → `NostrCommand::LoadMore`
- `ConnectionClosed` → `NostrCommand::Shutdown`

`application::state` only triggers these via `self.nostr.update(…)`; the channel send executes inside the model. This is the only `model` component whose `update` performs I/O — `timeline`, `editor`, `status_bar`, and `fps` are pure. It also contradicted a sentence added in #455 that claimed `update` never sends on the sender.

### Changes

- Document `model::nostr` as the one deliberate exception: the component that *owns* the gateway sender is the one that sends, via fire-and-forget channel sends rather than TEA `Command<AppMsg>` effects.
- Update the `model` invariant, the "Outcome reporting" section, and design principle #3; remove the inaccurate #455 sentence.
- Fix the gateway and end-to-end sequence diagrams so the `NostrCommand` send originates from `model::nostr`, not directly from `application`.

### Audit result

The doc's cross-layer grep flags one `model -> infrastructure` hit, but it is a `//!` doc-comment reference in `src/model/nostr_gateway.rs`, not a real dependency. No actual dependency-rule violations were found.

## Follow-up (not in this PR)

The cleaner end state is to make `model::nostr::update` report an outcome and move the send into `application`, so the side-effect-free invariant holds for the whole `model` layer. Left as a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)