### PR TITLE
refactor: make model::nostr side-effect free via NostrOutcome

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,33 +125,24 @@ appropriate filter. This keeps the filter rules pure and unit-testable.
 
 ### `model` — component state
 
-The TEA "Model" broken into components, each with its own message type and an
-`update` that — with one documented exception (`model::nostr`) — is side-effect
-free. Key modules/types:
+The TEA "Model" broken into components, each with its own message type and a
+side-effect-free `update`. Key modules/types:
 
 - `model::timeline` — `Timeline` and its `TimelineTab` (the UI surface that
   displays a `domain::nostr::FeedKind`), plus child components `selection`,
   `pagination`, `text_note`.
 - `model::editor`, `model::status_bar`, `model::fps`.
-- `model::nostr` — connection state; owns the command sender to the gateway and
-  is the one component whose `update` sends `NostrCommand`s on it directly (see
-  the invariant below).
+- `model::nostr` — connection state: tracks the per-feed subscriptions and
+  whether the worker is ready. It does **not** hold the command sender (the
+  application does); its `update` reports a `NostrOutcome` instead of sending.
 - `model::nostr_gateway` — the **Nostr gateway contract** (see below).
 
-**Invariant:** with one exception, `model::update` methods are side-effect free.
-They mutate state and, when the application must act, **report an outcome**
-rather than issuing an effect. `TimelineTab::update` / `Timeline::update` return
-`TimelineOutcome` (`None` / `LoadMoreRequested`); the application decides what to
-run. `editor`, `status_bar`, and `fps` are likewise pure.
-
-**The exception is `model::nostr`.** It holds the gateway `sender`, and its
-`update` issues commands on it directly — e.g. `EventSubmitted` →
-`NostrCommand::SendEventBuilder`, `HistoryRequested` → `NostrCommand::LoadMore`,
-`ConnectionClosed` → `NostrCommand::Shutdown`. These are fire-and-forget channel
-sends, not TEA `Command<AppMsg>` effects: `application::state` drives them by
-calling `self.nostr.update(…)`, but the send itself happens inside the model.
-This is a deliberate seam — the component that *owns* the sender is the one that
-sends — and the lone place a `model` `update` performs I/O.
+**Invariant:** `model::update` methods are side-effect free. They mutate state
+and, when the application must act, **report an outcome** rather than issuing an
+effect. `TimelineTab::update` / `Timeline::update` return `TimelineOutcome`
+(`None` / `LoadMoreRequested`), and `Nostr::update` returns `NostrOutcome`
+(`None` / `Send(NostrCommand)`); the application decides what to run. `editor`,
+`status_bar`, and `fps` are likewise pure.
 
 ### `application` — use cases
 
@@ -160,8 +151,9 @@ vocabulary, and orchestrates effects. Key modules/types:
 
 - `application::state` — `AppState`, the aggregate Model. Its command methods
   (`scroll_down`, `react_to_selected`, `load_more_timeline`, …) are the
-  use cases; they coordinate sub-models, talk to the gateway, and return
-  `Command<AppMsg>`. Also `Startup` and `UserState`.
+  use cases; they coordinate sub-models, dispatch outcomes to the gateway (it
+  owns the command sender), and return `Command<AppMsg>`. Also `Startup` and
+  `UserState`.
 - `application::message` — `AppMsg` and its groups (`SystemMsg`, `TimelineMsg`,
   `EditorMsg`, `NostrMsg`). The message contract for the whole app.
 - `application::config` — `Config` (loaded from files), plus the UI config value
@@ -225,13 +217,13 @@ of the app depending outward on infrastructure.
 flowchart LR
     subgraph model
       gw["nostr_gateway<br/>NostrCommand · Message · CommandError"]
-      mnostr["nostr<br/>(holds command sender)"]
+      mnostr["nostr<br/>(subscription state)"]
     end
-    app["application::state"]
+    app["application::state<br/>(holds command sender)"]
     infra["infrastructure::subscription::nostr<br/>NostrEvents"]
 
-    app -->|drives via nostr.update| mnostr
-    mnostr -->|holds sender, sends NostrCommand| gw
+    app -->|update → NostrOutcome| mnostr
+    app -->|sends NostrCommand| gw
     infra -->|implements: consumes NostrCommand, emits Message| gw
 ```
 
@@ -249,9 +241,8 @@ dependency.
 
 ### Outcome reporting (model → application)
 
-Apart from `model::nostr` (above), `model` components do not issue effects. When
-a state transition requires an effect, the `update` returns a `TimelineOutcome`
-and the application acts on it:
+`model` never issues effects. When a state transition requires an effect, the
+`update` returns an outcome and the application acts on it:
 
 ```rust
 // application::state
@@ -261,6 +252,15 @@ pub fn scroll_down(&mut self) -> Command<AppMsg> {
         TimelineOutcome::None => Command::none(),
     }
 }
+```
+
+The Nostr gateway works the same way: `Nostr::update` returns a `NostrOutcome`,
+and the application — which owns the command sender — performs the send:
+
+```rust
+// application::state
+let outcome = self.nostr.update(NostrMessage::HistoryRequested { feed, since });
+self.dispatch_nostr(outcome); // sends NostrCommand::LoadMore on the owned sender
 ```
 
 ### Messages
@@ -291,8 +291,8 @@ sequenceDiagram
     RT->>RT: map to AppMsg (Action, etc.)
     RT->>ST: call use case (e.g. scroll_down)
     ST->>MD: timeline update → TimelineOutcome
-    ST->>MD: nostr update (issues NostrCommand)
-    MD->>IN: NostrCommand (via gateway sender)
+    ST->>MD: nostr update → NostrOutcome
+    ST->>IN: NostrCommand (via owned gateway sender)
     IN-->>RT: gateway Message (subscription)
     ST-->>RT: Command<AppMsg>
     RT->>ST: view reads &AppState
@@ -300,10 +300,10 @@ sequenceDiagram
 ```
 
 > [!NOTE]
-> The `MD ->> IN` arrow (`NostrCommand`) is a **channel send**, not a direct
+> The `ST ->> IN` arrow (`NostrCommand`) is a **channel send**, not a direct
 > call. `application` has no compile-time dependency on `infrastructure`: it
-> drives `model::nostr` via `update`, and that component — which holds the
-> gateway sender — performs the send. The sequence shows message flow, not
+> drives `model::nostr` via `update`, gets a `NostrOutcome`, and sends the
+> command on the gateway sender it owns. The sequence shows message flow, not
 > import direction.
 
 ## Design principles
@@ -311,10 +311,9 @@ sequenceDiagram
 1. **Dependencies point inward.** Outer adapters depend on inner layers; never
    the reverse. Invert via inner-owned contracts when needed.
 2. **`domain` is pure.** No framework, I/O, UI, or model concepts.
-3. **`model` is side-effect free, save one seam.** Component `update`s mutate
-   state and report outcomes for the application to act on. The exception is
-   `model::nostr`, which owns the gateway sender and issues `NostrCommand`s on it
-   directly.
+3. **`model` is side-effect free.** Component `update`s mutate state and report
+   outcomes (`TimelineOutcome`, `NostrOutcome`) for the application to act on;
+   the application owns all effects, including the Nostr command sender.
 4. **One message vocabulary.** `AppMsg` is defined in `application`; only the
    `runtime` translates the outside world into it.
 5. **Views are read-only.** `presentation` renders `AppState` and nothing more.

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -11,7 +11,7 @@ use crate::{
     model::{
         editor::{Editor, Message as EditorMessage},
         fps::{Fps, Message as FpsMessage},
-        nostr::{Message as NostrMessage, Nostr},
+        nostr::{Message as NostrMessage, Nostr, NostrOutcome},
         nostr_gateway::{CommandError, NostrCommand},
         status_bar::{Message, StatusBar},
         timeline::{
@@ -58,6 +58,10 @@ pub struct AppState<'a> {
     pub fps: Fps,
     pub status_bar: StatusBar,
     pub startup: Startup,
+    /// Sender for dispatching commands to the Nostr subscription worker.
+    /// Owned here (not in `model::nostr`) so the application layer performs the
+    /// I/O while `model` stays side-effect free; set once the worker is ready.
+    command_sender: Option<mpsc::UnboundedSender<NostrCommand>>,
 }
 
 /// Configuration state - holds all user-configurable settings
@@ -167,8 +171,10 @@ impl<'a> AppState<'a> {
         if self.timeline.find_tab_by_feed(&feed).is_some() {
             log::info!("Created new author timeline for {author_npub}");
 
-            self.nostr
+            let outcome = self
+                .nostr
                 .update(NostrMessage::SubscriptionRequested { feed });
+            self.dispatch_nostr(outcome);
 
             self.status_bar.update(Message::MessageChanged {
                 label: author_npub,
@@ -201,7 +207,8 @@ impl<'a> AppState<'a> {
         });
 
         // Unsubscribe the subscriptions associated with the closed tab.
-        self.nostr.update(NostrMessage::SubscriptionClosed { feed });
+        let outcome = self.nostr.update(NostrMessage::SubscriptionClosed { feed });
+        self.dispatch_nostr(outcome);
 
         Command::none()
     }
@@ -231,8 +238,10 @@ impl<'a> AppState<'a> {
         let event_builder = build(note);
         log::info!("{label} event: {note_id}");
 
-        self.nostr
+        let outcome = self
+            .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
+        self.dispatch_nostr(outcome);
 
         self.status_bar.update(Message::MessageChanged {
             label: label.to_owned(),
@@ -280,8 +289,10 @@ impl<'a> AppState<'a> {
             EventBuilder::text_note(&content)
         };
 
-        self.nostr
+        let outcome = self
+            .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
+        self.dispatch_nostr(outcome);
 
         self.status_bar.update(Message::MessageChanged {
             label: "Posted".to_owned(),
@@ -305,8 +316,10 @@ impl<'a> AppState<'a> {
         let content = status.content();
         let event_builder = status.live_status_builder();
 
-        self.nostr
+        let outcome = self
+            .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
+        self.dispatch_nostr(outcome);
 
         self.status_bar.update(Message::MessageChanged {
             label: "Music".to_owned(),
@@ -321,6 +334,25 @@ impl<'a> AppState<'a> {
         self.timeline.active_tab().tab_title(self.user.profiles())
     }
 
+    /// Dispatch a [`NostrOutcome`] produced by `model::nostr` to the worker.
+    ///
+    /// `model::nostr::update` is side-effect free and only reports the command
+    /// to send; the application owns the sender and performs the actual I/O.
+    fn dispatch_nostr(&self, outcome: NostrOutcome) {
+        let NostrOutcome::Send(command) = outcome else {
+            return;
+        };
+
+        let Some(sender) = self.command_sender.as_ref() else {
+            log::warn!("Dropping Nostr command, worker not ready: {command:?}");
+            return;
+        };
+
+        if sender.send(command).is_err() {
+            log::error!("Failed to send Nostr command: subscription worker is gone");
+        }
+    }
+
     /// Record that the Nostr subscription is ready and store its command sender,
     /// then show the initial "loading" status for the active tab.
     pub fn on_connection_ready(
@@ -330,8 +362,9 @@ impl<'a> AppState<'a> {
         log::info!("NostrEvents subscription ready");
 
         let tab_title = self.active_tab_title();
-        self.nostr
-            .update(NostrMessage::ConnectionReady { command_sender });
+        self.command_sender = Some(command_sender);
+        let outcome = self.nostr.update(NostrMessage::ConnectionReady);
+        self.dispatch_nostr(outcome);
         self.status_bar.update(Message::MessageChanged {
             label: tab_title,
             message: "loading...".to_owned(),
@@ -514,7 +547,9 @@ impl<'a> AppState<'a> {
 
     /// Close the Nostr connection: unsubscribe and disconnect from relays.
     pub fn close_connection(&mut self) -> Command<AppMsg> {
-        self.nostr.update(NostrMessage::ConnectionClosed);
+        let outcome = self.nostr.update(NostrMessage::ConnectionClosed);
+        self.dispatch_nostr(outcome);
+        self.command_sender = None;
         Command::none()
     }
 
@@ -525,10 +560,11 @@ impl<'a> AppState<'a> {
         subscription_id: SubscriptionId,
     ) -> Command<AppMsg> {
         log::info!("Subscription created for {feed:?}: {subscription_id:?}");
-        self.nostr.update(NostrMessage::SubscriptionCreated {
+        let outcome = self.nostr.update(NostrMessage::SubscriptionCreated {
             feed,
             sub_id: subscription_id,
         });
+        self.dispatch_nostr(outcome);
         Command::none()
     }
 

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -1,14 +1,11 @@
 use nostr_sdk::prelude::*;
 use std::collections::HashMap;
-use tokio::sync::mpsc;
 
 use crate::domain::nostr::FeedKind;
 use crate::model::nostr_gateway::NostrCommand;
 
 pub enum Message {
-    ConnectionReady {
-        command_sender: mpsc::UnboundedSender<NostrCommand>,
-    },
+    ConnectionReady,
     EventSubmitted {
         event_builder: EventBuilder,
     },
@@ -29,11 +26,25 @@ pub enum Message {
     ConnectionClosed,
 }
 
+/// Follow-up effect the application must dispatch after a [`Nostr`] update.
+///
+/// `Nostr`, like the rest of `model`, is side-effect free: `update` mutates
+/// state and returns this outcome instead of sending on the gateway channel.
+/// The application layer owns the command sender and performs the send.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum NostrOutcome {
+    /// No command needs to be sent.
+    #[default]
+    None,
+    /// Dispatch this command to the subscription worker.
+    Send(NostrCommand),
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Nostr {
-    /// Command sender for NostrEvents subscription
-    /// This is set when the subscription emits a Ready message
-    command_sender: Option<mpsc::UnboundedSender<NostrCommand>>,
+    /// Whether the subscription worker is connected and accepting commands.
+    /// Set when the subscription emits a `Ready` message, cleared on shutdown.
+    connected: bool,
 
     /// Track subscription IDs for each feed
     /// The home feed has 3 subscriptions (backward, forward, profile)
@@ -47,7 +58,7 @@ impl Nostr {
     }
 
     pub fn is_ready(&self) -> bool {
-        self.command_sender.is_some()
+        self.connected
     }
 
     pub fn is_subscribed(&self, feed: &FeedKind) -> bool {
@@ -64,68 +75,70 @@ impl Nostr {
             .map(|(feed, _)| feed)
     }
 
-    pub fn update(&mut self, message: Message) {
+    pub fn update(&mut self, message: Message) -> NostrOutcome {
         match message {
-            Message::ConnectionReady { command_sender } => {
-                self.command_sender = Some(command_sender);
+            Message::ConnectionReady => {
+                self.connected = true;
+                NostrOutcome::None
             }
             Message::EventSubmitted { event_builder } => {
-                if let Some(sender) = self.command_sender.as_ref() {
-                    let _ = sender.send(NostrCommand::SendEventBuilder { event_builder });
+                if self.connected {
+                    NostrOutcome::Send(NostrCommand::SendEventBuilder { event_builder })
+                } else {
+                    NostrOutcome::None
                 }
             }
             Message::SubscriptionRequested { feed } => {
                 if matches!(feed, FeedKind::Home) {
-                    return;
+                    return NostrOutcome::None;
                 }
 
                 if self.feed_subscriptions.contains_key(&feed) {
                     // Already subscribed or in-flight.
-                    return;
+                    return NostrOutcome::None;
                 }
 
-                if let Some(sender) = self.command_sender.as_ref() {
-                    // Mark as in-flight before sending, so repeated calls are rejected.
-                    self.feed_subscriptions.insert(feed.clone(), Vec::new());
-
-                    if sender
-                        .send(NostrCommand::Subscribe { feed: feed.clone() })
-                        .is_err()
-                    {
-                        // NOTE: Avoid leaving an "in-flight" mark when the command didn't go through.
-                        self.feed_subscriptions.remove(&feed);
-                    }
+                if !self.connected {
+                    return NostrOutcome::None;
                 }
+
+                // Mark as in-flight before dispatching, so repeated calls are rejected.
+                self.feed_subscriptions.insert(feed.clone(), Vec::new());
+                NostrOutcome::Send(NostrCommand::Subscribe { feed })
             }
             Message::SubscriptionCreated { feed, sub_id } => {
                 self.feed_subscriptions
                     .entry(feed)
                     .or_default()
                     .push(sub_id);
+                NostrOutcome::None
             }
             Message::SubscriptionClosed { feed } => {
                 let subscription_ids = self.feed_subscriptions.remove(&feed).unwrap_or_default();
 
-                if !subscription_ids.is_empty() {
-                    if let Some(sender) = self.command_sender.as_ref() {
-                        let _ = sender.send(NostrCommand::Unsubscribe { subscription_ids });
-                    }
+                if !subscription_ids.is_empty() && self.connected {
+                    NostrOutcome::Send(NostrCommand::Unsubscribe { subscription_ids })
+                } else {
+                    NostrOutcome::None
                 }
-
-                self.feed_subscriptions.remove(&feed);
             }
             Message::HistoryRequested { feed, since } => {
-                if let Some(sender) = self.command_sender.as_ref() {
-                    let _ = sender.send(NostrCommand::LoadMore { feed, since });
+                if self.connected {
+                    NostrOutcome::Send(NostrCommand::LoadMore { feed, since })
+                } else {
+                    NostrOutcome::None
                 }
             }
             Message::ConnectionClosed => {
-                if let Some(sender) = self.command_sender.as_ref() {
-                    let _ = sender.send(NostrCommand::Shutdown);
-                }
-
-                self.command_sender = None;
+                let was_connected = self.connected;
+                self.connected = false;
                 self.feed_subscriptions.clear();
+
+                if was_connected {
+                    NostrOutcome::Send(NostrCommand::Shutdown)
+                } else {
+                    NostrOutcome::None
+                }
             }
         }
     }
@@ -143,23 +156,22 @@ mod tests {
     fn test_new_creates_default_instance() {
         let nostr = Nostr::new();
 
-        assert!(nostr.command_sender.is_none());
+        assert!(!nostr.is_ready());
         assert_eq!(nostr.feed_subscriptions, HashMap::new());
     }
 
     #[test]
-    fn test_is_ready_returns_false_when_no_command_sender() {
+    fn test_is_ready_returns_false_when_not_connected() {
         let nostr = Nostr::new();
 
         assert!(!nostr.is_ready());
     }
 
     #[test]
-    fn test_is_ready_returns_true_when_command_sender_exists() {
+    fn test_is_ready_returns_true_after_connection_ready() {
         let mut nostr = Nostr::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        assert_eq!(nostr.update(Message::ConnectionReady), NostrOutcome::None);
 
         assert!(nostr.is_ready());
     }
@@ -219,71 +231,64 @@ mod tests {
     }
 
     #[test]
-    fn test_update_connection_ready_sets_command_sender() {
+    fn test_update_connection_ready_sets_connected() {
         let mut nostr = Nostr::new();
-        let (tx, _rx) = mpsc::unbounded_channel();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        let outcome = nostr.update(Message::ConnectionReady);
 
-        assert!(nostr.command_sender.is_some());
+        assert_eq!(outcome, NostrOutcome::None);
+        assert!(nostr.is_ready());
     }
 
     #[test]
-    fn test_update_event_submitted_sends_command_when_ready() {
+    fn test_update_event_submitted_returns_send_when_ready() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let event_builder = EventBuilder::text_note("test");
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::EventSubmitted {
+        let outcome = nostr.update(Message::EventSubmitted {
             event_builder: event_builder.clone(),
         });
 
-        // Verify command was sent
-        let received = rx.try_recv();
         assert_eq!(
-            received,
-            Ok(NostrCommand::SendEventBuilder { event_builder })
+            outcome,
+            NostrOutcome::Send(NostrCommand::SendEventBuilder { event_builder })
         );
     }
 
     #[test]
-    fn test_update_event_submitted_does_nothing_when_not_ready() {
+    fn test_update_event_submitted_returns_none_when_not_ready() {
         let mut nostr = Nostr::new();
         let event_builder = EventBuilder::text_note("test");
 
-        // No command sender set, so nothing should happen
-        nostr.update(Message::EventSubmitted { event_builder });
+        let outcome = nostr.update(Message::EventSubmitted { event_builder });
 
-        // No panic means test passed
+        assert_eq!(outcome, NostrOutcome::None);
     }
 
     #[test]
     fn test_update_subscription_requested_ignores_home_tab() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionRequested {
+        let outcome = nostr.update(Message::SubscriptionRequested {
             feed: FeedKind::Home,
         });
 
-        // No command should be sent for Home tab
-        assert!(rx.try_recv().is_err());
+        assert_eq!(outcome, NostrOutcome::None);
         assert!(!nostr.feed_subscriptions.contains_key(&FeedKind::Home));
     }
 
     #[test]
     fn test_update_subscription_requested_creates_subscription() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
+        let outcome = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
         // Verify in-flight mark was set
         assert!(nostr.feed_subscriptions.contains_key(&feed));
@@ -295,29 +300,41 @@ mod tests {
             &Vec::<SubscriptionId>::new()
         );
 
-        // Verify command was sent
-        let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::Subscribe { feed }));
+        // Verify the subscribe command was reported
+        assert_eq!(
+            outcome,
+            NostrOutcome::Send(NostrCommand::Subscribe { feed })
+        );
+    }
+
+    #[test]
+    fn test_update_subscription_requested_ignores_request_when_not_connected() {
+        let mut nostr = Nostr::new();
+        let feed = create_test_feed();
+
+        // Not connected yet, so no in-flight mark and no command.
+        let outcome = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
+
+        assert_eq!(outcome, NostrOutcome::None);
+        assert!(!nostr.feed_subscriptions.contains_key(&feed));
     }
 
     #[test]
     fn test_update_subscription_requested_ignores_duplicate_request() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
-
-        // First command should be sent
-        assert!(rx.try_recv().is_ok());
+        let first = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
+        assert_eq!(
+            first,
+            NostrOutcome::Send(NostrCommand::Subscribe { feed: feed.clone() })
+        );
 
         // Second request should be ignored
-        nostr.update(Message::SubscriptionRequested { feed });
-
-        // No second command should be sent
-        assert!(rx.try_recv().is_err());
+        let second = nostr.update(Message::SubscriptionRequested { feed });
+        assert_eq!(second, NostrOutcome::None);
     }
 
     #[test]
@@ -363,29 +380,27 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_closed_removes_subscription_and_sends_unsubscribe() {
+    fn test_update_subscription_closed_removes_subscription_and_returns_unsubscribe() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
         nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
 
-        nostr.update(Message::SubscriptionClosed { feed: feed.clone() });
+        let outcome = nostr.update(Message::SubscriptionClosed { feed: feed.clone() });
 
         // Verify subscription was removed
         assert!(!nostr.feed_subscriptions.contains_key(&feed));
 
-        // Verify unsubscribe command was sent
-        let received = rx.try_recv();
+        // Verify unsubscribe command was reported
         assert_eq!(
-            received,
-            Ok(NostrCommand::Unsubscribe {
+            outcome,
+            NostrOutcome::Send(NostrCommand::Unsubscribe {
                 subscription_ids: vec![sub_id]
             })
         );
@@ -394,55 +409,61 @@ mod tests {
     #[test]
     fn test_update_subscription_closed_handles_non_existent_subscription() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionClosed { feed });
+        let outcome = nostr.update(Message::SubscriptionClosed { feed });
 
-        // No unsubscribe command should be sent for empty subscription list
-        assert!(rx.try_recv().is_err());
+        // No unsubscribe command for an empty subscription list
+        assert_eq!(outcome, NostrOutcome::None);
     }
 
     #[test]
-    fn test_update_history_requested_sends_load_more_command() {
+    fn test_update_history_requested_returns_load_more_command() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
         let since = Timestamp::from(1234567890);
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::HistoryRequested {
+        let outcome = nostr.update(Message::HistoryRequested {
             feed: feed.clone(),
             since,
         });
 
-        // Verify command was sent
-        let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::LoadMore { feed, since }));
+        assert_eq!(
+            outcome,
+            NostrOutcome::Send(NostrCommand::LoadMore { feed, since })
+        );
     }
 
     #[test]
-    fn test_update_connection_closed_clears_state_and_sends_shutdown() {
+    fn test_update_connection_closed_clears_state_and_returns_shutdown() {
         let mut nostr = Nostr::new();
-        let (tx, mut rx) = mpsc::unbounded_channel();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::ConnectionReady { command_sender: tx });
+        nostr.update(Message::ConnectionReady);
 
         nostr.update(Message::SubscriptionCreated { feed, sub_id });
 
-        nostr.update(Message::ConnectionClosed);
+        let outcome = nostr.update(Message::ConnectionClosed);
 
         // Verify state was cleared
-        assert!(nostr.command_sender.is_none());
+        assert!(!nostr.is_ready());
         assert_eq!(nostr.feed_subscriptions, HashMap::new());
 
-        // Verify shutdown command was sent
-        let received = rx.try_recv();
-        assert_eq!(received, Ok(NostrCommand::Shutdown));
+        // Verify shutdown command was reported
+        assert_eq!(outcome, NostrOutcome::Send(NostrCommand::Shutdown));
+    }
+
+    #[test]
+    fn test_update_connection_closed_returns_none_when_not_connected() {
+        let mut nostr = Nostr::new();
+
+        let outcome = nostr.update(Message::ConnectionClosed);
+
+        assert_eq!(outcome, NostrOutcome::None);
     }
 }


### PR DESCRIPTION
## Summary

Implements option **B** from the #456 follow-up: bring `model::nostr` under the same side-effect-free invariant as the rest of `model`, so the documented "`model` reports outcomes; the application owns all effects" rule holds universally.

Previously `model::nostr::update` sent `NostrCommand`s on the gateway sender directly — the only `model` component that performed I/O.

## Changes

- **`model::nostr`** — `Nostr::update` now returns a `NostrOutcome` (`None` / `Send(NostrCommand)`) instead of sending. `Nostr` keeps only its subscription bookkeeping plus a `connected` flag; the `command_sender` is removed from it.
- **`application::state`** — `AppState` owns the `command_sender` and performs the send through a new private `dispatch_nostr` helper. Every `self.nostr.update(...)` call site now dispatches the returned outcome. `on_connection_ready` stores the sender; `close_connection` clears it.
- **Tests** — model unit tests assert on the returned `NostrOutcome` rather than draining a channel, with added cases for the not-connected paths.
- **`docs/architecture.md`** — reverted to a universal `model` side-effect-free invariant (the exception introduced in #456 is gone). The gateway and end-to-end diagrams now show `application::state` owning the sender and dispatching `NostrOutcome`.

This mirrors the existing `TimelineOutcome` pattern (`Timeline::update` → `TimelineOutcome` → application acts).

## Behavior

Preserved, with one deliberate exception: the previous in-flight-subscription **rollback on a failed send** is dropped. `UnboundedSender::send` only fails once the subscription worker is gone (i.e. the app is shutting down), the rollback was untested, and its effect is unobservable in practice.

## Verification

`just fmt` + `just lint` (clippy `-D warnings`) clean; `just test` → 362 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)