### PR TITLE
refactor: model absence of outcome via Option, not a None variant

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,15 +134,18 @@ side-effect-free `update`. Key modules/types:
 - `model::editor`, `model::status_bar`, `model::fps`.
 - `model::nostr` — connection state: tracks the per-feed subscriptions and
   whether the worker is ready. It does **not** hold the command sender (the
-  application does); its `update` reports a `NostrOutcome` instead of sending.
+  application does); its `update` reports an `Option<NostrOutcome>` instead of
+  sending.
 - `model::nostr_gateway` — the **Nostr gateway contract** (see below).
 
 **Invariant:** `model::update` methods are side-effect free. They mutate state
 and, when the application must act, **report an outcome** rather than issuing an
-effect. `TimelineTab::update` / `Timeline::update` return `TimelineOutcome`
-(`None` / `LoadMoreRequested`), and `Nostr::update` returns `NostrOutcome`
-(`None` / `Send(NostrCommand)`); the application decides what to run. `editor`,
-`status_bar`, and `fps` are likewise pure.
+effect. `TimelineTab::update` / `Timeline::update` return
+`Option<TimelineOutcome>` (`Some(LoadMoreRequested)` or `None`), and
+`Nostr::update` returns `Option<NostrOutcome>` (`Some(Send(NostrCommand))` or
+`None`); the outcome enums hold only real follow-ups, with absence modelled by
+`Option`. The `update` methods are `#[must_use]`, so the application cannot
+silently drop an outcome. `editor`, `status_bar`, and `fps` are likewise pure.
 
 ### `application` — use cases
 
@@ -248,14 +251,15 @@ dependency.
 // application::state
 pub fn scroll_down(&mut self) -> Command<AppMsg> {
     match self.timeline.update(TimelineMessage::NextItemSelected) {
-        TimelineOutcome::LoadMoreRequested => self.load_more_timeline(),
-        TimelineOutcome::None => Command::none(),
+        Some(TimelineOutcome::LoadMoreRequested) => self.load_more_timeline(),
+        None => Command::none(),
     }
 }
 ```
 
-The Nostr gateway works the same way: `Nostr::update` returns a `NostrOutcome`,
-and the application — which owns the command sender — performs the send:
+The Nostr gateway works the same way: `Nostr::update` returns an
+`Option<NostrOutcome>`, and the application — which owns the command sender —
+performs the send:
 
 ```rust
 // application::state

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -338,8 +338,8 @@ impl<'a> AppState<'a> {
     ///
     /// `model::nostr::update` is side-effect free and only reports the command
     /// to send; the application owns the sender and performs the actual I/O.
-    fn dispatch_nostr(&self, outcome: NostrOutcome) {
-        let NostrOutcome::Send(command) = outcome else {
+    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) {
+        let Some(NostrOutcome::Send(command)) = outcome else {
             return;
         };
 
@@ -420,8 +420,10 @@ impl<'a> AppState<'a> {
         let feed = self.timeline.active_tab().feed().clone();
         let tab_title = self.active_tab_title();
 
-        self.nostr
+        let outcome = self
+            .nostr
             .update(NostrMessage::HistoryRequested { feed, since });
+        self.dispatch_nostr(outcome);
 
         self.status_bar.update(Message::MessageChanged {
             label: tab_title,
@@ -471,8 +473,8 @@ impl<'a> AppState<'a> {
     /// `LoadMoreRequested` and the application loads older events.
     pub fn scroll_down(&mut self) -> Command<AppMsg> {
         match self.timeline.update(TimelineMessage::NextItemSelected) {
-            TimelineOutcome::LoadMoreRequested => self.load_more_timeline(),
-            TimelineOutcome::None => Command::none(),
+            Some(TimelineOutcome::LoadMoreRequested) => self.load_more_timeline(),
+            None => Command::none(),
         }
     }
 
@@ -1049,7 +1051,7 @@ mod tests {
 
         // Associate a subscription with the Home tab.
         let sub_id = SubscriptionId::new("home_sub");
-        state.nostr.update(NostrMessage::SubscriptionCreated {
+        let _ = state.nostr.update(NostrMessage::SubscriptionCreated {
             feed: FeedKind::Home,
             sub_id: sub_id.clone(),
         });

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -29,13 +29,11 @@ pub enum Message {
 /// Follow-up effect the application must dispatch after a [`Nostr`] update.
 ///
 /// `Nostr`, like the rest of `model`, is side-effect free: `update` mutates
-/// state and returns this outcome instead of sending on the gateway channel.
-/// The application layer owns the command sender and performs the send.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// state and returns `Some(outcome)` instead of sending on the gateway channel,
+/// or `None` when there is nothing to dispatch. The application layer owns the
+/// command sender and performs the send.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NostrOutcome {
-    /// No command needs to be sent.
-    #[default]
-    None,
     /// Dispatch this command to the subscription worker.
     Send(NostrCommand),
 }
@@ -75,58 +73,63 @@ impl Nostr {
             .map(|(feed, _)| feed)
     }
 
-    pub fn update(&mut self, message: Message) -> NostrOutcome {
+    #[must_use]
+    pub fn update(&mut self, message: Message) -> Option<NostrOutcome> {
         match message {
             Message::ConnectionReady => {
                 self.connected = true;
-                NostrOutcome::None
+                None
             }
             Message::EventSubmitted { event_builder } => {
                 if self.connected {
-                    NostrOutcome::Send(NostrCommand::SendEventBuilder { event_builder })
+                    Some(NostrOutcome::Send(NostrCommand::SendEventBuilder {
+                        event_builder,
+                    }))
                 } else {
-                    NostrOutcome::None
+                    None
                 }
             }
             Message::SubscriptionRequested { feed } => {
                 if matches!(feed, FeedKind::Home) {
-                    return NostrOutcome::None;
+                    return None;
                 }
 
                 if self.feed_subscriptions.contains_key(&feed) {
                     // Already subscribed or in-flight.
-                    return NostrOutcome::None;
+                    return None;
                 }
 
                 if !self.connected {
-                    return NostrOutcome::None;
+                    return None;
                 }
 
                 // Mark as in-flight before dispatching, so repeated calls are rejected.
                 self.feed_subscriptions.insert(feed.clone(), Vec::new());
-                NostrOutcome::Send(NostrCommand::Subscribe { feed })
+                Some(NostrOutcome::Send(NostrCommand::Subscribe { feed }))
             }
             Message::SubscriptionCreated { feed, sub_id } => {
                 self.feed_subscriptions
                     .entry(feed)
                     .or_default()
                     .push(sub_id);
-                NostrOutcome::None
+                None
             }
             Message::SubscriptionClosed { feed } => {
                 let subscription_ids = self.feed_subscriptions.remove(&feed).unwrap_or_default();
 
                 if !subscription_ids.is_empty() && self.connected {
-                    NostrOutcome::Send(NostrCommand::Unsubscribe { subscription_ids })
+                    Some(NostrOutcome::Send(NostrCommand::Unsubscribe {
+                        subscription_ids,
+                    }))
                 } else {
-                    NostrOutcome::None
+                    None
                 }
             }
             Message::HistoryRequested { feed, since } => {
                 if self.connected {
-                    NostrOutcome::Send(NostrCommand::LoadMore { feed, since })
+                    Some(NostrOutcome::Send(NostrCommand::LoadMore { feed, since }))
                 } else {
-                    NostrOutcome::None
+                    None
                 }
             }
             Message::ConnectionClosed => {
@@ -135,9 +138,9 @@ impl Nostr {
                 self.feed_subscriptions.clear();
 
                 if was_connected {
-                    NostrOutcome::Send(NostrCommand::Shutdown)
+                    Some(NostrOutcome::Send(NostrCommand::Shutdown))
                 } else {
-                    NostrOutcome::None
+                    None
                 }
             }
         }
@@ -171,7 +174,7 @@ mod tests {
     fn test_is_ready_returns_true_after_connection_ready() {
         let mut nostr = Nostr::new();
 
-        assert_eq!(nostr.update(Message::ConnectionReady), NostrOutcome::None);
+        assert_eq!(nostr.update(Message::ConnectionReady), None);
 
         assert!(nostr.is_ready());
     }
@@ -200,7 +203,7 @@ mod tests {
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id,
         });
@@ -222,7 +225,7 @@ mod tests {
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
@@ -236,7 +239,7 @@ mod tests {
 
         let outcome = nostr.update(Message::ConnectionReady);
 
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
         assert!(nostr.is_ready());
     }
 
@@ -245,7 +248,7 @@ mod tests {
         let mut nostr = Nostr::new();
         let event_builder = EventBuilder::text_note("test");
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::EventSubmitted {
             event_builder: event_builder.clone(),
@@ -253,7 +256,9 @@ mod tests {
 
         assert_eq!(
             outcome,
-            NostrOutcome::Send(NostrCommand::SendEventBuilder { event_builder })
+            Some(NostrOutcome::Send(NostrCommand::SendEventBuilder {
+                event_builder
+            }))
         );
     }
 
@@ -264,20 +269,20 @@ mod tests {
 
         let outcome = nostr.update(Message::EventSubmitted { event_builder });
 
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
     }
 
     #[test]
     fn test_update_subscription_requested_ignores_home_tab() {
         let mut nostr = Nostr::new();
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::SubscriptionRequested {
             feed: FeedKind::Home,
         });
 
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
         assert!(!nostr.feed_subscriptions.contains_key(&FeedKind::Home));
     }
 
@@ -286,7 +291,7 @@ mod tests {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
@@ -303,7 +308,7 @@ mod tests {
         // Verify the subscribe command was reported
         assert_eq!(
             outcome,
-            NostrOutcome::Send(NostrCommand::Subscribe { feed })
+            Some(NostrOutcome::Send(NostrCommand::Subscribe { feed }))
         );
     }
 
@@ -315,7 +320,7 @@ mod tests {
         // Not connected yet, so no in-flight mark and no command.
         let outcome = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
 
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
         assert!(!nostr.feed_subscriptions.contains_key(&feed));
     }
 
@@ -324,17 +329,19 @@ mod tests {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let first = nostr.update(Message::SubscriptionRequested { feed: feed.clone() });
         assert_eq!(
             first,
-            NostrOutcome::Send(NostrCommand::Subscribe { feed: feed.clone() })
+            Some(NostrOutcome::Send(NostrCommand::Subscribe {
+                feed: feed.clone()
+            }))
         );
 
         // Second request should be ignored
         let second = nostr.update(Message::SubscriptionRequested { feed });
-        assert_eq!(second, NostrOutcome::None);
+        assert_eq!(second, None);
     }
 
     #[test]
@@ -343,7 +350,7 @@ mod tests {
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
@@ -362,12 +369,12 @@ mod tests {
         let sub_id1 = SubscriptionId::new("test_sub1");
         let sub_id2 = SubscriptionId::new("test_sub2");
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id1.clone(),
         });
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id2.clone(),
         });
@@ -385,9 +392,9 @@ mod tests {
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionCreated {
+        let _ = nostr.update(Message::SubscriptionCreated {
             feed: feed.clone(),
             sub_id: sub_id.clone(),
         });
@@ -400,9 +407,9 @@ mod tests {
         // Verify unsubscribe command was reported
         assert_eq!(
             outcome,
-            NostrOutcome::Send(NostrCommand::Unsubscribe {
+            Some(NostrOutcome::Send(NostrCommand::Unsubscribe {
                 subscription_ids: vec![sub_id]
-            })
+            }))
         );
     }
 
@@ -411,12 +418,12 @@ mod tests {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::SubscriptionClosed { feed });
 
         // No unsubscribe command for an empty subscription list
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
     }
 
     #[test]
@@ -425,7 +432,7 @@ mod tests {
         let feed = create_test_feed();
         let since = Timestamp::from(1234567890);
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::HistoryRequested {
             feed: feed.clone(),
@@ -434,7 +441,7 @@ mod tests {
 
         assert_eq!(
             outcome,
-            NostrOutcome::Send(NostrCommand::LoadMore { feed, since })
+            Some(NostrOutcome::Send(NostrCommand::LoadMore { feed, since }))
         );
     }
 
@@ -444,9 +451,9 @@ mod tests {
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
 
-        nostr.update(Message::ConnectionReady);
+        let _ = nostr.update(Message::ConnectionReady);
 
-        nostr.update(Message::SubscriptionCreated { feed, sub_id });
+        let _ = nostr.update(Message::SubscriptionCreated { feed, sub_id });
 
         let outcome = nostr.update(Message::ConnectionClosed);
 
@@ -455,7 +462,7 @@ mod tests {
         assert_eq!(nostr.feed_subscriptions, HashMap::new());
 
         // Verify shutdown command was reported
-        assert_eq!(outcome, NostrOutcome::Send(NostrCommand::Shutdown));
+        assert_eq!(outcome, Some(NostrOutcome::Send(NostrCommand::Shutdown)));
     }
 
     #[test]
@@ -464,6 +471,6 @@ mod tests {
 
         let outcome = nostr.update(Message::ConnectionClosed);
 
-        assert_eq!(outcome, NostrOutcome::None);
+        assert_eq!(outcome, None);
     }
 }

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -143,7 +143,8 @@ impl Timeline {
         tab.is_at_bottom()
     }
 
-    pub fn update(&mut self, message: Message) -> TimelineOutcome {
+    #[must_use]
+    pub fn update(&mut self, message: Message) -> Option<TimelineOutcome> {
         match message {
             Message::NoteAddedToTab { event, feed } => {
                 // Find the tab index for the specified feed
@@ -152,7 +153,7 @@ impl Timeline {
                     None => {
                         // Tab not found - cannot add note
                         log::warn!("Cannot add note: tab {feed:?} not found");
-                        return TimelineOutcome::None;
+                        return None;
                     }
                 };
 
@@ -207,7 +208,7 @@ impl Timeline {
                 // Check if a tab for the same feed already exists
                 if self.find_tab_by_feed(&feed).is_some() {
                     log::warn!("Tab for this feed already exists");
-                    return TimelineOutcome::None;
+                    return None;
                 }
 
                 // Create and add the new tab
@@ -221,13 +222,13 @@ impl Timeline {
                 // Validate index
                 if index >= self.tabs.len() {
                     log::warn!("Tab index out of bounds");
-                    return TimelineOutcome::None;
+                    return None;
                 }
 
                 // Cannot remove the Home tab
                 if matches!(self.tabs[index].feed(), FeedKind::Home) {
                     log::warn!("Cannot remove the Home tab");
-                    return TimelineOutcome::None;
+                    return None;
                 }
 
                 // Remove the tab
@@ -263,7 +264,7 @@ impl Timeline {
             }
         }
 
-        TimelineOutcome::None
+        None
     }
 }
 

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -29,13 +29,11 @@ use super::{
 /// Follow-up action the application layer must take after a timeline update.
 ///
 /// Timeline state objects are side-effect free, like the rest of `model`: their
-/// `update` methods mutate state and return this outcome instead of issuing a
-/// `Command`/`AppMsg`. The application layer decides which effect to run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// `update` methods mutate state and return `Some(outcome)` instead of issuing a
+/// `Command`/`AppMsg`, or `None` when no follow-up is required. The application
+/// layer decides which effect to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimelineOutcome {
-    /// No follow-up action is required.
-    #[default]
-    None,
     /// The selection reached the bottom; older events should be loaded.
     LoadMoreRequested,
 }
@@ -170,7 +168,7 @@ impl TimelineTab {
     /// ### NextItemSelected
     /// When the user tries to scroll down at the bottom of the timeline:
     /// - Updates pagination state to "loading more"
-    /// - Returns `TimelineOutcome::LoadMoreRequested` so the application can fetch older events
+    /// - Returns `Some(TimelineOutcome::LoadMoreRequested)` so the application can fetch older events
     ///
     /// ### NoteAdded
     /// When a new note arrives, coordinates three child components:
@@ -182,7 +180,8 @@ impl TimelineTab {
     /// The coordination logic lives here because it's TimelineTab's responsibility
     /// to maintain consistency across its children, not the responsibility of
     /// Selection or Pagination themselves.
-    pub fn update(&mut self, message: Message) -> TimelineOutcome {
+    #[must_use]
+    pub fn update(&mut self, message: Message) -> Option<TimelineOutcome> {
         match message {
             // Selection-related messages - simple delegation
             Message::ItemSelected(index) => {
@@ -208,7 +207,7 @@ impl TimelineTab {
                                 self.pagination
                                     .update(PaginationMessage::LoadingMoreStarted { since });
 
-                                return TimelineOutcome::LoadMoreRequested;
+                                return Some(TimelineOutcome::LoadMoreRequested);
                             }
                         }
                     } else {
@@ -260,7 +259,7 @@ impl TimelineTab {
             }
         };
 
-        TimelineOutcome::None
+        None
     }
 }
 
@@ -305,17 +304,17 @@ mod tests {
         // Test ItemSelected - no command should be issued for selection changes
         let cmd = tab.update(Message::ItemSelected(5));
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Test SelectionCleared
         let cmd = tab.update(Message::SelectionCleared);
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Test FirstItemSelected
         let cmd = tab.update(Message::FirstItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Add some notes first so LastItemSelected and NextItemSelected work properly
         for i in 0..11 {
@@ -327,17 +326,17 @@ mod tests {
         let _ = tab.update(Message::ItemSelected(5));
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), Some(10));
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Test PreviousItemSelected
         let cmd = tab.update(Message::PreviousItemSelected);
         assert_eq!(tab.selected_index(), Some(9));
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Test NextItemSelected (not at bottom, so no LoadMore)
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), Some(10));
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
     }
 
     #[test]
@@ -358,7 +357,7 @@ mod tests {
         // Try to scroll down at bottom - should trigger loading more and return LoadMore command
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested); // LoadMore command was issued
+        assert_eq!(cmd, Some(TimelineOutcome::LoadMoreRequested)); // LoadMore command was issued
     }
 
     #[test]
@@ -375,12 +374,12 @@ mod tests {
         // First scroll-down at bottom triggers loading more
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested);
+        assert_eq!(cmd, Some(TimelineOutcome::LoadMoreRequested));
 
         // A subsequent scroll-down while already loading must not re-trigger it
         let cmd = tab.update(Message::NextItemSelected);
         assert!(tab.is_loading_more());
-        assert_eq!(cmd, TimelineOutcome::None); // No duplicate LoadMore command
+        assert_eq!(cmd, None); // No duplicate LoadMore command
     }
 
     #[test]
@@ -391,7 +390,7 @@ mod tests {
         // Should do nothing when there are no notes (no oldest_timestamp)
         let cmd = tab.update(Message::NextItemSelected);
         assert!(!tab.is_loading_more());
-        assert_eq!(cmd, TimelineOutcome::None); // No command should be issued
+        assert_eq!(cmd, None); // No command should be issued
     }
 
     #[test]
@@ -404,7 +403,7 @@ mod tests {
         assert_eq!(tab.len(), 1);
         assert!(!tab.is_empty());
         assert_eq!(tab.oldest_timestamp(), Some(Timestamp::from(1000)));
-        assert_eq!(cmd, TimelineOutcome::None); // NoteAdded should not issue commands
+        assert_eq!(cmd, None); // NoteAdded should not issue commands
     }
 
     #[test]
@@ -479,7 +478,7 @@ mod tests {
         // Selection should be adjusted to index 2 to maintain the same item selected
         assert_eq!(tab.selected_index(), Some(2));
         assert_eq!(tab.len(), 3);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
     }
 
     #[test]
@@ -503,7 +502,7 @@ mod tests {
         // Selection should not change because the new item was inserted after
         assert_eq!(tab.selected_index(), Some(0));
         assert_eq!(tab.len(), 3);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
     }
 
     #[test]
@@ -595,12 +594,12 @@ mod tests {
         // NextItemSelected on empty timeline should do nothing
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // LastItemSelected on empty timeline should do nothing
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
     }
 
     #[test]
@@ -615,7 +614,7 @@ mod tests {
         // because Selection's logic requires max_index > 0 for initial selection
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), None);
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
 
         // Select the item manually
         let _ = tab.update(Message::ItemSelected(0));
@@ -624,13 +623,13 @@ mod tests {
         // Can't go beyond the only item - but at bottom with single item, should trigger LoadMore
         let cmd = tab.update(Message::NextItemSelected);
         assert_eq!(tab.selected_index(), Some(0));
-        assert_eq!(cmd, TimelineOutcome::LoadMoreRequested); // LoadMore command issued when at bottom
+        assert_eq!(cmd, Some(TimelineOutcome::LoadMoreRequested)); // LoadMore command issued when at bottom
 
         // LastItemSelected should select index 0
         let _ = tab.update(Message::SelectionCleared);
         let cmd = tab.update(Message::LastItemSelected);
         assert_eq!(tab.selected_index(), Some(0));
-        assert_eq!(cmd, TimelineOutcome::None);
+        assert_eq!(cmd, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follows the design discussion after #457: move "no follow-up" out of the outcome enums and into `Option`, since the absence of an outcome is not a kind of outcome. The enums keep their domain names and remain the extension point for future follow-ups.

- `TimelineOutcome` → `{ LoadMoreRequested }`; `Timeline::update` / `TimelineTab::update` return `Option<TimelineOutcome>`.
- `NostrOutcome` → `{ Send(NostrCommand) }`; `Nostr::update` returns `Option<NostrOutcome>`; `dispatch_nostr` takes the `Option`.
- The three `update` methods gain a **function-level** `#[must_use]`. A type-level `#[must_use]` cannot propagate through `Option`, but the function-level attribute restores the "the caller must handle the returned outcome" guarantee.

## Bug caught by `#[must_use]`

Adding the attribute immediately failed the build on a latent regression from #457: `load_more_timeline` discarded the `HistoryRequested` outcome, so `NostrCommand::LoadMore` was never dispatched — pagination (load-more) was silently broken. Fixed here by dispatching the outcome. This is a concrete payoff of the function-level `#[must_use]` we discussed.

## Notes

- `Default` is dropped from both enums (there is no longer a default variant); absence is `Option::None`.
- Docs (`architecture.md`) and unit tests updated to the `Option<…>` shape.

## Verification

`just fmt` + `just lint` (clippy `-D warnings`) clean; `just test` → 362 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)