### PR TITLE
docs: clarify config.styles status and the error-to-UI flow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,6 +161,10 @@ vocabulary, and orchestrates effects. Key modules/types:
   `EditorMsg`, `NostrMsg`). The message contract for the whole app.
 - `application::config` — `Config` (loaded from files), plus the UI config value
   types `keybindings` (`KeyBindings`, `Action`) and `styles` (`Styles`).
+  `keybindings` is consumed by `runtime` for input resolution. `styles` is a
+  **reserved theming hook that is not yet wired up**: it is parsed and merged,
+  but no widget reads it — `presentation` currently hardcodes its `ratatui`
+  styles. It is kept here pending a future theming feature.
 
 ### `infrastructure` — I/O adapters
 
@@ -242,6 +246,25 @@ neutral leaf that may not reference `FeedKind`, `model` — already a dependency
 fits. Its feed identity comes from `domain::nostr::FeedKind`, a downward
 dependency.
 
+### Error reporting (worker → UI)
+
+Command failures travel back through the same gateway contract and surface in
+the status bar, with no inward layer reaching outward:
+
+1. The worker (`infrastructure::subscription::nostr::NostrEvents`) fails to run a
+   `NostrCommand` and emits `model::nostr_gateway::Message::Error { error }`,
+   where `error` is a `CommandError` (e.g. `SendEventFailed`,
+   `ConnectRelayFailed`).
+2. `runtime` receives it in `handle_nostr_subscription_message` and calls the
+   use case `AppState::notify_subscription_error(error)`.
+3. That use case updates `model::status_bar` with an error message
+   (`Message::ErrorMessageChanged`, labelled `Nostr`).
+4. `presentation`'s `StatusBarWidget` renders it on the next frame.
+
+Relay shutdown follows the same shape via `RelayPoolNotification::Shutdown` →
+`AppState::notify_subscription_shutdown`. System-level errors raised inside the
+application use `AppState::show_error`, which writes to the same status bar.
+
 ### Outcome reporting (model → application)
 
 `model` never issues effects. When a state transition requires an effect, the
@@ -279,7 +302,9 @@ enums and are driven by `AppState`, not by `AppMsg` directly.
 `application::config::Config` aggregates all settings — app/Nostr settings plus
 the UI value types `KeyBindings` and `Styles` — and loads/merges them from
 config files. `runtime` reads `config.keybindings` to resolve input; `main.rs`
-builds the `Config` at startup.
+builds the `Config` at startup. `config.styles` is parsed and merged but not yet
+consumed (see the `application::config` note above); it is a reserved hook for a
+future theming feature, not a live setting.
 
 ## End-to-end flow
 


### PR DESCRIPTION
## Summary

Two architecture-doc clarifications from investigating deferred review points (1) `Styles` placement and (2) the undocumented error flow. **Docs only** — grounded in the code.

### (1) `config.styles` is a not-yet-wired hook

Investigation found `Styles` is **not a misplaced-but-used type** — it is parsed and merged in `application::config` but **never consumed**: no widget reads `config.styles`, and `presentation` hardcodes its `ratatui` styles (19 sites). It is also absent from the shipped default `.config/config.json5`. By contrast `config.keybindings` is genuinely used by `runtime` for input resolution.

Per the decision, `Styles` is **kept as-is** and the doc now describes it as a reserved theming hook that is not yet wired up, so it no longer implies it affects rendering. (Relocating it to `presentation` would only move dead code; wiring it up is a separate feature.)

### (2) Error-to-UI flow

Documented the previously-undocumented path, which follows the same inward-contract shape as the rest of the gateway:

`infrastructure` (`NostrEvents` raises `CommandError`) → `model::nostr_gateway::Message::Error` → `runtime::handle_nostr_subscription_message` → `AppState::notify_subscription_error` → `model::status_bar` (`ErrorMessageChanged`) → `StatusBarWidget`.

Also noted the parallel shutdown (`notify_subscription_shutdown`) and system-error (`show_error`) paths into the same status bar. No inward layer reaches outward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)