### PR TITLE
feat: add mention timeline tab (kind-1 #p-tagged events)

### DIFF
--- a/.config/config.json5
+++ b/.config/config.json5
@@ -12,6 +12,7 @@
       "<f>": "React",                // React to the post
       "<t>": "Repost",               // Repost the post
       "<i>": "OpenAuthorTimeline",   // Open author timeline
+      "<m>": "OpenMentionTab",       // Open mention tab
       "<Ctrl-w>": "CloseCurrentTab", // Close current tab
       "<h>": "PrevTab",              // Switch to previous tab
       "<left>": "PrevTab",           // Switch to previous tab

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A TUI client for [Nostr](https://nostr.com)
 ## Current Features
 
 - Timeline
+- Mention timeline
 - Post, reply, react and repost
 - Open per-user timelines as tabs
 - Broadcast the currently playing track as a music status (NIP-38)
@@ -81,6 +82,7 @@ Options:
 | `f`                   | Send reaction                       |
 | `t`                   | Repost                              |
 | `i`                   | Open the author's timeline as a tab |
+| `m`                   | Open the mention timeline as a tab  |
 | `h` `left`            | Switch to the previous tab          |
 | `l` `right`           | Switch to the next tab              |
 | `Ctrl-w`              | Close the current tab               |
@@ -121,6 +123,7 @@ The following actions are available:
 | `React`            | Send a reaction to the selected note |
 | `Repost`           | Repost the selected note             |
 | `OpenAuthorTimeline` | Open the author's timeline as a tab |
+| `OpenMentionTab`   | Open the mention timeline as a tab   |
 | `CloseCurrentTab`  | Close the current tab                |
 | `PrevTab`          | Switch to the previous tab           |
 | `NextTab`          | Switch to the next tab               |

--- a/src/application/config/keybindings.rs
+++ b/src/application/config/keybindings.rs
@@ -38,6 +38,7 @@ pub enum Action {
 
     // Tab management
     OpenAuthorTimeline,
+    OpenMentionTab,
     CloseCurrentTab,
     PrevTab,
     NextTab,

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -65,6 +65,8 @@ pub enum TimelineMsg {
     PrevTab,
     /// Open author timeline for the selected note's author
     OpenAuthorTimeline,
+    /// Open mention timeline
+    OpenMentionTab,
     /// Close the current tab
     CloseCurrentTab,
 }

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -145,6 +145,41 @@ impl<'a> AppState<'a> {
         }
     }
 
+    /// Open (or switch to) the mention timeline tab.
+    ///
+    /// If the Mention tab already exists, it is selected. Otherwise a new tab is
+    /// created, a subscription is requested, and a "loading" status message is shown.
+    pub fn open_mention_tab(&mut self) -> Command<AppMsg> {
+        let feed = FeedKind::Mention;
+
+        // Tab already open: just switch to it.
+        if let Some(index) = self.timeline.find_tab_by_feed(&feed) {
+            let _ = self.timeline.update(TimelineMessage::TabSelected { index });
+            return Command::none();
+        }
+
+        let _ = self
+            .timeline
+            .update(TimelineMessage::TabAdded { feed: feed.clone() });
+
+        if self.timeline.find_tab_by_feed(&feed).is_some() {
+            log::info!("Created new mention timeline");
+
+            let outcome = self
+                .nostr
+                .update(NostrMessage::SubscriptionRequested { feed });
+            self.dispatch_nostr(outcome);
+
+            self.set_status("Mention", "loading...");
+        } else {
+            log::error!("Failed to create mention timeline");
+
+            self.set_status_error("Mention", "failed to open tab");
+        }
+
+        Command::none()
+    }
+
     /// Open (or switch to) the author timeline tab for the given pubkey.
     ///
     /// If a tab for this author already exists, it is selected. Otherwise a new
@@ -843,6 +878,40 @@ mod tests {
             state.status_bar.message(),
             Some(format!("[{author_npub}] loading...").as_str())
         );
+    }
+
+    #[test]
+    fn test_open_mention_tab_switches_to_existing_tab() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let feed = FeedKind::Mention;
+
+        // Pre-create the mention tab, then move focus back to Home.
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabAdded { feed: feed.clone() });
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabSelected { index: 0 });
+        assert_eq!(state.timeline.active_tab_index(), 0);
+
+        let _ = state.open_mention_tab();
+
+        // Switches to the existing tab instead of creating a duplicate.
+        assert_eq!(state.timeline.tabs().len(), 2);
+        assert_eq!(state.timeline.active_tab().feed(), &feed);
+    }
+
+    #[test]
+    fn test_open_mention_tab_creates_new_tab_and_shows_loading() {
+        let mut state = AppState::new(Keys::generate().public_key());
+        let feed = FeedKind::Mention;
+
+        let _ = state.open_mention_tab();
+
+        // A new mention tab is created, focused, and a loading status is shown.
+        assert_eq!(state.timeline.tabs().len(), 2);
+        assert_eq!(state.timeline.active_tab().feed(), &feed);
+        assert_eq!(state.status_bar.message(), Some("[Mention] loading..."));
     }
 
     #[test]

--- a/src/domain/nostr/feed.rs
+++ b/src/domain/nostr/feed.rs
@@ -11,6 +11,8 @@ use nostr_sdk::prelude::*;
 pub enum FeedKind {
     /// The home feed (the followed authors, plus the user themselves).
     Home,
+    /// The mention feed (kind-1 events that tag the current user via `#p`).
+    Mention,
     /// A single author's feed.
     Author(PublicKey),
 }

--- a/src/domain/nostr/feed_filter.rs
+++ b/src/domain/nostr/feed_filter.rs
@@ -26,6 +26,9 @@ pub const HOME_FEED_KINDS: [Kind; 4] = [
 /// Event kinds shown in a single user's feed.
 pub const USER_FEED_KINDS: [Kind; 2] = [Kind::TextNote, Kind::Repost];
 
+/// Event kinds shown in the mention feed.
+pub const MENTION_FEED_KINDS: [Kind; 1] = [Kind::TextNote];
+
 /// Ensure the user's own pubkey is part of the author set so that their posts
 /// always appear in the home feed, even when they do not follow themselves.
 pub fn with_own_pubkey(mut authors: Vec<PublicKey>, own_pubkey: PublicKey) -> Vec<PublicKey> {
@@ -91,6 +94,34 @@ pub fn user_load_more_filter(pubkey: PublicKey, since: Timestamp) -> Filter {
     Filter::new()
         .authors(vec![pubkey])
         .kinds(USER_FEED_KINDS)
+        .until(since)
+        .limit(DEFAULT_FEED_LIMIT)
+}
+
+/// Build the backward + forward subscription filters for the mention feed.
+///
+/// Returns `[backward, forward]`:
+/// - `backward`: historical kind-1 events tagging `pubkey` via `#p`, up to `now`
+/// - `forward`: real-time kind-1 events tagging `pubkey` via `#p` from `now` onward
+pub fn mention_feed_filters(pubkey: PublicKey, now: Timestamp) -> [Filter; 2] {
+    let backward = Filter::new()
+        .pubkey(pubkey)
+        .kinds(MENTION_FEED_KINDS)
+        .until(now)
+        .limit(DEFAULT_FEED_LIMIT);
+    let forward = Filter::new()
+        .pubkey(pubkey)
+        .kinds(MENTION_FEED_KINDS)
+        .since(now);
+
+    [backward, forward]
+}
+
+/// Build the "load more" filter for paginating older mention-feed events before `since`.
+pub fn mention_load_more_filter(pubkey: PublicKey, since: Timestamp) -> Filter {
+    Filter::new()
+        .pubkey(pubkey)
+        .kinds(MENTION_FEED_KINDS)
         .until(since)
         .limit(DEFAULT_FEED_LIMIT)
 }
@@ -209,6 +240,45 @@ mod tests {
             Filter::new()
                 .authors(vec![author])
                 .kinds(USER_FEED_KINDS)
+                .until(since)
+                .limit(DEFAULT_FEED_LIMIT)
+        );
+    }
+
+    #[test]
+    fn test_mention_feed_filters() {
+        let own = pubkey(3);
+        let now = Timestamp::from(2000);
+
+        let [backward, forward] = mention_feed_filters(own, now);
+
+        assert_eq!(
+            backward,
+            Filter::new()
+                .pubkey(own)
+                .kinds(MENTION_FEED_KINDS)
+                .until(now)
+                .limit(DEFAULT_FEED_LIMIT)
+        );
+        assert_eq!(
+            forward,
+            Filter::new()
+                .pubkey(own)
+                .kinds(MENTION_FEED_KINDS)
+                .since(now)
+        );
+    }
+
+    #[test]
+    fn test_mention_load_more_filter() {
+        let own = pubkey(3);
+        let since = Timestamp::from(500);
+
+        assert_eq!(
+            mention_load_more_filter(own, since),
+            Filter::new()
+                .pubkey(own)
+                .kinds(MENTION_FEED_KINDS)
                 .until(since)
                 .limit(DEFAULT_FEED_LIMIT)
         );

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -10,8 +10,8 @@ use tears::{SubscriptionId, SubscriptionSource};
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 use crate::domain::nostr::feed_filter::{
-    home_feed_filters, home_load_more_filter, user_feed_filters, user_load_more_filter,
-    with_own_pubkey,
+    home_feed_filters, home_load_more_filter, mention_feed_filters, mention_load_more_filter,
+    user_feed_filters, user_load_more_filter, with_own_pubkey,
 };
 use crate::domain::nostr::FeedKind;
 use crate::model::nostr_gateway::{CommandError, Message, NostrCommand};
@@ -170,6 +170,17 @@ impl NostrEvents {
                             return;
                         }
                     },
+                    FeedKind::Mention => {
+                        let Ok(signer) = client.signer().await else {
+                            log::warn!("No signer available, cannot load more mention events");
+                            return;
+                        };
+                        let Ok(own_pubkey) = signer.get_public_key().await else {
+                            log::warn!("Failed to get public key, cannot load more mention events");
+                            return;
+                        };
+                        mention_load_more_filter(own_pubkey, since)
+                    }
                     FeedKind::Author(pubkey) => user_load_more_filter(*pubkey, since),
                 };
 
@@ -190,6 +201,42 @@ impl NostrEvents {
                 match &feed {
                     FeedKind::Home => {
                         log::warn!("Home feed should be initialized, not subscribed via command");
+                    }
+                    FeedKind::Mention => {
+                        let Ok(signer) = client.signer().await else {
+                            log::error!("No signer available, cannot subscribe to mention feed");
+                            return;
+                        };
+                        let Ok(own_pubkey) = signer.get_public_key().await else {
+                            log::error!(
+                                "Failed to get public key, cannot subscribe to mention feed"
+                            );
+                            return;
+                        };
+
+                        let [backward_filter, forward_filter] =
+                            mention_feed_filters(own_pubkey, Timestamp::now());
+
+                        let result = tokio::try_join!(
+                            client.subscribe(backward_filter, None),
+                            client.subscribe(forward_filter, None)
+                        );
+
+                        match result {
+                            Ok((sub_id1, sub_id2)) => {
+                                let _ = msg_tx.send(Message::SubscriptionCreated {
+                                    feed: feed.clone(),
+                                    subscription_id: sub_id1.val,
+                                });
+                                let _ = msg_tx.send(Message::SubscriptionCreated {
+                                    feed,
+                                    subscription_id: sub_id2.val,
+                                });
+                            }
+                            Err(e) => {
+                                log::error!("Failed to subscribe to mention feed: {e}");
+                            }
+                        }
                     }
                     FeedKind::Author(pubkey) => {
                         // Subscribe to both backward (historical) and forward (real-time) events

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -100,6 +100,7 @@ impl TimelineTab {
     pub fn tab_title(&self, profiles: &HashMap<PublicKey, Profile>) -> String {
         match self.feed {
             FeedKind::Home => "Home".to_string(),
+            FeedKind::Mention => "Mention".to_string(),
             FeedKind::Author(pubkey) => profiles
                 .get(&pubkey)
                 .and_then(|profile| profile.handle())
@@ -638,6 +639,14 @@ mod tests {
         let profiles = HashMap::new();
 
         assert_eq!(tab.tab_title(&profiles), "Home");
+    }
+
+    #[test]
+    fn test_tab_title_mention() {
+        let tab = TimelineTab::new(FeedKind::Mention);
+        let profiles = HashMap::new();
+
+        assert_eq!(tab.tab_title(&profiles), "Mention");
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -276,6 +276,9 @@ impl<'a> TearsApp<'a> {
             KeyAction::OpenAuthorTimeline => {
                 Command::message(AppMsg::Timeline(TimelineMsg::OpenAuthorTimeline))
             }
+            KeyAction::OpenMentionTab => {
+                Command::message(AppMsg::Timeline(TimelineMsg::OpenMentionTab))
+            }
             KeyAction::CloseCurrentTab => {
                 Command::message(AppMsg::Timeline(TimelineMsg::CloseCurrentTab))
             }
@@ -327,6 +330,7 @@ impl<'a> TearsApp<'a> {
                     None => Command::none(),
                 }
             }
+            TimelineMsg::OpenMentionTab => self.state.open_mention_tab(),
             TimelineMsg::CloseCurrentTab => self.state.close_current_tab(),
         }
     }


### PR DESCRIPTION
## Summary

- Adds a **Mention tab** that subscribes to kind-1 `TextNote` events where the current user is tagged via `#p`
- Press `m` to open the tab (idempotent: switches to it if already open, closable unlike the Home tab)
- Follows the same patterns as the existing `Author` tab: `FeedKind::Mention` is a unit variant (pubkey implicit from the signer, consistent with `FeedKind::Home`)

## Changes

**Domain**
- `FeedKind::Mention` — new unit variant in `feed.rs`
- `MENTION_FEED_KINDS`, `mention_feed_filters`, `mention_load_more_filter` — pure filter builders in `feed_filter.rs`

**Infrastructure**
- `NostrEvents::handle_command` — `Subscribe` and `LoadMore` arms for `FeedKind::Mention` (resolves own pubkey from signer, mirrors the home-feed pattern)

**Application**
- `AppState::open_mention_tab` — opens or switches to the Mention tab, requests subscription, shows loading status
- `TimelineMsg::OpenMentionTab` + `Action::OpenMentionTab` wired through `runtime.rs`
- Default keybinding: `m`

**Docs**
- README updated: current features, keybinding table, actions table

## Test plan

- [x] `mention_feed_filters` / `mention_load_more_filter` unit tests (filter shape assertions)
- [x] `test_tab_title_mention` (returns `"Mention"`)
- [x] `test_open_mention_tab_switches_to_existing_tab` (no duplicate tab created)
- [x] `test_open_mention_tab_creates_new_tab_and_shows_loading` (tab added, status shown)
- [x] `cargo test` — 375 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)