### PR TITLE
build(deps): bump tears from 0.10.2 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "tears"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b888142d4e86d8c603141b7db17beb505fa62fb4bf2f8dbf03f594d215eb1d86"
+checksum = "596dbc1a06e9ac9d9c01a6129ed9efb7e81a1e9328d08191e0024bbe33b74199"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = "1"
 signal-hook = "0.4"
 sorted-vec = "0.8"
 strip-ansi-escapes = "0.2"
-tears = "0.10.2"
+tears = "0.11.0"
 thousands = "0.2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ pkgin install nostui
 nostui [OPTIONS]
 
 Options:
-  -t, --tick-rate <FLOAT>   Tick rate, i.e. number of ticks per second [default: 16]
-  -f, --frame-rate <FLOAT>  Frame rate, i.e. number of frames per second [default: 16]
-  -h, --help                Print help
-  -V, --version             Print version
+  -t, --tick-rate <FLOAT>  Tick rate, i.e. number of ticks per second [default: 16]
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ### Default Keybindings

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -124,6 +124,8 @@ Drop the option wherever nostui is launched — a shell alias, a `.desktop` entr
 **Note:**
 There is no direct replacement, and redraw volume can move in either direction. Idle nostui redraws once per tick, so `--tick-rate` currently sets the idle floor and lowering it is the nearest thing to the old throttle — but that is a side effect of how the tick is handled today, not a rendering control, and [#510](https://github.com/akiomik/nostui/issues/510) plans to remove it. Under a busy feed there is no longer any ceiling: redraws follow inbound relay traffic rather than being clamped to 16 fps, so a heavy home feed can redraw more often than it used to.
 
+The same applies upward, and it is the direction most likely to surprise: a `--tick-rate` you raised on 0.1.x cost extra update passes but never more than 16 renders per second. It now costs a full render per tick even when nothing is happening, so `--tick-rate 200` means 200 renders per second on a completely idle screen. If you raised it, lower it back.
+
 ### Deprecations
 
 #### Deprecated: `privatekey` config field

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -99,6 +99,31 @@ This is primarily an internal change. If you were:
 **Note:**
 The "ticks per sec" value still provides useful performance information, representing how frequently the application processes events and updates state.
 
+---
+
+#### Removed: `--frame-rate` command line option
+
+**What changed:**
+- The `-f` / `--frame-rate` option has been removed. Passing it now fails argument parsing with `error: unexpected argument '-f' found`
+- There is no replacement option
+
+**Reason:**
+The Tears framework removed its frame rate in 0.11.0. Render cadence is now bounded by the update pass: the loop renders when a pass leaves the view dirty and parks when it has no work, so there is no period left to configure. Keeping the option would mean accepting a value and ignoring it.
+
+**Migration steps:**
+
+Drop the option wherever nostui is launched — a shell alias, a `.desktop` entry, a systemd unit, or a wrapper script:
+
+```diff
+- nostui --frame-rate 30 --tick-rate 16
++ nostui --tick-rate 16
+```
+
+`--tick-rate` is unaffected. It controls how often the application processes a tick, which is also what the FPS display measures.
+
+**Note:**
+If you lowered the frame rate to reduce redraw cost — over SSH, or on a slow terminal — there is no setting that restores that. Redraw frequency is now a property of how often application state changes.
+
 ### Deprecations
 
 #### Deprecated: `privatekey` config field

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -122,7 +122,7 @@ Drop the option wherever nostui is launched — a shell alias, a `.desktop` entr
 `--tick-rate` is unaffected. It controls how often the application processes a tick, which is also what the FPS display measures.
 
 **Note:**
-If you lowered the frame rate to reduce redraw cost — over SSH, or on a slow terminal — there is no setting that restores that. Redraw frequency is now a property of how often application state changes.
+There is no direct replacement, and redraw volume can move in either direction. Idle nostui redraws once per tick, so `--tick-rate` currently sets the idle floor and lowering it is the nearest thing to the old throttle — but that is a side effect of how the tick is handled today, not a rendering control, and [#510](https://github.com/akiomik/nostui/issues/510) plans to remove it. Under a busy feed there is no longer any ceiling: redraws follow inbound relay traffic rather than being clamped to 16 fps, so a heavy home feed can redraw more often than it used to.
 
 ### Deprecations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,10 +21,9 @@ into layers under `src/`, each a top-level module declared in `lib.rs`.
 | `utils` | Neutral leaf helpers (logging, panic, paths). | (nothing internal) |
 
 `main.rs` is the binary entry point: it parses the CLI, loads `Config`, builds
-the Nostr client, and hands an `InitFlags` to the `runtime`. It also owns the
-edges of the process that the `runtime` cannot: taking the terminal over and
-restoring it on every path out, and shutting the Nostr client down once
-`Runtime::run` has returned.
+the Nostr client, and hands an `InitFlags` to the `runtime`. It also takes the
+terminal over and restores it on every path out, which the `runtime` cannot do
+for the paths that fail before it starts.
 
 ## The dependency rule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,10 @@ into layers under `src/`, each a top-level module declared in `lib.rs`.
 | `utils` | Neutral leaf helpers (logging, panic, paths). | (nothing internal) |
 
 `main.rs` is the binary entry point: it parses the CLI, loads `Config`, builds
-the Nostr client, and hands an `InitFlags` to the `runtime`.
+the Nostr client, and hands an `InitFlags` to the `runtime`. It also owns the
+edges of the process that the `runtime` cannot: taking the terminal over and
+restoring it on every path out, and shutting the Nostr client down once
+`Runtime::run` has returned.
 
 ## The dependency rule
 

--- a/src/infrastructure/cli.rs
+++ b/src/infrastructure/cli.rs
@@ -13,13 +13,4 @@ pub struct Cli {
         default_value_t = 16.0
     )]
     pub tick_rate: f64,
-
-    #[arg(
-        short,
-        long,
-        value_name = "FLOAT",
-        help = "Frame rate, i.e. number of frames per second",
-        default_value_t = 16.0
-    )]
-    pub frame_rate: f64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,13 +150,15 @@ async fn tokio_main() -> Result<()> {
         // held it there is an unacknowledged publish — which they can act on, and cannot
         // learn any other way.
         //
-        // "An event", not "a post": every publish takes this path, so the one still in
-        // flight may equally be a reaction, a repost, or a NIP-38 status that a track
-        // change produced without the user publishing anything at all.
+        // Stated as a condition, not a diagnosis. A publish is the likeliest holder of the
+        // read lock, but `subscribe` and `unsubscribe` take it too, so the wait does not
+        // prove anything was being published — and when something was, it need not be a
+        // note: reactions, reposts, and NIP-38 status events from a track change all take
+        // the same path. Report what is known, and let the reader decide if it applies.
         log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
         eprintln!(
-            "{}: relays did not respond within {}s; an event published just before \
-             quitting may not have reached them",
+            "{}: relays did not finish shutting down within {}s; if anything was \
+             published just before quitting, it may not have reached them",
             env!("CARGO_PKG_NAME"),
             SHUTDOWN_TIMEOUT.as_secs()
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,14 @@ async fn tokio_main() -> Result<()> {
     log::info!("Connecting to relays...");
     client.connect().await;
 
-    // Create initialization flags for TearsApp
+    // Create initialization flags for TearsApp. The client is cheap to clone (it is
+    // reference-counted internally), and the clone kept here is what closes the relay
+    // connections after the runtime has stopped.
     let init_flags = InitFlags {
         pubkey,
         keys,
         config,
-        nostr_client: client,
+        nostr_client: client.clone(),
         tick_timer: tick_timer_from_rate(args.tick_rate)?,
     };
 
@@ -85,6 +87,14 @@ async fn tokio_main() -> Result<()> {
 
     // Restore terminal
     ratatui::restore();
+
+    // Close the relay connections. Quitting asks the subscription worker to disconnect,
+    // but a quit returned from `update` now terminates the runtime at that same dispatch,
+    // so the worker may never be polled before `run` returns. Disconnecting here makes
+    // the WebSocket close frame independent of that race; it is a no-op if the worker
+    // already got there.
+    log::info!("Disconnecting from relays...");
+    client.disconnect().await;
 
     Ok(result?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,21 @@
 #![deny(warnings)]
 
 use std::num::NonZeroU64;
+use std::time::Duration;
 
 use clap::Parser;
 use color_eyre::eyre::{eyre, Result};
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
 use tears::{subscription::time::Timer, Runtime};
+use tokio::time::timeout;
+
+/// How long to wait for the Nostr client to shut down before exiting without it.
+///
+/// Sized against nostr-sdk's own ten-second `wait_for_ok_timeout`: long enough for a
+/// publish to responsive relays to land, short enough that an unresponsive one does not
+/// make quitting look like a hang.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
 use nostui::{
     application::config::Config,
@@ -113,15 +122,24 @@ async fn tokio_main() -> Result<()> {
     // wake and exit on its own; `disconnect` sends nothing, so the loop stays parked until
     // the tokio runtime drops it.
     //
+    // Bounded, because `shutdown` takes the relay pool's write lock while an in-flight
+    // `send_event` holds the read lock for as long as it waits for `OK` — ten seconds per
+    // relay by default. Blocking on that lock is not wasted time: it is the user's own
+    // post finishing, and letting it land is what we want. Blocking on it unbounded is
+    // not, because by this point the terminal is restored and the delay reads as a hang
+    // at the shell prompt with SIGINT already taken over by the runtime's signal handler.
+    //
     // Two things it still does not do. It does not wait for a relay's connection task to
     // send the WebSocket close frame, and nostr-sdk 0.45 exposes no way to wait for one,
     // so a task not polled before the runtime is dropped still closes without one. And it
-    // cannot flush the worker's outbound queue, which it has no handle on: a note
-    // submitted just before quitting can still be queued there, and tearing the relays
-    // down can fail its send. Dropping the runtime a moment later would lose it anyway —
-    // that queue has no confirmation step at all. Tracked in #511.
+    // cannot flush the worker's outbound *queue*, only whatever send is already in flight:
+    // a note still queued when this runs is lost, as it was before. Tracked in #511.
     log::info!("Shutting down the Nostr client...");
-    client.shutdown().await;
+    if timeout(SHUTDOWN_TIMEOUT, client.shutdown()).await.is_err() {
+        log::warn!(
+            "Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}; exiting without it"
+        );
+    }
 
     result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,12 @@
 #![deny(warnings)]
 
 use std::num::NonZeroU64;
-use std::time::Duration;
 
 use clap::Parser;
 use color_eyre::eyre::{eyre, Result};
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
 use tears::{subscription::time::Timer, Runtime};
-use tokio::time::timeout;
-
-/// How long to wait for the Nostr client to shut down before exiting without it.
-///
-/// The wait exists so an in-flight publish can finish; the bound exists so a relay that
-/// never answers cannot turn quitting into an apparent hang. This is deliberately shorter
-/// than nostr-sdk's own ten-second `wait_for_ok_timeout`, which means it is a compromise
-/// rather than a guarantee: a relay that acks promptly keeps its publish, and one slower
-/// than this loses it exactly as it did before the wait existed.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
-
-/// How long the shutdown may take before the wait is announced on stderr.
-///
-/// Short enough that a pause the user can notice is always explained, long enough that a
-/// shutdown finishing normally — the overwhelming majority — says nothing at all.
-const SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
 
 use nostui::{
     application::config::Config,
@@ -77,10 +60,6 @@ async fn tokio_main() -> Result<()> {
 
     let args = <Cli as Parser>::parse();
 
-    // Validate the tick rate before the client exists, so a bad value fails without
-    // having connected to any relay.
-    let tick_timer = tick_timer_from_rate(args.tick_rate)?;
-
     // Load configuration
     let config = Config::new()?;
 
@@ -106,92 +85,16 @@ async fn tokio_main() -> Result<()> {
     log::info!("Connecting to relays...");
     client.connect().await;
 
-    // Create initialization flags for TearsApp. `Client` is reference-counted internally,
-    // so the clone handed to the application shares one connection pool with the binding
-    // kept here — which is what stays reachable to signal termination once `run` returns.
+    // Create initialization flags for TearsApp
     let init_flags = InitFlags {
         pubkey,
         keys,
         config,
-        nostr_client: client.clone(),
-        tick_timer,
+        nostr_client: client,
+        tick_timer: tick_timer_from_rate(args.tick_rate)?,
     };
 
-    let result = run_on_terminal(init_flags).await;
-
-    // Tear the client down. This is the *only* thing that terminates the relays on the
-    // quit path: `SystemMsg::Quit` deliberately does not ask the subscription worker to
-    // disconnect, because the worker's `disconnect` would abort an in-flight publish and
-    // race this call for the outcome. See the comment there.
-    //
-    // `shutdown` rather than `disconnect`, for the lock it takes. `shutdown` acquires the
-    // relay pool's write lock, which an in-flight `send_event` holds for reading until it
-    // has its `OK` — ten seconds per relay by default. `disconnect` takes only a read lock
-    // and so never waits for one. Waiting is the point: what it waits for is the user's
-    // own post finishing.
-    //
-    // Not for the worker loop's sake — that ends on its own, and not tidily: `Runtime::run`
-    // consumes the application, so both the command sender and the receiver for the
-    // worker's notifications are gone by the time this runs, and the loop breaks on
-    // whichever its `select!` reaches first. A command still queued may be abandoned.
-    //
-    // Bounded, because waiting on that lock unbounded is not free: by this point the
-    // terminal is restored, so the delay reads as a hang at the shell prompt, with SIGINT
-    // already taken over by the runtime's signal handler for the rest of the process
-    // lifetime.
-    //
-    // `SHUTDOWN_TIMEOUT` buys the publish a grace period rather than a guarantee: it is
-    // shorter than that ten-second wait, so a relay slow to ack still loses the post here.
-    // Bounding the exit is worth that; not bounding it would mean a quit that can sit
-    // silent for twenty seconds with no way to interrupt it.
-    //
-    // Two things it still does not do. It does not wait for a relay's connection task to
-    // send the WebSocket close frame, and nostr-sdk 0.45 exposes no way to wait for one,
-    // so a task not polled before the runtime is dropped still closes without one. And it
-    // cannot flush the worker's outbound *queue*, only whatever send is already in flight:
-    // a note still queued when this runs is lost, as it was before. Tracked in #511.
-    log::info!("Shutting down the Nostr client...");
-    let shutdown = client.shutdown();
-    tokio::pin!(shutdown);
-
-    // Only worth waiting for on a clean exit. If the runtime failed, an error is about to
-    // be reported and there is no publish of the user's worth holding it behind — so tear
-    // the relays down without the wait or the announcements.
-    if result.is_err() {
-        let _ = timeout(SHUTDOWN_GRACE, shutdown).await;
-        return result;
-    }
-
-    // Announced in two stages, so that the pause is never silent but a normal quit is
-    // never noisy. Almost every shutdown finishes well inside `SHUTDOWN_GRACE` and prints
-    // nothing; one that does not has become perceptible, and by then the user is at a
-    // restored prompt that has stopped answering Ctrl-C, so it has to say why.
-    if timeout(SHUTDOWN_GRACE, &mut shutdown).await.is_err() {
-        eprintln!(
-            "{}: waiting up to {}s for relays to finish...",
-            env!("CARGO_PKG_NAME"),
-            SHUTDOWN_TIMEOUT.as_secs()
-        );
-
-        // Stated as a condition, not a diagnosis. A publish is the likeliest holder of the
-        // read lock, but `subscribe` and `unsubscribe` take it too, so the wait does not
-        // prove anything was being published — and when something was, it need not be a
-        // note: reactions, reposts, and NIP-38 status events from a track change all take
-        // the same path. Report what is known, and let the reader decide if it applies.
-        if timeout(SHUTDOWN_TIMEOUT - SHUTDOWN_GRACE, shutdown)
-            .await
-            .is_err()
-        {
-            log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
-            eprintln!(
-                "{}: relays did not finish shutting down; if anything was published just \
-                 before quitting, it may not have reached them",
-                env!("CARGO_PKG_NAME")
-            );
-        }
-    }
-
-    result
+    run_on_terminal(init_flags).await
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,23 +102,26 @@ async fn tokio_main() -> Result<()> {
 
     let result = run_on_terminal(init_flags).await;
 
-    // Signal relay termination. Quitting asks the subscription worker to disconnect, but
-    // a quit returned from `update` now terminates the runtime at that same dispatch, so
-    // the worker may never be polled before `run` returns. Issuing the signal here does
-    // not depend on it.
+    // Tear the client down. Quitting asks the subscription worker to disconnect, but a
+    // quit returned from `update` now terminates the runtime at that same dispatch, so the
+    // worker may never be polled before `run` returns. Doing it here does not depend on
+    // that.
     //
-    // Best effort: `Client::disconnect` marks each relay terminated and notifies its
-    // connection task, but does not wait for that task to send the WebSocket close frame,
-    // and nostr-sdk 0.45 exposes no way to wait for one. A relay whose task is not polled
-    // before the tokio runtime is dropped still sees the socket close without a close
-    // frame; this only makes sure the signal was issued.
+    // `shutdown` rather than `disconnect`, because this client is finished rather than
+    // merely idle: it shuts each relay down, empties the pool, and broadcasts
+    // `ClientNotification::Shutdown`. That broadcast is what lets the detached worker loop
+    // wake and exit on its own; `disconnect` sends nothing, so the loop stays parked until
+    // the tokio runtime drops it.
     //
-    // It also does not flush the worker's outbound queue, which it cannot reach: a note
-    // submitted just before quitting can still be in that queue, and terminating the
-    // relays here can fail its send. Dropping the tokio runtime a moment later would
-    // lose it anyway — the queue has no confirmation step at all. Tracked in #511.
-    log::info!("Disconnecting from relays...");
-    client.disconnect().await;
+    // Two things it still does not do. It does not wait for a relay's connection task to
+    // send the WebSocket close frame, and nostr-sdk 0.45 exposes no way to wait for one,
+    // so a task not polled before the runtime is dropped still closes without one. And it
+    // cannot flush the worker's outbound queue, which it has no handle on: a note
+    // submitted just before quitting can still be queued there, and tearing the relays
+    // down can fail its send. Dropping the runtime a moment later would lose it anyway —
+    // that queue has no confirmation step at all. Tracked in #511.
+    log::info!("Shutting down the Nostr client...");
+    client.shutdown().await;
 
     result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,9 +130,10 @@ async fn tokio_main() -> Result<()> {
     // and so never waits for one. Waiting is the point: what it waits for is the user's
     // own post finishing.
     //
-    // Not for the worker loop's sake — that ends on its own. `Runtime::run` consumes the
-    // application, so the command sender it held is dropped by the time this runs, and the
-    // worker's `cmd_rx.recv()` returns `None` once it has drained anything still queued.
+    // Not for the worker loop's sake — that ends on its own, and not tidily: `Runtime::run`
+    // consumes the application, so both the command sender and the receiver for the
+    // worker's notifications are gone by the time this runs, and the loop breaks on
+    // whichever its `select!` reaches first. A command still queued may be abandoned.
     //
     // Bounded, because waiting on that lock unbounded is not free: by this point the
     // terminal is restored, so the delay reads as a hang at the shell prompt, with SIGINT
@@ -152,6 +153,14 @@ async fn tokio_main() -> Result<()> {
     log::info!("Shutting down the Nostr client...");
     let shutdown = client.shutdown();
     tokio::pin!(shutdown);
+
+    // Only worth waiting for on a clean exit. If the runtime failed, an error is about to
+    // be reported and there is no publish of the user's worth holding it behind — so tear
+    // the relays down without the wait or the announcements.
+    if result.is_err() {
+        let _ = timeout(SHUTDOWN_GRACE, shutdown).await;
+        return result;
+    }
 
     // Announced in two stages, so that the pause is never silent but a normal quit is
     // never noisy. Almost every shutdown finishes well inside `SHUTDOWN_GRACE` and prints

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,12 @@ use tokio::time::timeout;
 /// than this loses it exactly as it did before the wait existed.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// How long the shutdown may take before the wait is announced on stderr.
+///
+/// Short enough that a pause the user can notice is always explained, long enough that a
+/// shutdown finishing normally — the overwhelming majority — says nothing at all.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
+
 use nostui::{
     application::config::Config,
     infrastructure::cli::Cli,
@@ -144,24 +150,36 @@ async fn tokio_main() -> Result<()> {
     // cannot flush the worker's outbound *queue*, only whatever send is already in flight:
     // a note still queued when this runs is lost, as it was before. Tracked in #511.
     log::info!("Shutting down the Nostr client...");
-    if timeout(SHUTDOWN_TIMEOUT, client.shutdown()).await.is_err() {
-        // On stderr, not only in the log. The user has been looking at a restored prompt
-        // for `SHUTDOWN_TIMEOUT` with no way to interrupt, and the thing that most likely
-        // held it there is an unacknowledged publish — which they can act on, and cannot
-        // learn any other way.
-        //
+    let shutdown = client.shutdown();
+    tokio::pin!(shutdown);
+
+    // Announced in two stages, so that the pause is never silent but a normal quit is
+    // never noisy. Almost every shutdown finishes well inside `SHUTDOWN_GRACE` and prints
+    // nothing; one that does not has become perceptible, and by then the user is at a
+    // restored prompt that has stopped answering Ctrl-C, so it has to say why.
+    if timeout(SHUTDOWN_GRACE, &mut shutdown).await.is_err() {
+        eprintln!(
+            "{}: waiting up to {}s for relays to finish...",
+            env!("CARGO_PKG_NAME"),
+            SHUTDOWN_TIMEOUT.as_secs()
+        );
+
         // Stated as a condition, not a diagnosis. A publish is the likeliest holder of the
         // read lock, but `subscribe` and `unsubscribe` take it too, so the wait does not
         // prove anything was being published — and when something was, it need not be a
         // note: reactions, reposts, and NIP-38 status events from a track change all take
         // the same path. Report what is known, and let the reader decide if it applies.
-        log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
-        eprintln!(
-            "{}: relays did not finish shutting down within {}s; if anything was \
-             published just before quitting, it may not have reached them",
-            env!("CARGO_PKG_NAME"),
-            SHUTDOWN_TIMEOUT.as_secs()
-        );
+        if timeout(SHUTDOWN_TIMEOUT - SHUTDOWN_GRACE, shutdown)
+            .await
+            .is_err()
+        {
+            log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
+            eprintln!(
+                "{}: relays did not finish shutting down; if anything was published just \
+                 before quitting, it may not have reached them",
+                env!("CARGO_PKG_NAME")
+            );
+        }
     }
 
     result

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,11 @@ async fn tokio_main() -> Result<()> {
     // and nostr-sdk 0.45 exposes no way to wait for one. A relay whose task is not polled
     // before the tokio runtime is dropped still sees the socket close without a close
     // frame; this only makes sure the signal was issued.
+    //
+    // It also does not flush the worker's outbound queue, which it cannot reach: a note
+    // submitted just before quitting can still be in that queue, and terminating the
+    // relays here can fail its send. Dropping the tokio runtime a moment later would
+    // lose it anyway — the queue has no confirmation step at all. Tracked in #511.
     log::info!("Disconnecting from relays...");
     client.disconnect().await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,9 @@ fn tick_timer_from_rate(tick_rate: f64) -> Result<Timer> {
     Ok(Timer::new(interval_ms))
 }
 
-/// Draw the application on an initialized terminal, restoring the terminal on every
-/// path out — including a failure to clear it.
+/// Take over the terminal, run the application on it, and restore it on every path out —
+/// including a failure to clear it, which used to leave the caller on the alternate
+/// screen in raw mode.
 async fn run_on_terminal(init_flags: InitFlags) -> Result<()> {
     let mut terminal = ratatui::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,4 +178,16 @@ mod tests {
         assert!(tick_timer_from_rate(f64::INFINITY).is_err());
         assert!(tick_timer_from_rate(1000.1).is_err());
     }
+
+    #[test]
+    fn tick_timer_from_rate_rejects_a_rate_whose_interval_overflows_u64_millis() {
+        // Positive and finite, so it clears the first guard, but 1000 / 1e-20 is far past
+        // `u64::MAX` milliseconds. Pin the message so this asserts the overflow guard
+        // rather than passing on whichever guard happens to fire.
+        let error = tick_timer_from_rate(1e-20).expect_err("tick rate should be rejected");
+        assert!(
+            error.to_string().contains("too low to convert"),
+            "expected the interval-overflow guard, got: {error}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,18 +118,20 @@ async fn tokio_main() -> Result<()> {
     // worker may never be polled before `run` returns. Doing it here does not depend on
     // that.
     //
-    // `shutdown` rather than `disconnect`, because this client is finished rather than
-    // merely idle: it shuts each relay down, empties the pool, and broadcasts
-    // `ClientNotification::Shutdown`. That broadcast is what lets the detached worker loop
-    // wake and exit on its own; `disconnect` sends nothing, so the loop stays parked until
-    // the tokio runtime drops it.
+    // `shutdown` rather than `disconnect`, for the lock it takes. `shutdown` acquires the
+    // relay pool's write lock, which an in-flight `send_event` holds for reading until it
+    // has its `OK` — ten seconds per relay by default. `disconnect` takes only a read lock
+    // and so never waits for one. Waiting is the point: what it waits for is the user's
+    // own post finishing.
     //
-    // Bounded, because `shutdown` takes the relay pool's write lock while an in-flight
-    // `send_event` holds the read lock for as long as it waits for `OK` — ten seconds per
-    // relay by default. Waiting on that lock is not wasted time: it is the user's own post
-    // finishing. Waiting on it unbounded is, because by this point the terminal is
-    // restored and the delay reads as a hang at the shell prompt, with SIGINT already
-    // taken over by the runtime's signal handler for the rest of the process lifetime.
+    // Not for the worker loop's sake — that exits either way. `Runtime::run` consumes the
+    // application, so by the time this line runs the command sender it held is dropped and
+    // the loop's `cmd_rx.recv()` has already returned `None`.
+    //
+    // Bounded, because waiting on that lock unbounded is not free: by this point the
+    // terminal is restored, so the delay reads as a hang at the shell prompt, with SIGINT
+    // already taken over by the runtime's signal handler for the rest of the process
+    // lifetime.
     //
     // `SHUTDOWN_TIMEOUT` buys the publish a grace period rather than a guarantee: it is
     // shorter than that ten-second wait, so a relay slow to ack still loses the post here.
@@ -143,8 +145,16 @@ async fn tokio_main() -> Result<()> {
     // a note still queued when this runs is lost, as it was before. Tracked in #511.
     log::info!("Shutting down the Nostr client...");
     if timeout(SHUTDOWN_TIMEOUT, client.shutdown()).await.is_err() {
-        log::warn!(
-            "Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}; exiting without it"
+        // On stderr, not only in the log. The user has been looking at a restored prompt
+        // for `SHUTDOWN_TIMEOUT` with no way to interrupt, and the thing that most likely
+        // held it there is their own last post not being acknowledged — which they can act
+        // on, and cannot learn any other way.
+        log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
+        eprintln!(
+            "{}: relays did not respond within {}s; a post made just before quitting may \
+             not have been published",
+            env!("CARGO_PKG_NAME"),
+            SHUTDOWN_TIMEOUT.as_secs()
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,10 +119,10 @@ async fn tokio_main() -> Result<()> {
 
     let result = run_on_terminal(init_flags).await;
 
-    // Tear the client down. Quitting asks the subscription worker to disconnect, but a
-    // quit returned from `update` now terminates the runtime at that same dispatch, so the
-    // worker may never be polled before `run` returns. Doing it here does not depend on
-    // that.
+    // Tear the client down. This is the *only* thing that terminates the relays on the
+    // quit path: `SystemMsg::Quit` deliberately does not ask the subscription worker to
+    // disconnect, because the worker's `disconnect` would abort an in-flight publish and
+    // race this call for the outcome. See the comment there.
     //
     // `shutdown` rather than `disconnect`, for the lock it takes. `shutdown` acquires the
     // relay pool's write lock, which an in-flight `send_event` holds for reading until it
@@ -130,9 +130,9 @@ async fn tokio_main() -> Result<()> {
     // and so never waits for one. Waiting is the point: what it waits for is the user's
     // own post finishing.
     //
-    // Not for the worker loop's sake — that exits either way. `Runtime::run` consumes the
-    // application, so by the time this line runs the command sender it held is dropped and
-    // the loop's `cmd_rx.recv()` has already returned `None`.
+    // Not for the worker loop's sake — that ends on its own. `Runtime::run` consumes the
+    // application, so the command sender it held is dropped by the time this runs, and the
+    // worker's `cmd_rx.recv()` returns `None` once it has drained anything still queued.
     //
     // Bounded, because waiting on that lock unbounded is not free: by this point the
     // terminal is restored, so the delay reads as a hang at the shell prompt, with SIGINT

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ async fn tokio_main() -> Result<()> {
 
     let args = <Cli as Parser>::parse();
 
-    // Validate the tick rate before anything is opened, so a bad value fails without
-    // leaving relay connections behind.
+    // Validate the tick rate before the client exists, so a bad value fails without
+    // having connected to any relay.
     let tick_timer = tick_timer_from_rate(args.tick_rate)?;
 
     // Load configuration
@@ -89,9 +89,9 @@ async fn tokio_main() -> Result<()> {
     log::info!("Connecting to relays...");
     client.connect().await;
 
-    // Create initialization flags for TearsApp. The client is cheap to clone (it is
-    // reference-counted internally), and the clone kept here is what closes the relay
-    // connections after the runtime has stopped.
+    // Create initialization flags for TearsApp. `Client` is reference-counted internally,
+    // so the clone handed to the application shares one connection pool with the binding
+    // kept here — which is what stays reachable to signal termination once `run` returns.
     let init_flags = InitFlags {
         pubkey,
         keys,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,11 @@ use tokio::time::timeout;
 
 /// How long to wait for the Nostr client to shut down before exiting without it.
 ///
-/// Sized against nostr-sdk's own ten-second `wait_for_ok_timeout`: long enough for a
-/// publish to responsive relays to land, short enough that an unresponsive one does not
-/// make quitting look like a hang.
+/// The wait exists so an in-flight publish can finish; the bound exists so a relay that
+/// never answers cannot turn quitting into an apparent hang. This is deliberately shorter
+/// than nostr-sdk's own ten-second `wait_for_ok_timeout`, which means it is a compromise
+/// rather than a guarantee: a relay that acks promptly keeps its publish, and one slower
+/// than this loses it exactly as it did before the wait existed.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
 use nostui::{
@@ -124,10 +126,15 @@ async fn tokio_main() -> Result<()> {
     //
     // Bounded, because `shutdown` takes the relay pool's write lock while an in-flight
     // `send_event` holds the read lock for as long as it waits for `OK` — ten seconds per
-    // relay by default. Blocking on that lock is not wasted time: it is the user's own
-    // post finishing, and letting it land is what we want. Blocking on it unbounded is
-    // not, because by this point the terminal is restored and the delay reads as a hang
-    // at the shell prompt with SIGINT already taken over by the runtime's signal handler.
+    // relay by default. Waiting on that lock is not wasted time: it is the user's own post
+    // finishing. Waiting on it unbounded is, because by this point the terminal is
+    // restored and the delay reads as a hang at the shell prompt, with SIGINT already
+    // taken over by the runtime's signal handler for the rest of the process lifetime.
+    //
+    // `SHUTDOWN_TIMEOUT` buys the publish a grace period rather than a guarantee: it is
+    // shorter than that ten-second wait, so a relay slow to ack still loses the post here.
+    // Bounding the exit is worth that; not bounding it would mean a quit that can sit
+    // silent for twenty seconds with no way to interrupt it.
     //
     // Two things it still does not do. It does not wait for a relay's connection task to
     // send the WebSocket close frame, and nostr-sdk 0.45 exposes no way to wait for one,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 #![deny(warnings)]
 
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::NonZeroU64;
 
 use clap::Parser;
 use color_eyre::eyre::{eyre, Result};
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
-use tears::{subscription::time::Timer, FrameRate, Runtime};
+use tears::{subscription::time::Timer, Runtime};
 
 use nostui::{
     application::config::Config,
@@ -32,20 +32,6 @@ fn tick_timer_from_rate(tick_rate: f64) -> Result<Timer> {
     })?;
 
     Ok(Timer::new(interval_ms))
-}
-
-fn frame_rate_from_value(frame_rate: f64) -> Result<FrameRate> {
-    if !frame_rate.is_finite() || frame_rate <= 0.0 {
-        return Err(eyre!("frame rate must be a positive finite number"));
-    }
-    if frame_rate > f64::from(u32::MAX) {
-        return Err(eyre!("frame rate is too high: {frame_rate}"));
-    }
-
-    let frames_per_second = NonZeroU32::new(frame_rate as u32)
-        .ok_or_else(|| eyre!("frame rate is too low to produce a non-zero FPS: {frame_rate}"))?;
-
-    FrameRate::new(frames_per_second).map_err(|e| eyre!("invalid frame rate: {e}"))
 }
 
 async fn tokio_main() -> Result<()> {
@@ -93,11 +79,8 @@ async fn tokio_main() -> Result<()> {
     terminal.clear()?;
 
     // Run the Tears application
-    log::info!(
-        "Starting Tears application with frame_rate: {}",
-        args.frame_rate
-    );
-    let runtime = Runtime::<TearsApp>::new(init_flags, frame_rate_from_value(args.frame_rate)?);
+    log::info!("Starting Tears application");
+    let runtime = Runtime::<TearsApp>::new(init_flags);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,34 @@ fn tick_timer_from_rate(tick_rate: f64) -> Result<Timer> {
     Ok(Timer::new(interval_ms))
 }
 
+/// Draw the application on an initialized terminal, restoring the terminal on every
+/// path out — including a failure to clear it.
+async fn run_on_terminal(init_flags: InitFlags) -> Result<()> {
+    let mut terminal = ratatui::init();
+
+    let result = async {
+        terminal.clear()?;
+        log::info!("Starting Tears application");
+        Runtime::<TearsApp>::new(init_flags)
+            .run(&mut terminal)
+            .await
+    }
+    .await;
+
+    ratatui::restore();
+
+    Ok(result?)
+}
+
 async fn tokio_main() -> Result<()> {
     initialize_logging()?;
     initialize_panic_handler()?;
 
     let args = <Cli as Parser>::parse();
+
+    // Validate the tick rate before anything is opened, so a bad value fails without
+    // leaving relay connections behind.
+    let tick_timer = tick_timer_from_rate(args.tick_rate)?;
 
     // Load configuration
     let config = Config::new()?;
@@ -73,30 +96,25 @@ async fn tokio_main() -> Result<()> {
         keys,
         config,
         nostr_client: client.clone(),
-        tick_timer: tick_timer_from_rate(args.tick_rate)?,
+        tick_timer,
     };
 
-    // Setup terminal
-    let mut terminal = ratatui::init();
-    terminal.clear()?;
+    let result = run_on_terminal(init_flags).await;
 
-    // Run the Tears application
-    log::info!("Starting Tears application");
-    let runtime = Runtime::<TearsApp>::new(init_flags);
-    let result = runtime.run(&mut terminal).await;
-
-    // Restore terminal
-    ratatui::restore();
-
-    // Close the relay connections. Quitting asks the subscription worker to disconnect,
-    // but a quit returned from `update` now terminates the runtime at that same dispatch,
-    // so the worker may never be polled before `run` returns. Disconnecting here makes
-    // the WebSocket close frame independent of that race; it is a no-op if the worker
-    // already got there.
+    // Signal relay termination. Quitting asks the subscription worker to disconnect, but
+    // a quit returned from `update` now terminates the runtime at that same dispatch, so
+    // the worker may never be polled before `run` returns. Issuing the signal here does
+    // not depend on it.
+    //
+    // Best effort: `Client::disconnect` marks each relay terminated and notifies its
+    // connection task, but does not wait for that task to send the WebSocket close frame,
+    // and nostr-sdk 0.45 exposes no way to wait for one. A relay whose task is not polled
+    // before the tokio runtime is dropped still sees the socket close without a close
+    // frame; this only makes sure the signal was issued.
     log::info!("Disconnecting from relays...");
     client.disconnect().await;
 
-    Ok(result?)
+    result
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,12 +147,16 @@ async fn tokio_main() -> Result<()> {
     if timeout(SHUTDOWN_TIMEOUT, client.shutdown()).await.is_err() {
         // On stderr, not only in the log. The user has been looking at a restored prompt
         // for `SHUTDOWN_TIMEOUT` with no way to interrupt, and the thing that most likely
-        // held it there is their own last post not being acknowledged — which they can act
-        // on, and cannot learn any other way.
+        // held it there is an unacknowledged publish — which they can act on, and cannot
+        // learn any other way.
+        //
+        // "An event", not "a post": every publish takes this path, so the one still in
+        // flight may equally be a reaction, a repost, or a NIP-38 status that a track
+        // change produced without the user publishing anything at all.
         log::warn!("Nostr client did not shut down within {SHUTDOWN_TIMEOUT:?}");
         eprintln!(
-            "{}: relays did not respond within {}s; a post made just before quitting may \
-             not have been published",
+            "{}: relays did not respond within {}s; an event published just before \
+             quitting may not have reached them",
             env!("CARGO_PKG_NAME"),
             SHUTDOWN_TIMEOUT.as_secs()
         );

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -195,31 +195,25 @@ impl<'a> TearsApp<'a> {
             SystemMsg::Quit => {
                 log::info!("Quit requested - initiating graceful shutdown");
 
-                // Deliberately does *not* ask the subscription worker to disconnect.
+                // Queues at most `NostrCommand::Shutdown` — never a per-subscription
+                // `CLOSE`, since disconnecting ends them at the relay anyway — and nothing
+                // at all if the gateway is already disconnected.
                 //
-                // `close_connection` would queue `NostrCommand::Shutdown`, and the worker
-                // handles that by calling `Client::disconnect`, which sets every relay to
-                // `RelayStatus::Terminated` and broadcasts it. A publish waiting for its
-                // `OK` gives up the moment it sees a disconnected status, returning
-                // `Err(not_connected)` (nostr-sdk relay/inner.rs:1488, status.rs:101).
+                // This cannot cut a publish short, even though the worker handles
+                // `Shutdown` by disconnecting and a disconnect does abort a pending `OK`
+                // wait. Every command shares one FIFO channel and the worker awaits each
+                // one inline, so while a `SendEventBuilder` is in flight the loop is inside
+                // `handle_command` rather than at its `select!`, and a `Shutdown` queued
+                // behind it is not dequeued until that send resolves.
                 //
-                // On 0.10.x the quit travelled a channel, so the worker was generally
-                // polled first and the send went out. The quit is synchronous now, so that
-                // request would land while the send is still in flight and abort it — the
-                // user's own note, discarded by their own client, after the status bar
-                // said "Posted". Not sending it lets the send race the process exit
-                // instead of being cancelled outright.
-                //
-                // This does not make the send safe. The worker is a detached task the
-                // runtime neither owns nor joins, its `select!` also breaks the moment a
-                // relay notification fails to send, and the tokio runtime is dropped
-                // shortly after. Removing a certain abort is not a delivery guarantee;
-                // that needs the confirmation step tracked in #511.
-                //
-                // Nothing else disconnects on this path, and nothing needs to: the process
-                // is exiting, and the WebSocket close frame was never guaranteed anyway.
-                // `NostrMsg::Disconnect` still goes through `close_connection`, because
-                // there the client has to stay usable afterwards.
+                // What the send is not safe from is the exit itself. The quit applies
+                // synchronously on tears 0.11, so `run` can return while the worker — a
+                // detached task the runtime neither owns nor joins — is still publishing,
+                // and the tokio runtime is dropped moments later. The status bar has
+                // already said "Posted" by then. #511 covers making that claim honest, and
+                // #512 covers giving the send a chance to land.
+                let _ = self.state.close_connection();
+
                 Command::quit()
             }
             SystemMsg::Resize(width, height) => {
@@ -503,8 +497,6 @@ mod tests {
     use std::num::NonZeroU64;
 
     use super::*;
-    use tokio::sync::mpsc;
-
     use crate::application::config::Config;
     use crate::domain::nostr::FeedKind;
     use crate::model::editor::Message as EditorMessage;
@@ -731,28 +723,6 @@ mod tests {
         // Selection should be at the last index
         let expected_index = app.state.timeline.len() - 1;
         assert_eq!(app.state.timeline.selected_index(), Some(expected_index));
-    }
-
-    #[test]
-    fn quit_does_not_ask_the_worker_to_disconnect() {
-        let mut app = create_test_app();
-
-        // Give the app a command channel, the way `Message::Ready` does in production.
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let _ = app.state.on_connection_ready(tx);
-        // `on_connection_ready` subscribes the active feed; drain that.
-        while rx.try_recv().is_ok() {}
-
-        let _ = app.update(AppMsg::System(SystemMsg::Quit));
-
-        // Nothing may be queued. A `NostrCommand::Shutdown` here would make the detached
-        // worker call `Client::disconnect`, which terminates every relay and aborts an
-        // in-flight publish waiting for its `OK` — the send that `main`'s bounded
-        // `Client::shutdown` exists to let finish.
-        assert!(
-            rx.try_recv().is_err(),
-            "quit must leave relay termination to `main`, which waits for in-flight sends"
-        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -197,7 +197,8 @@ impl<'a> TearsApp<'a> {
                 // Ask the subscription worker to unsubscribe and disconnect. The send is
                 // synchronous, but the quit below now terminates the runtime at this same
                 // dispatch, so the worker is not guaranteed to be polled before `run`
-                // returns. `main` disconnects again after `run` for that reason.
+                // returns. `main` signals relay termination again afterwards so it does
+                // not depend on this worker having run.
                 let _ = self.state.close_connection();
 
                 // Trigger the quit action

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -236,7 +236,7 @@ impl<'a> TearsApp<'a> {
         // Fallback: handle special keys not in config
         match key.code {
             // Escape key - unselect/cancel (delegates to TimelineMsg::Deselect)
-            KeyCode::Esc => Command::message(AppMsg::Timeline(TimelineMsg::Deselect)),
+            KeyCode::Esc => Command::message(AppMsg::Timeline(TimelineMsg::Deselect)).into(),
             _ => Command::none(),
         }
     }
@@ -248,13 +248,15 @@ impl<'a> TearsApp<'a> {
         // not a quit command. Only hardcoded special keys are processed.
         match (key.code, key.modifiers) {
             // Escape: cancel composing
-            (KeyCode::Esc, _) => Command::message(AppMsg::Editor(EditorMsg::CancelComposing)),
+            (KeyCode::Esc, _) => {
+                Command::message(AppMsg::Editor(EditorMsg::CancelComposing)).into()
+            }
             // Ctrl+P: submit note (hardcoded for safety)
             (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
-                Command::message(AppMsg::Editor(EditorMsg::SubmitNote))
+                Command::message(AppMsg::Editor(EditorMsg::SubmitNote)).into()
             }
             // All other keys are passed to textarea for input
-            _ => Command::message(AppMsg::Editor(EditorMsg::ProcessTextAreaInput(key))),
+            _ => Command::message(AppMsg::Editor(EditorMsg::ProcessTextAreaInput(key))).into(),
         }
     }
 
@@ -262,42 +264,52 @@ impl<'a> TearsApp<'a> {
     fn handle_action(&mut self, action: KeyAction) -> Command<AppMsg> {
         match action {
             // Navigation
-            KeyAction::ScrollUp => Command::message(AppMsg::Timeline(TimelineMsg::ScrollUp)),
-            KeyAction::ScrollDown => Command::message(AppMsg::Timeline(TimelineMsg::ScrollDown)),
+            KeyAction::ScrollUp => Command::message(AppMsg::Timeline(TimelineMsg::ScrollUp)).into(),
+            KeyAction::ScrollDown => {
+                Command::message(AppMsg::Timeline(TimelineMsg::ScrollDown)).into()
+            }
             KeyAction::ScrollToTop => {
                 // Delegate to TimelineMsg::SelectFirst
-                Command::message(AppMsg::Timeline(TimelineMsg::SelectFirst))
+                Command::message(AppMsg::Timeline(TimelineMsg::SelectFirst)).into()
             }
             KeyAction::ScrollToBottom => {
                 // Delegate to TimelineMsg::SelectLast
-                Command::message(AppMsg::Timeline(TimelineMsg::SelectLast))
+                Command::message(AppMsg::Timeline(TimelineMsg::SelectLast)).into()
             }
             KeyAction::Unselect => {
                 // Delegate to TimelineMsg::Deselect to keep logic centralized
-                Command::message(AppMsg::Timeline(TimelineMsg::Deselect))
+                Command::message(AppMsg::Timeline(TimelineMsg::Deselect)).into()
             }
 
             // Compose/interactions
-            KeyAction::NewTextNote => Command::message(AppMsg::Editor(EditorMsg::StartComposing)),
-            KeyAction::ReplyTextNote => Command::message(AppMsg::Editor(EditorMsg::StartReply)),
-            KeyAction::React => Command::message(AppMsg::Timeline(TimelineMsg::ReactToSelected)),
-            KeyAction::Repost => Command::message(AppMsg::Timeline(TimelineMsg::RepostSelected)),
+            KeyAction::NewTextNote => {
+                Command::message(AppMsg::Editor(EditorMsg::StartComposing)).into()
+            }
+            KeyAction::ReplyTextNote => {
+                Command::message(AppMsg::Editor(EditorMsg::StartReply)).into()
+            }
+            KeyAction::React => {
+                Command::message(AppMsg::Timeline(TimelineMsg::ReactToSelected)).into()
+            }
+            KeyAction::Repost => {
+                Command::message(AppMsg::Timeline(TimelineMsg::RepostSelected)).into()
+            }
 
             // Tab management
             KeyAction::OpenAuthorTimeline => {
-                Command::message(AppMsg::Timeline(TimelineMsg::OpenAuthorTimeline))
+                Command::message(AppMsg::Timeline(TimelineMsg::OpenAuthorTimeline)).into()
             }
             KeyAction::OpenMentionTab => {
-                Command::message(AppMsg::Timeline(TimelineMsg::OpenMentionTab))
+                Command::message(AppMsg::Timeline(TimelineMsg::OpenMentionTab)).into()
             }
             KeyAction::CloseCurrentTab => {
-                Command::message(AppMsg::Timeline(TimelineMsg::CloseCurrentTab))
+                Command::message(AppMsg::Timeline(TimelineMsg::CloseCurrentTab)).into()
             }
-            KeyAction::PrevTab => Command::message(AppMsg::Timeline(TimelineMsg::PrevTab)),
-            KeyAction::NextTab => Command::message(AppMsg::Timeline(TimelineMsg::NextTab)),
+            KeyAction::PrevTab => Command::message(AppMsg::Timeline(TimelineMsg::PrevTab)).into(),
+            KeyAction::NextTab => Command::message(AppMsg::Timeline(TimelineMsg::NextTab)).into(),
 
             // System
-            KeyAction::Quit => Command::message(AppMsg::System(SystemMsg::Quit)),
+            KeyAction::Quit => Command::message(AppMsg::System(SystemMsg::Quit)).into(),
             KeyAction::SubmitTextNote => {
                 // Only valid in composing mode, handled separately
                 Command::none()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -208,10 +208,14 @@ impl<'a> TearsApp<'a> {
                 //
                 // Termination therefore has exactly one signal on this path, in `main`,
                 // and it is the one that takes the relay pool's write lock and so actually
-                // waits. The worker still ends: dropping the application drops the command
-                // sender, so once the worker has drained whatever is still queued — a
-                // reaction or note sent moments ago, which it should finish — its
-                // `cmd_rx.recv()` returns `None` and the loop breaks.
+                // waits.
+                //
+                // The worker still ends, though not tidily: its `select!` also breaks the
+                // moment a relay notification fails to send, and that receiver dies when
+                // `Runtime::run` settles — so a command still queued behind it may be
+                // abandoned rather than run. Not sending `Shutdown` removes a *certain*
+                // abort of the in-flight publish; it does not promise the queue drains.
+                // That promise needs the confirmation step tracked in #511.
                 //
                 // `NostrMsg::Disconnect` still goes through `close_connection`, because
                 // there the client has to stay usable and nothing else will disconnect it.
@@ -421,15 +425,23 @@ impl<'a> TearsApp<'a> {
 
     /// Handle NostrEvents subscription messages
     ///
-    /// Every arm here returns a redrawing command, so on tears 0.11 each inbound relay
-    /// notification that lands in its own pass costs one full render. With the frame rate
-    /// gone there is no ceiling above that, and on a busy feed redraw frequency tracks
-    /// relay throughput where 0.10.x clamped it to `--frame-rate`.
+    /// Every arm here returns a redrawing command — including the two that change nothing
+    /// — so on tears 0.11 each inbound relay notification that lands in its own pass costs
+    /// one full render. With the frame rate gone there is no ceiling above that, and on a
+    /// busy feed redraw frequency tracks relay throughput where 0.10.x clamped it to
+    /// `--frame-rate`.
     ///
     /// This is a known, accepted regression, not an oversight. `Command::without_redraw`
-    /// is not the fix: it declares that the update did not change the visible view, which
-    /// is false for an arm that appends to the timeline. Bounding it properly means
+    /// is not a general fix: it declares that the update did not change the visible view,
+    /// which is false for an arm that appends to the timeline. Bounding it properly means
     /// deciding per message whether the view actually changed — tracked in #510.
+    ///
+    /// Two arms are exempt from that reasoning and are worth noting for #510, because for
+    /// them the declaration would be true rather than convenient: `ClientNotification::Event`
+    /// only logs (nostui routes events from the `Message` stream instead, see the note
+    /// below), and a `Message` carrying anything other than `RelayMessage::Event` also only
+    /// logs. Since the pool emits both notifications for each newly-seen event, the ignored
+    /// `Event` doubles the redraw count per note for no visible change.
     fn handle_nostr_subscription_message(
         &mut self,
         msg: NostrSubscriptionMessage,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -194,11 +194,14 @@ impl<'a> TearsApp<'a> {
         match msg {
             SystemMsg::Quit => {
                 log::info!("Quit requested - initiating graceful shutdown");
-                // Ask the subscription worker to unsubscribe and disconnect. The send is
-                // synchronous, but the quit below now terminates the runtime at this same
-                // dispatch, so the worker is not guaranteed to be polled before `run`
-                // returns. `main` signals relay termination again afterwards so it does
-                // not depend on this worker having run.
+                // Drop the tracked subscriptions and ask the worker to disconnect. This
+                // sends `NostrCommand::Shutdown` and nothing else — no `CLOSE` is sent
+                // per subscription, because disconnecting ends them at the relay anyway.
+                //
+                // The send itself is synchronous, but the quit below now terminates the
+                // runtime at this same dispatch, so the worker is not guaranteed to be
+                // polled before `run` returns. `main` signals relay termination again
+                // afterwards so it does not depend on this worker having run.
                 let _ = self.state.close_connection();
 
                 // Trigger the quit action

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -194,14 +194,16 @@ impl<'a> TearsApp<'a> {
         match msg {
             SystemMsg::Quit => {
                 log::info!("Quit requested - initiating graceful shutdown");
-                // Drop the tracked subscriptions and ask the worker to disconnect. This
-                // sends `NostrCommand::Shutdown` and nothing else — no `CLOSE` is sent
-                // per subscription, because disconnecting ends them at the relay anyway.
+                // Drop the tracked subscriptions and ask the worker to disconnect. At most
+                // this sends `NostrCommand::Shutdown` — never a per-subscription `CLOSE`,
+                // because disconnecting ends them at the relay anyway — and it sends
+                // nothing at all if the gateway was already disconnected.
                 //
                 // The send itself is synchronous, but the quit below now terminates the
                 // runtime at this same dispatch, so the worker is not guaranteed to be
-                // polled before `run` returns. `main` signals relay termination again
-                // afterwards so it does not depend on this worker having run.
+                // polled before `run` returns. Between that and the nothing-sent case,
+                // `main` signals relay termination again after `run` rather than relying
+                // on this path.
                 let _ = self.state.close_connection();
 
                 // Trigger the quit action

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -194,7 +194,10 @@ impl<'a> TearsApp<'a> {
         match msg {
             SystemMsg::Quit => {
                 log::info!("Quit requested - initiating graceful shutdown");
-                // Unsubscribe from all timeline subscriptions and disconnect from relays
+                // Ask the subscription worker to unsubscribe and disconnect. The send is
+                // synchronous, but the quit below now terminates the runtime at this same
+                // dispatch, so the worker is not guaranteed to be polled before `run`
+                // returns. `main` disconnects again after `run` for that reason.
                 let _ = self.state.close_connection();
 
                 // Trigger the quit action
@@ -205,7 +208,9 @@ impl<'a> TearsApp<'a> {
                 // Terminal resize is handled automatically by ratatui
                 Command::none()
             }
-            // Track app FPS based on tick events (approximately matches render FPS)
+            // Count ticks for the FPS display. This measures how often the application
+            // processes a tick, not how often it renders: the runtime renders when a pass
+            // leaves the view dirty, which no longer tracks the tick interval.
             SystemMsg::Tick => self.state.record_tick(),
             SystemMsg::ShowError(error) => self.state.show_error(error),
             SystemMsg::KeyInput(key) => self.handle_key_input(key),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -215,8 +215,10 @@ impl<'a> TearsApp<'a> {
                 Command::none()
             }
             // Count ticks for the FPS display. This measures how often the application
-            // processes a tick, not how often it renders: the runtime renders when a pass
-            // leaves the view dirty, which no longer tracks the tick interval.
+            // processes a tick, which is no longer the same as how often it renders: the
+            // runtime renders once per pass that leaves the view dirty. An idle nostui has
+            // only the tick to dirty it, so the two rates still coincide there, but every
+            // inbound relay event adds a pass the tick knows nothing about.
             SystemMsg::Tick => self.state.record_tick(),
             SystemMsg::ShowError(error) => self.state.show_error(error),
             SystemMsg::KeyInput(key) => self.handle_key_input(key),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -412,6 +412,16 @@ impl<'a> TearsApp<'a> {
     }
 
     /// Handle NostrEvents subscription messages
+    ///
+    /// Every arm here returns a redrawing command, so on tears 0.11 each inbound relay
+    /// notification that lands in its own pass costs one full render. With the frame rate
+    /// gone there is no ceiling above that, and on a busy feed redraw frequency tracks
+    /// relay throughput where 0.10.x clamped it to `--frame-rate`.
+    ///
+    /// This is a known, accepted regression, not an oversight. `Command::without_redraw`
+    /// is not the fix: it declares that the update did not change the visible view, which
+    /// is false for an arm that appends to the timeline. Bounding it properly means
+    /// deciding per message whether the view actually changed — tracked in #510.
     fn handle_nostr_subscription_message(
         &mut self,
         msg: NostrSubscriptionMessage,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -194,19 +194,27 @@ impl<'a> TearsApp<'a> {
         match msg {
             SystemMsg::Quit => {
                 log::info!("Quit requested - initiating graceful shutdown");
-                // Drop the tracked subscriptions and ask the worker to disconnect. At most
-                // this sends `NostrCommand::Shutdown` — never a per-subscription `CLOSE`,
-                // because disconnecting ends them at the relay anyway — and it sends
-                // nothing at all if the gateway was already disconnected.
-                //
-                // The send itself is synchronous, but the quit below now terminates the
-                // runtime at this same dispatch, so the worker is not guaranteed to be
-                // polled before `run` returns. Between that and the nothing-sent case,
-                // `main` signals relay termination again after `run` rather than relying
-                // on this path.
-                let _ = self.state.close_connection();
 
-                // Trigger the quit action
+                // Deliberately does *not* ask the subscription worker to disconnect.
+                //
+                // `close_connection` would queue `NostrCommand::Shutdown`, and the worker
+                // handles that by calling `Client::disconnect`, which sets every relay to
+                // `RelayStatus::Terminated` and broadcasts it. A publish waiting for its
+                // `OK` gives up the moment it sees a disconnected status, returning
+                // `Err(not_connected)` — so that path would destroy the very in-flight
+                // send `main`'s bounded `Client::shutdown` exists to let finish, and would
+                // race it for the outcome, since the worker is a detached task the runtime
+                // neither owns nor joins.
+                //
+                // Termination therefore has exactly one signal on this path, in `main`,
+                // and it is the one that takes the relay pool's write lock and so actually
+                // waits. The worker still ends: dropping the application drops the command
+                // sender, so once the worker has drained whatever is still queued — a
+                // reaction or note sent moments ago, which it should finish — its
+                // `cmd_rx.recv()` returns `None` and the loop breaks.
+                //
+                // `NostrMsg::Disconnect` still goes through `close_connection`, because
+                // there the client has to stay usable and nothing else will disconnect it.
                 Command::quit()
             }
             SystemMsg::Resize(width, height) => {
@@ -482,6 +490,8 @@ mod tests {
     use std::num::NonZeroU64;
 
     use super::*;
+    use tokio::sync::mpsc;
+
     use crate::application::config::Config;
     use crate::domain::nostr::FeedKind;
     use crate::model::editor::Message as EditorMessage;
@@ -708,6 +718,28 @@ mod tests {
         // Selection should be at the last index
         let expected_index = app.state.timeline.len() - 1;
         assert_eq!(app.state.timeline.selected_index(), Some(expected_index));
+    }
+
+    #[test]
+    fn quit_does_not_ask_the_worker_to_disconnect() {
+        let mut app = create_test_app();
+
+        // Give the app a command channel, the way `Message::Ready` does in production.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _ = app.state.on_connection_ready(tx);
+        // `on_connection_ready` subscribes the active feed; drain that.
+        while rx.try_recv().is_ok() {}
+
+        let _ = app.update(AppMsg::System(SystemMsg::Quit));
+
+        // Nothing may be queued. A `NostrCommand::Shutdown` here would make the detached
+        // worker call `Client::disconnect`, which terminates every relay and aborts an
+        // in-flight publish waiting for its `OK` — the send that `main`'s bounded
+        // `Client::shutdown` exists to let finish.
+        assert!(
+            rx.try_recv().is_err(),
+            "quit must leave relay termination to `main`, which waits for in-flight sends"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -201,24 +201,25 @@ impl<'a> TearsApp<'a> {
                 // handles that by calling `Client::disconnect`, which sets every relay to
                 // `RelayStatus::Terminated` and broadcasts it. A publish waiting for its
                 // `OK` gives up the moment it sees a disconnected status, returning
-                // `Err(not_connected)` — so that path would destroy the very in-flight
-                // send `main`'s bounded `Client::shutdown` exists to let finish, and would
-                // race it for the outcome, since the worker is a detached task the runtime
-                // neither owns nor joins.
+                // `Err(not_connected)` (nostr-sdk relay/inner.rs:1488, status.rs:101).
                 //
-                // Termination therefore has exactly one signal on this path, in `main`,
-                // and it is the one that takes the relay pool's write lock and so actually
-                // waits.
+                // On 0.10.x the quit travelled a channel, so the worker was generally
+                // polled first and the send went out. The quit is synchronous now, so that
+                // request would land while the send is still in flight and abort it — the
+                // user's own note, discarded by their own client, after the status bar
+                // said "Posted". Not sending it lets the send race the process exit
+                // instead of being cancelled outright.
                 //
-                // The worker still ends, though not tidily: its `select!` also breaks the
-                // moment a relay notification fails to send, and that receiver dies when
-                // `Runtime::run` settles — so a command still queued behind it may be
-                // abandoned rather than run. Not sending `Shutdown` removes a *certain*
-                // abort of the in-flight publish; it does not promise the queue drains.
-                // That promise needs the confirmation step tracked in #511.
+                // This does not make the send safe. The worker is a detached task the
+                // runtime neither owns nor joins, its `select!` also breaks the moment a
+                // relay notification fails to send, and the tokio runtime is dropped
+                // shortly after. Removing a certain abort is not a delivery guarantee;
+                // that needs the confirmation step tracked in #511.
                 //
+                // Nothing else disconnects on this path, and nothing needs to: the process
+                // is exiting, and the WebSocket close frame was never guaranteed anyway.
                 // `NostrMsg::Disconnect` still goes through `close_connection`, because
-                // there the client has to stay usable and nothing else will disconnect it.
+                // there the client has to stay usable afterwards.
                 Command::quit()
             }
             SystemMsg::Resize(width, height) => {


### PR DESCRIPTION
Supersedes #508, which is the bump alone and does not build against the new API.

tears 0.11 replaces the runtime core with the reducer-first kernel. Three of its
breaking changes reach nostui.

## Changes the compiler reported

**Effect constructors return `EffectCommand<Msg>`.** Every `Command::message`
site in `runtime.rs` — the key-to-message mapping in `handle_action`,
`handle_normal_mode_key` and `handle_composing_mode_key` — converts with
`.into()`. The two other shapes in that entry do not apply here: nostui keys no
commands (no `cancellable` / `cancellable_with` anywhere), so neither the
carrier-only keying modifiers nor `Command::batch` honouring each child's key
changes behaviour, and there is no empty `Command::batch(vec![])` to annotate.

**`FrameRate` is gone**, along with `Runtime::new`'s second parameter. Render
cadence is bounded by the pass now: the loop renders when a pass leaves the view
dirty and parks when it has no work. `--frame-rate` is therefore removed rather
than accepted and ignored — see the note below.

**`Application::new` runs inside `run()`.** `Runtime::new` is now a `const fn`
that only stores the flags. `main` constructs the runtime and awaits `run()` on
the next line, and `TearsApp::new` only builds state, so nothing observes the
move.

## Changes the compiler could not report

Each of these was checked against the migration guide's triage rather than
assumed:

- **One lane / delivery order / input priority** (guide §2.1, §2.2, §2.10) —
  nostui never sets `data_lane_capacity`, so the lane stays unbounded and no
  admission behaviour changes. Delivery becomes FIFO, but nostui runs no keyed
  commands and never cancelled one on a terminal event, so there is no
  cancel window it was leaning on.
- **Synchronous quit** (§2.3) — `SystemMsg::Quit` calls
  `AppState::close_connection`, which dispatches `ConnectionClosed` over the
  subscription's command channel synchronously and returns `Command::none()`,
  then returns `Command::quit()`. The shutdown message is sent before the quit
  applies, which is the ordering the new contract pins by construction.
- **Batch cap** (§2.6) — left unset, so a batch is now bounded by the kernel's
  1024-input count cap instead of the removed 100µs window. For a feed that
  arrives in bursts this coalesces more messages into one render, which is the
  direction we want; no explicit `batch_max_messages` is set.
- **Subscription admission and re-evaluation** (§2.8) — the declared set changes
  only when `nip38.enabled` toggles the media subscription. Every source is an
  await-based stream, so none of them is slow to honour cancellation.
- **Shutdown join** (§2.11) — the runtime-owned task per subscription is the
  forwarder, and each one is a `recv().await` loop that ends when its channel
  closes. The Nostr subscription's own relay loop is a detached `tokio::spawn`
  the runtime does not own and does not join.
- **Panic hook** (§2.9) — nostui installs its own hook in `utils::panic`, not
  `tears::install_panic_hook`, so that entry does not reach us.
- **Telemetry** (§3) and **`TestStore`** (§4) — nostui consumes no
  `tears::runtime::load` events and uses no `TestStore`.

## Breaking change for users

`-f` / `--frame-rate` is removed. Passing it now fails argument parsing rather
than being silently ignored, matching the upstream judgement that a control
which does nothing is worse than no control. A frame rate passed to throttle
drawing has no replacement knob; that work would have to move into the state
that drives the view.

## Scope

This PR is the tears 0.11 migration, plus fixes for the paths the migration would otherwise leave broken — nostui is installed from source, so `main` should not carry one.

**Kept, because it is broken rather than merely improvable:**

- `run_on_terminal`, so a failing `terminal.clear()` cannot return while still on the alternate screen in raw mode. The `--frame-rate` validation this PR removes had the same shape, one line earlier.

That is the only behavioural change beyond the migration. An earlier revision also changed the quit path; review showed the reasoning was wrong and it has been reverted — a `NostrCommand::Shutdown` cannot interrupt a publish, because every command shares one FIFO channel and the worker awaits each inline, so a `Shutdown` queued behind a `SendEventBuilder` is not dequeued until that send resolves.

**Split out, because they improve rather than repair:**

- **#512** — waiting for in-flight relay sends before the process exits. Built and reviewed here across eight rounds, then removed: without it a publish still in flight dies at runtime drop, which is what 0.10.2 did too. The design is recorded on the issue in full so it does not have to be rediscovered.
- **#510** — redraw volume. With the frame rate gone, redraws follow relay throughput where 0.10.2 clamped them to 16 fps. Deferred by maintainer decision. Two arms of `handle_nostr_subscription_message` are pure no-ops that could truthfully take `without_redraw` with no viewport work; that is noted on the issue and in the code, and deliberately not applied here.
- **#511** — nostui reports "Posted" when a send has only been queued, and nothing ever confirms it.

**`codecov/patch` / `codecov/project` are red**, and that is accepted — the bar is no substantive coverage defect, not an unmoved percentage. Auditing the uncovered lines turned up exactly one real gap, `tick_timer_from_rate`'s interval-overflow guard, now covered with the error message pinned so it cannot pass on the wrong guard. The rest is entry-point glue: taking over the terminal, connecting to relays, running the runtime. Neither check is required, and `codecov/patch` is red on merged PRs today including #502.

## Verification

`just fmt`, `just lint` and `just test` all pass (373 lib + 2 bin + 1 doc tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi





