### PR TITLE
fix: do not report a publish as done until a relay says so

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,13 +269,19 @@ the status bar, with no inward layer reaching outward:
 
 1. The worker (`infrastructure::subscription::nostr::NostrEvents`) fails to run a
    `NostrCommand` and emits `model::nostr_gateway::Message::Error { error }`,
-   where `error` is a `CommandError` (e.g. `SendEventFailed`,
+   where `error` is a `CommandError` (e.g. `AddRelayFailed`,
    `ConnectRelayFailed`).
 2. `runtime` receives it in `handle_nostr_subscription_message` and calls the
    use case `AppState::notify_subscription_error(error)`.
 3. That use case updates `model::status_bar` with an error message
    (`Message::ErrorMessageChanged`, labelled `Nostr`).
 4. `presentation`'s `StatusBarWidget` renders it on the next frame.
+
+Publishing is the exception: an event send reports its outcome — success as
+well as failure — through `Message::EventPublished`, which
+`AppState::resolve_publish` matches to the submission it belongs to. The status
+bar shows the publish as pending until then, so nothing claims a note was
+posted before a relay has said so.
 
 Relay shutdown follows the same shape via `RelayPoolNotification::Shutdown` →
 `AppState::notify_subscription_shutdown`. System-level errors raised inside the

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -514,15 +514,36 @@ impl<'a> AppState<'a> {
     fn fail_pending_publishes(&mut self, reason: &str) {
         let abandoned: Vec<PendingPublish> = self.pending_publishes.drain(..).collect();
 
-        for pending in abandoned {
-            self.report_publish_failure(
-                pending.id,
-                pending.origin,
-                &pending.settled_label,
-                &pending.message,
-                reason,
-            );
+        for pending in &abandoned {
+            log::error!("Publish abandoned, {reason}: {}", pending.message);
         }
+
+        // One report, not one per entry. Reporting in a loop leaves only the last entry
+        // visible — and if that one is automatic its report is suppressed, so a user's
+        // own lost note would be written and then wiped by a track change queued behind
+        // it. The first user-origin entry is the one they have been waiting on longest.
+        let mut users = abandoned
+            .iter()
+            .filter(|pending| pending.origin == PublishOrigin::User);
+
+        let Some(first) = users.next() else {
+            return;
+        };
+
+        let others = users.count();
+        let reason = if others == 0 {
+            reason.to_owned()
+        } else {
+            format!("{reason} (and {others} more)")
+        };
+
+        self.report_publish_failure(
+            first.id,
+            first.origin,
+            &first.settled_label,
+            &first.message,
+            &reason,
+        );
     }
 
     /// Report a publish that failed, as loudly as its origin deserves.
@@ -669,7 +690,12 @@ impl<'a> AppState<'a> {
             // feed subscriptions, which is right when nostui is closing the connection
             // deliberately and wrong here. The tabs are still open, and their subscription
             // ids are what a replacement worker needs in order to unsubscribe.
-            let _ = self.nostr.update(NostrMessage::ConnectionLost);
+            let outcome = self.nostr.update(NostrMessage::ConnectionLost);
+            debug_assert!(
+                outcome.is_none(),
+                "ConnectionLost must not ask for a command: the worker it would be \
+                 addressed to is the one that just went away"
+            );
             self.command_sender = None;
             return false;
         }
@@ -1862,6 +1888,34 @@ mod tests {
         // Its line is already gone, so there is nothing of its own to retire and it must
         // not clear what replaced it.
         assert_eq!(state.status_bar.message(), moved_on.as_deref());
+    }
+
+    #[test]
+    fn abandoning_publishes_reports_the_users_own_loss() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        // A track change queues an automatic publish behind the user's reaction.
+        let _ = state.react_to_selected();
+        let _ = state.publish_music_status(create_track("Song"));
+
+        let (tx, _rx2) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+
+        // Reporting entry by entry would leave only the last one visible, and that one is
+        // automatic — so its suppression would wipe the note the user actually lost.
+        let message = state.status_bar.message().expect("a status message");
+        assert!(
+            message.starts_with("[ERR: Reacted]") && message.contains(&note1),
+            "the user's own lost publish must survive the loop, got: {message}"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -384,10 +384,14 @@ impl<'a> AppState<'a> {
         // editor loses the text for good — the next `ComposingStarted` clears the buffer
         // — so a submission that has already failed keeps it for another attempt.
         //
-        // This covers the failures this layer can see before sending. Ones reported back
-        // later still lose the text — including read-only mode, which only the worker
-        // knows about — because getting it back needs a way to put content into the
-        // editor that `model::editor` does not have yet: #514.
+        // This covers only the failures this layer can see before sending. Anything the
+        // worker reports back still loses the text, because getting it back needs a way
+        // to put content into the editor that `model::editor` does not have: #514.
+        //
+        // That is not a rare tail. Nothing gates composing in read-only mode, and the
+        // signing check lives in the worker, so a user configured with an `npub` gets
+        // `true` here and loses every note they write, on every submit. An all-relays-
+        // refused send is the other instance.
         if self.begin_publish(outcome, PublishOrigin::User, "Posted", content) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
@@ -1571,8 +1575,10 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_submission_keeps_the_composed_note() {
-        // Not connected, so the submission fails before it is queued.
+    fn a_submission_that_fails_before_it_is_queued_keeps_the_composed_note() {
+        // Named for what it covers: this is the pre-send case, the only one where the
+        // draft survives. A failure the worker reports back still loses it — see #514,
+        // and the comment in `submit_note`.
         let mut state = AppState::new(Keys::generate().public_key());
 
         state.editor.update(EditorMessage::ComposingStarted);

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -381,20 +381,18 @@ impl<'a> AppState<'a> {
         });
     }
 
-    /// Dispatch a [`NostrOutcome`] produced by `model::nostr` to the worker.
-    ///
-    /// `model::nostr::update` is side-effect free and only reports the command
-    /// to send; the application owns the sender and performs the actual I/O.
     /// Hand a submitted event to the worker and show it as pending.
     ///
     /// The status bar says "Sending" rather than `settled_label` until a relay has
     /// answered, because until then nothing has been published — the command only sits on
     /// the worker's queue. [`Self::resolve_publish`] supplies the ending.
     ///
-    /// When the event never reaches the worker at all — `model::nostr` declines it while
-    /// disconnected, or no worker is listening — there is nothing to wait for and no
+    /// When the event never reaches the worker at all there is nothing to wait for and no
     /// report will arrive, so this settles immediately as an error instead of leaving a
-    /// pending entry that can never be popped.
+    /// pending entry that can never be popped — and would shift every later outcome onto
+    /// the wrong submission. The three ways that happens are distinguished, because they
+    /// tell the user different things: the connection was never up, it is not up *yet*,
+    /// or it has gone away.
     fn begin_publish(
         &mut self,
         outcome: Option<NostrOutcome>,
@@ -403,8 +401,21 @@ impl<'a> AppState<'a> {
     ) {
         let message = message.into();
 
-        if !self.dispatch_nostr(outcome) {
+        if outcome.is_none() {
+            // `model::nostr` declines a submission while it believes it is disconnected.
             self.set_status_error(settled_label, "not connected");
+            return;
+        }
+
+        let worker_was_ready = self.command_sender.is_some();
+
+        if !self.dispatch_nostr(outcome) {
+            let reason = if worker_was_ready {
+                "connection lost"
+            } else {
+                "not connected yet"
+            };
+            self.set_status_error(settled_label, reason);
             return;
         }
 
@@ -420,7 +431,7 @@ impl<'a> AppState<'a> {
     /// Matched positionally rather than by an id: the worker awaits each command inline
     /// and reports every `SendEventBuilder` exactly once, so reports arrive in the order
     /// the entries were pushed.
-    pub fn resolve_publish(&mut self, result: Result<(), CommandError>) -> Command<AppMsg> {
+    pub fn resolve_publish(&mut self, result: Result<(), String>) -> Command<AppMsg> {
         let Some(pending) = self.pending_publishes.pop_front() else {
             log::warn!("Publish outcome with nothing pending: {result:?}");
             return Command::none();
@@ -428,15 +439,29 @@ impl<'a> AppState<'a> {
 
         match result {
             Ok(()) => self.set_status(pending.settled_label, pending.message),
-            Err(error) => {
-                log::error!("Failed to publish: {error:?}");
-                self.set_status_error("Send", format!("{error:?}"));
+            Err(reason) => {
+                log::error!("Failed to publish {}: {reason}", pending.message);
+                // Keeps the label and the content: with more than one publish outstanding
+                // — a NIP-38 status from a track change alongside a note the user just
+                // wrote — an error attributed to neither says nothing useful.
+                self.set_status_error(
+                    pending.settled_label,
+                    format!("{}: {reason}", pending.message),
+                );
             }
         }
 
         Command::none()
     }
 
+    /// Dispatch a [`NostrOutcome`] produced by `model::nostr` to the worker.
+    ///
+    /// `model::nostr::update` is side-effect free and only reports the command
+    /// to send; the application owns the sender and performs the actual I/O.
+    ///
+    /// Returns whether the command actually reached the worker. `false` means it was
+    /// dropped and nothing will ever be reported for it — which is what lets
+    /// [`Self::begin_publish`] settle a publish immediately instead of waiting forever.
     fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
             return false;
@@ -1279,14 +1304,16 @@ mod tests {
         let _ = state.publish_music_status(create_track("Song"));
         assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
 
-        let _ = state.resolve_publish(Err(CommandError::SendEventFailed {
-            error: String::from("relay refused"),
-        }));
+        let _ = state.resolve_publish(Err(String::from(
+            "no relay accepted the event: wss://relay.example: blocked",
+        )));
 
+        // The label and the content survive, so the user can tell *which* publish failed
+        // when more than one is outstanding.
         let message = state.status_bar.message().expect("a status message");
         assert!(
-            message.starts_with("[ERR: Send]") && message.contains("relay refused"),
-            "expected the failure to be reported, got: {message}"
+            message.starts_with("[ERR: Music] Song - Artist:") && message.contains("blocked"),
+            "expected the failed publish to be identified, got: {message}"
         );
     }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1774,7 +1774,7 @@ mod tests {
     }
 
     #[test]
-    fn a_success_does_not_wipe_another_publishs_failure() -> Result<()> {
+    fn a_success_does_not_wipe_another_publishes_failure() -> Result<()> {
         let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -75,8 +75,9 @@ pub struct AppState<'a> {
 /// A publish that has been handed to the worker but not yet confirmed by a relay.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingPublish {
-    /// Status-bar label to show once the relay accepts it — the past-tense word the
-    /// status bar has always shown for this kind of event.
+    /// Status-bar label to show once the relay accepts it — the word the status bar has
+    /// always used for this kind of event, whether or not it reads as a verb
+    /// ("Posted", "Reacted", "Reposted", but also "Music").
     settled_label: String,
     /// What was published, shown while pending and again once settled.
     message: String,
@@ -386,9 +387,9 @@ impl<'a> AppState<'a> {
     /// to send; the application owns the sender and performs the actual I/O.
     /// Hand a submitted event to the worker and show it as pending.
     ///
-    /// The status bar says "sending" rather than the past-tense `settled_label` until a
-    /// relay has answered, because until then nothing has been published — the command
-    /// only sits on the worker's queue. [`Self::resolve_publish`] supplies the ending.
+    /// The status bar says "Sending" rather than `settled_label` until a relay has
+    /// answered, because until then nothing has been published — the command only sits on
+    /// the worker's queue. [`Self::resolve_publish`] supplies the ending.
     ///
     /// When the event never reaches the worker at all — `model::nostr` declines it while
     /// disconnected, or no worker is listening — there is nothing to wait for and no

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -336,6 +336,10 @@ impl<'a> AppState<'a> {
         // Only discard the draft once the publish is actually on its way. Closing the
         // editor loses the text for good — the next `ComposingStarted` clears the buffer
         // — so a submission that has already failed keeps it for another attempt.
+        //
+        // This covers the failures known before sending. One the relays report later
+        // still loses the text, because getting it back needs a way to put content into
+        // the editor that `model::editor` does not have yet: #514.
         if self.begin_publish(outcome, "Posted", content) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
@@ -429,6 +433,14 @@ impl<'a> AppState<'a> {
         true
     }
 
+    /// The status line [`Self::begin_publish`] writes while a publish is pending.
+    ///
+    /// [`Self::resolve_publish`] compares against it to tell whether the user is still
+    /// looking at this publish when the answer finally arrives.
+    fn pending_status_line(message: &str) -> String {
+        format!("[Sending] {}", message.replace('\n', " "))
+    }
+
     /// Settle the oldest unreported publish with the relay's answer.
     ///
     /// Matched positionally rather than by an id: the worker awaits each command inline
@@ -436,17 +448,37 @@ impl<'a> AppState<'a> {
     /// the entries were pushed.
     pub fn resolve_publish(&mut self, result: Result<(), String>) -> Command<AppMsg> {
         let Some(pending) = self.pending_publishes.pop_front() else {
+            // Nothing to attribute it to, so the content and label are unavailable. A
+            // failure is still worth saying: something the user asked for did not happen,
+            // and silence is what this whole change exists to remove.
             log::warn!("Publish outcome with nothing pending: {result:?}");
+            if let Err(reason) = result {
+                self.set_status_error("Send", reason);
+            }
             return Command::none();
         };
 
         match result {
-            Ok(()) => self.set_status(pending.settled_label, pending.message),
+            Ok(()) => {
+                // An answer can arrive seconds later — a relay may take its full ack
+                // timeout — by which time the user has moved on and the status bar is
+                // showing something newer. Confirming a success over the top of that is
+                // noise, so it only lands if this publish is still what is on screen.
+                if self.status_bar.message()
+                    == Some(Self::pending_status_line(&pending.message)).as_deref()
+                {
+                    self.set_status(pending.settled_label, pending.message);
+                } else {
+                    log::info!("Published: {}", pending.message);
+                }
+            }
             Err(reason) => {
                 log::error!("Failed to publish {}: {reason}", pending.message);
-                // Keeps the label and the content: with more than one publish outstanding
-                // — a NIP-38 status from a track change alongside a note the user just
-                // wrote — an error attributed to neither says nothing useful.
+                // Failures are shown whatever else is on screen: the user asked for this
+                // and it did not happen. Keeps the label and the content, because with
+                // more than one publish outstanding — a NIP-38 status from a track change
+                // alongside a note just written — an error attributed to neither says
+                // nothing useful.
                 self.set_status_error(
                     pending.settled_label,
                     format!("{}: {reason}", pending.message),
@@ -670,31 +702,13 @@ impl<'a> AppState<'a> {
         let outcome = self.nostr.update(NostrMessage::ConnectionClosed);
         let _ = self.dispatch_nostr(outcome);
         self.command_sender = None;
-        self.fail_pending_publishes("the connection closed");
+
+        // `pending_publishes` is deliberately left alone. The worker takes commands in
+        // order, so a publish queued ahead of the shutdown request still runs and still
+        // reports — failing them here would put "the connection closed" on screen for a
+        // note that then succeeds. Ones that genuinely never run are failed by the worker
+        // as it exits, so every entry is still settled by exactly one report.
         Command::none()
-    }
-
-    /// Fail every publish still waiting for an answer.
-    ///
-    /// The worker that would have reported them is going away, so nothing will settle
-    /// them. Clearing here keeps the positional matching a property of the code that
-    /// owns the queue: a leftover entry would otherwise settle the *next* connection's
-    /// first outcome against this connection's label and content.
-    fn fail_pending_publishes(&mut self, reason: &str) {
-        let abandoned: Vec<PendingPublish> = self.pending_publishes.drain(..).collect();
-
-        for pending in &abandoned {
-            log::error!("Publish abandoned, {reason}: {}", pending.message);
-        }
-
-        // One line of status for however many were lost — the most recent, since that is
-        // the one the user was most likely watching.
-        if let Some(last) = abandoned.last() {
-            self.set_status_error(
-                last.settled_label.clone(),
-                format!("{}: {reason}", last.message),
-            );
-        }
     }
 
     /// Track a subscription that the relay layer created for a tab.
@@ -1394,7 +1408,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_the_connection_fails_whatever_was_still_pending() {
+    fn closing_the_connection_leaves_pending_publishes_for_the_worker() {
         let (mut state, _rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
@@ -1402,13 +1416,15 @@ mod tests {
 
         let _ = state.close_connection();
 
-        // Nothing will report these now, and a leftover entry would settle the next
-        // connection's first outcome against this submission.
-        assert!(state.pending_publishes.is_empty());
-        let message = state.status_bar.message().expect("a status message");
-        assert!(
-            message.starts_with("[ERR: Music] Song - Artist:"),
-            "expected the abandoned publish to be reported, got: {message}"
+        // Not cleared, and not failed. The worker takes commands in order, so this one
+        // runs before the shutdown request it was queued ahead of and reports its real
+        // outcome; anything that genuinely never runs is failed by the worker on its way
+        // out. Failing them here would report a loss for a note that then succeeds.
+        assert_eq!(state.pending_publishes.len(), 1);
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[Sending] Song - Artist"),
+            "the pending status should stand until the worker answers"
         );
     }
 
@@ -1427,17 +1443,67 @@ mod tests {
         let _ = state.publish_music_status(create_track("Song"));
         assert_eq!(state.pending_publishes.len(), 2);
 
-        // The first outcome settles the first submission, not the most recent one.
-        let _ = state.resolve_publish(Ok(()));
+        // Failures rather than successes, so the assertions do not depend on which
+        // pending line happens to be on screen — each error names what it belongs to.
+        let _ = state.resolve_publish(Err(String::from("first")));
         assert_eq!(
             state.status_bar.message(),
-            Some(format!("[Reacted] {note1}").as_str())
+            Some(format!("[ERR: Reacted] {note1}: first").as_str())
         );
 
-        let _ = state.resolve_publish(Ok(()));
-        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        let _ = state.resolve_publish(Err(String::from("second")));
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Music] Song - Artist: second")
+        );
 
         Ok(())
+    }
+
+    #[test]
+    fn a_late_success_does_not_overwrite_a_newer_status() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // The user moves on while the relay is still thinking.
+        let _ = state.open_mention_tab();
+        let moved_on = state.status_bar.message().map(ToOwned::to_owned);
+
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(
+            state.status_bar.message(),
+            moved_on.as_deref(),
+            "a confirmation that arrives after the user has moved on is only noise"
+        );
+    }
+
+    #[test]
+    fn a_late_failure_is_shown_even_over_a_newer_status() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        let _ = state.open_mention_tab();
+
+        let _ = state.resolve_publish(Err(String::from("refused")));
+
+        // Unlike a success, this is something the user asked for that did not happen.
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Music] Song - Artist: refused")
+        );
+    }
+
+    #[test]
+    fn an_unattributable_failure_is_still_reported() {
+        let (mut state, _rx) = connected_state();
+
+        // No pending entry, so there is no label or content to name — but staying silent
+        // about a failure is the behaviour this change exists to remove.
+        let _ = state.resolve_publish(Err(String::from("refused")));
+
+        assert_eq!(state.status_bar.message(), Some("[ERR: Send] refused"));
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -286,7 +286,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.begin_publish(outcome, label, note_id);
+        let _ = self.begin_publish(outcome, label, note_id);
 
         Command::none()
     }
@@ -333,10 +333,12 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.begin_publish(outcome, "Posted", content);
-
-        // Clear UI state.
-        self.editor.update(EditorMessage::ComposingCanceled);
+        // Only discard the draft once the publish is actually on its way. Closing the
+        // editor loses the text for good — the next `ComposingStarted` clears the buffer
+        // — so a submission that has already failed keeps it for another attempt.
+        if self.begin_publish(outcome, "Posted", content) {
+            self.editor.update(EditorMessage::ComposingCanceled);
+        }
 
         Command::none()
     }
@@ -355,7 +357,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.begin_publish(outcome, "Music", content);
+        let _ = self.begin_publish(outcome, "Music", content);
 
         Command::none()
     }
@@ -389,34 +391,33 @@ impl<'a> AppState<'a> {
     ///
     /// When the event never reaches the worker at all there is nothing to wait for and no
     /// report will arrive, so this settles immediately as an error instead of leaving a
-    /// pending entry that can never be popped — and would shift every later outcome onto
-    /// the wrong submission. The three ways that happens are distinguished, because they
-    /// tell the user different things: the connection was never up, it is not up *yet*,
-    /// or it has gone away.
+    /// pending entry that can never be popped — which would also shift every later
+    /// outcome onto the wrong submission.
+    ///
+    /// Returns whether the publish is now pending. `false` means it already failed, and
+    /// callers that were about to discard what they published — the editor's buffer —
+    /// should keep it instead.
     fn begin_publish(
         &mut self,
         outcome: Option<NostrOutcome>,
         settled_label: &str,
         message: impl Into<String>,
-    ) {
+    ) -> bool {
         let message = message.into();
 
+        // `model::nostr` declines a submission whenever it believes it is disconnected.
         if outcome.is_none() {
-            // `model::nostr` declines a submission while it believes it is disconnected.
-            self.set_status_error(settled_label, "not connected");
-            return;
+            self.set_status_error(settled_label, format!("{message}: not connected"));
+            return false;
         }
 
-        let worker_was_ready = self.command_sender.is_some();
-
         if !self.dispatch_nostr(outcome) {
-            let reason = if worker_was_ready {
-                "connection lost"
-            } else {
-                "not connected yet"
-            };
-            self.set_status_error(settled_label, reason);
-            return;
+            // Reachable only as a lost worker. An outcome exists, so `model::nostr`
+            // believes it is connected, and the sender is set and cleared in the same
+            // calls that set and clear that belief — so the sender cannot be missing
+            // here, only closed.
+            self.set_status_error(settled_label, format!("{message}: connection lost"));
+            return false;
         }
 
         self.pending_publishes.push_back(PendingPublish {
@@ -424,6 +425,8 @@ impl<'a> AppState<'a> {
             message: message.clone(),
         });
         self.set_status("Sending", message);
+
+        true
     }
 
     /// Settle the oldest unreported publish with the relay's answer.
@@ -667,7 +670,31 @@ impl<'a> AppState<'a> {
         let outcome = self.nostr.update(NostrMessage::ConnectionClosed);
         let _ = self.dispatch_nostr(outcome);
         self.command_sender = None;
+        self.fail_pending_publishes("the connection closed");
         Command::none()
+    }
+
+    /// Fail every publish still waiting for an answer.
+    ///
+    /// The worker that would have reported them is going away, so nothing will settle
+    /// them. Clearing here keeps the positional matching a property of the code that
+    /// owns the queue: a leftover entry would otherwise settle the *next* connection's
+    /// first outcome against this connection's label and content.
+    fn fail_pending_publishes(&mut self, reason: &str) {
+        let abandoned: Vec<PendingPublish> = self.pending_publishes.drain(..).collect();
+
+        for pending in &abandoned {
+            log::error!("Publish abandoned, {reason}: {}", pending.message);
+        }
+
+        // One line of status for however many were lost — the most recent, since that is
+        // the one the user was most likely watching.
+        if let Some(last) = abandoned.last() {
+            self.set_status_error(
+                last.settled_label.clone(),
+                format!("{}: {reason}", last.message),
+            );
+        }
     }
 
     /// Track a subscription that the relay layer created for a tab.
@@ -1327,11 +1354,62 @@ mod tests {
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] not connected")
+            Some("[ERR: Music] Song - Artist: not connected")
         );
 
         // Nothing pending means a later stray outcome cannot settle this as posted.
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn a_failed_submission_keeps_the_composed_note() {
+        // Not connected, so the submission fails before it is queued.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        // Closing the editor would lose the text for good: the next `ComposingStarted`
+        // clears the buffer, so there is no way back to it.
+        assert!(state.editor.is_active());
+        assert_eq!(state.editor.get_content(), "h");
+    }
+
+    #[test]
+    fn a_successful_submission_closes_the_editor() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        assert!(!state.editor.is_active());
+    }
+
+    #[test]
+    fn closing_the_connection_fails_whatever_was_still_pending() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.pending_publishes.len(), 1);
+
+        let _ = state.close_connection();
+
+        // Nothing will report these now, and a leftover entry would settle the next
+        // connection's first outcome against this submission.
+        assert!(state.pending_publishes.is_empty());
+        let message = state.status_bar.message().expect("a status message");
+        assert!(
+            message.starts_with("[ERR: Music] Song - Artist:"),
+            "expected the abandoned publish to be reported, got: {message}"
+        );
     }
 
     #[test]
@@ -1532,7 +1610,8 @@ mod tests {
     fn test_notify_subscription_error_sets_error_status() {
         let mut state = AppState::new(Keys::generate().public_key());
 
-        let _ = state.notify_subscription_error(CommandError::SendEventFailed {
+        let _ = state.notify_subscription_error(CommandError::AddRelayFailed {
+            url: String::from("wss://relay.example"),
             error: "x".to_owned(),
         });
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -70,18 +70,31 @@ pub struct AppState<'a> {
     /// exactly once, so its reports arrive in the order the entries were pushed and
     /// can be matched positionally rather than by an id.
     pending_publishes: VecDeque<PendingPublish>,
-    /// The publish whose pending line the status bar is currently showing.
+    /// What the status bar is showing on a publish's behalf, if anything.
     ///
-    /// Cleared by every other write to the bar, so it answers "is this still mine?"
-    /// exactly, where comparing the rendered text could not tell two publishes of the
-    /// same content apart.
-    status_owner: Option<PublishId>,
+    /// Cleared by every other write to the bar, so it answers "is this still mine?" and
+    /// "is an unread failure up?" exactly, where comparing the rendered text could not
+    /// tell two publishes of the same content apart.
+    status_owner: Option<PublishStatus>,
     /// Source of [`PublishId`]s, monotonic for the life of the application.
     next_publish_id: u64,
 }
 
 /// Status-bar label shown while a publish is waiting for a relay's answer.
 const PENDING_LABEL: &str = "Sending";
+
+/// What the status bar is currently showing on some publish's behalf.
+///
+/// Recorded rather than inferred from the text: two publishes can render identically,
+/// and a failure has to be distinguishable from a pending line so a later success does
+/// not quietly wipe it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishStatus {
+    /// A publish's "Sending" line, still waiting for an answer.
+    Pending(PublishId),
+    /// A failure a publish reported, which nothing has replaced since.
+    Failed,
+}
 
 /// Identifies one submitted publish, so its own status line can be recognised without
 /// comparing rendered text.
@@ -495,7 +508,7 @@ impl<'a> AppState<'a> {
         });
 
         self.set_status(PENDING_LABEL, message);
-        self.status_owner = Some(id);
+        self.status_owner = Some(PublishStatus::Pending(id));
 
         true
     }
@@ -540,7 +553,7 @@ impl<'a> AppState<'a> {
         // it would go on claiming a publish is in flight that has definitively failed —
         // the same dishonest status this whole change exists to remove, inverted.
         if origin == PublishOrigin::Automatic {
-            if self.status_owner == Some(id) {
+            if self.status_owner == Some(PublishStatus::Pending(id)) {
                 let _ = self.clear_status_message();
             }
             return;
@@ -550,6 +563,7 @@ impl<'a> AppState<'a> {
         // as its content is a bech32 id — long, and far less use to the reader than why
         // it failed. Truncation should eat the id, not the cause.
         self.set_status_error(settled_label, format!("{reason} ({message})"));
+        self.status_owner = Some(PublishStatus::Failed);
     }
 
     /// Settle the oldest unreported publish with the relay's answer.
@@ -579,6 +593,11 @@ impl<'a> AppState<'a> {
                 // user has caused since. Swallowing it instead would leave "Sending" as
                 // the last thing they ever heard about their own note, which is worse.
                 //
+                // One thing it will not overwrite is another publish's failure. Two
+                // submissions settle in order, so a refused reaction followed by a
+                // successful repost would otherwise show the error for the length of one
+                // dispatch. Of the two, the error is the one worth keeping.
+                //
                 // An automatic one lands only where it would not be talking over
                 // anything: its own pending line, or an empty bar. Its answer can arrive
                 // a full ack timeout later, and a track change announced over whatever
@@ -586,9 +605,24 @@ impl<'a> AppState<'a> {
                 // Scrolling clears the status on every timeline message, so treating a
                 // cleared bar as "moved on" would stop `Music` ever appearing for anyone
                 // who touches the timeline while an ack is outstanding.
-                let announce = pending.origin == PublishOrigin::User
-                    || self.status_owner == Some(pending.id)
-                    || self.status_bar.message().is_none();
+                //
+                // It also stays quiet if a later automatic publish is still outstanding:
+                // entries settle in order, so announcing this one would leave the bar
+                // naming a track that has already been superseded.
+                let holds_failure = self.status_owner == Some(PublishStatus::Failed);
+                let newer_automatic_pending = self
+                    .pending_publishes
+                    .iter()
+                    .any(|queued| queued.origin == PublishOrigin::Automatic);
+
+                let announce = match pending.origin {
+                    PublishOrigin::User => !holds_failure,
+                    PublishOrigin::Automatic => {
+                        !newer_automatic_pending
+                            && (self.status_owner == Some(PublishStatus::Pending(pending.id))
+                                || self.status_bar.message().is_none())
+                    }
+                };
 
                 if announce {
                     self.set_status(pending.settled_label, pending.message);
@@ -1717,6 +1751,53 @@ mod tests {
         // Quiet, but not leaving the screen claiming a publish is still in flight —
         // nothing else clears the status bar on its own.
         assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn a_stale_automatic_success_does_not_name_the_wrong_track() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+
+        // Two track changes inside one ack window, then a scroll clears the bar.
+        let _ = state.publish_music_status(create_track("Old"));
+        let _ = state.publish_music_status(create_track("New"));
+        let _ = state.clear_status_message();
+
+        // The older one is answered first. Announcing it would leave the bar naming a
+        // track that has already been superseded.
+        let _ = state.resolve_publish(Ok(()));
+        assert_eq!(state.status_bar.message(), None);
+
+        let _ = state.resolve_publish(Ok(()));
+        assert_eq!(state.status_bar.message(), Some("[Music] New - Artist"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_success_does_not_wipe_another_publishs_failure() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        // React and repost in quick succession; the reaction is refused, the repost works.
+        let _ = state.react_to_selected();
+        let _ = state.repost_selected();
+
+        let _ = state.resolve_publish(Err(String::from("refused")));
+        let _ = state.resolve_publish(Ok(()));
+
+        // Both settle in one burst, so confirming the repost would show the error for the
+        // length of a single dispatch. The error is the one worth keeping.
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[ERR: Reacted] refused ({note1})").as_str())
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -70,6 +70,11 @@ pub struct AppState<'a> {
     /// exactly once, so its reports arrive in the order the entries were pushed and
     /// can be matched positionally rather than by an id.
     pending_publishes: VecDeque<PendingPublish>,
+    /// Whether the configured key can only read — an `npub` rather than a signing key.
+    ///
+    /// Known here so a publish can be refused before it is queued. The worker rejects
+    /// them anyway, but only after the draft has been discarded.
+    read_only: bool,
     /// What the status bar is showing on a publish's behalf, if anything.
     ///
     /// Cleared by every other write to the bar, so it answers "is this still mine?" and
@@ -147,10 +152,15 @@ impl<'a> AppState<'a> {
     }
 
     /// Initialize AppState with the specified public key and config
-    pub fn new_with_config(current_user_pubkey: PublicKey, config: Config) -> Self {
+    pub fn new_with_config(
+        current_user_pubkey: PublicKey,
+        config: Config,
+        read_only: bool,
+    ) -> Self {
         Self {
             user: UserState::new_with_pubkey(current_user_pubkey),
             config: ConfigState { config },
+            read_only,
             ..Default::default()
         }
     }
@@ -384,14 +394,11 @@ impl<'a> AppState<'a> {
         // editor loses the text for good — the next `ComposingStarted` clears the buffer
         // — so a submission that has already failed keeps it for another attempt.
         //
-        // This covers only the failures this layer can see before sending. Anything the
-        // worker reports back still loses the text, because getting it back needs a way
-        // to put content into the editor that `model::editor` does not have: #514.
-        //
-        // That is not a rare tail. Nothing gates composing in read-only mode, and the
-        // signing check lives in the worker, so a user configured with an `npub` gets
-        // `true` here and loses every note they write, on every submit. An all-relays-
-        // refused send is the other instance.
+        // This covers only the failures this layer can see before sending — including
+        // read-only mode, which is refused in `begin_publish` precisely so the draft
+        // survives it. A failure the *relays* report still loses the text, because
+        // getting it back needs a way to put content into the editor that `model::editor`
+        // does not have: #514.
         if self.begin_publish(outcome, PublishOrigin::User, "Posted", content) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
@@ -469,6 +476,15 @@ impl<'a> AppState<'a> {
         // check simply does not match for it.
         let id = PublishId(self.next_publish_id);
         self.next_publish_id = self.next_publish_id.wrapping_add(1);
+
+        // Refused here rather than by the worker. The worker rejects it too, but its
+        // answer arrives after `submit_note` has closed the editor and lost the draft —
+        // and nothing gates composing in read-only mode, so that is every note the user
+        // writes. Failing before the dispatch keeps the text (#514).
+        if self.read_only {
+            self.report_publish_failure(id, origin, settled_label, &message, "read-only mode");
+            return false;
+        }
 
         // `model::nostr` declines a submission whenever it believes it is disconnected.
         if outcome.is_none() {
@@ -1618,6 +1634,36 @@ mod tests {
         // clears the buffer, so there is no way back to it.
         assert!(state.editor.is_active());
         assert_eq!(state.editor.get_content(), "h");
+    }
+
+    #[test]
+    fn read_only_mode_refuses_a_note_and_keeps_the_draft() {
+        // An `npub` configuration: connected, but with no key to sign with.
+        let mut state =
+            AppState::new_with_config(Keys::generate().public_key(), Config::default(), true);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+        while rx.try_recv().is_ok() {}
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        // Nothing gates composing in read-only mode, so leaving this to the worker meant
+        // losing the text on every single note.
+        assert!(state.editor.is_active());
+        assert_eq!(state.editor.get_content(), "h");
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Posted] read-only mode (h)")
+        );
+
+        // And nothing was queued, so no report will arrive to settle a phantom entry.
+        assert!(rx.try_recv().is_err());
+        assert!(state.pending_publishes.is_empty());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -353,9 +353,10 @@ impl<'a> AppState<'a> {
         // editor loses the text for good — the next `ComposingStarted` clears the buffer
         // — so a submission that has already failed keeps it for another attempt.
         //
-        // This covers the failures known before sending. One the relays report later
-        // still loses the text, because getting it back needs a way to put content into
-        // the editor that `model::editor` does not have yet: #514.
+        // This covers the failures this layer can see before sending. Ones reported back
+        // later still lose the text — including read-only mode, which only the worker
+        // knows about — because getting it back needs a way to put content into the
+        // editor that `model::editor` does not have yet: #514.
         if self.begin_publish(outcome, PublishOrigin::User, "Posted", content) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
@@ -459,6 +460,24 @@ impl<'a> AppState<'a> {
         true
     }
 
+    /// Fail every publish still waiting for an answer.
+    ///
+    /// Only for the case where the reports themselves are gone. A publish whose worker is
+    /// still running settles on its own report, success or failure — failing those here
+    /// would claim a loss for something that then succeeds.
+    fn fail_pending_publishes(&mut self, reason: &str) {
+        let abandoned: Vec<PendingPublish> = self.pending_publishes.drain(..).collect();
+
+        for pending in abandoned {
+            self.report_publish_failure(
+                pending.origin,
+                &pending.settled_label,
+                &pending.message,
+                reason,
+            );
+        }
+    }
+
     /// Report a publish that failed, as loudly as its origin deserves.
     fn report_publish_failure(
         &mut self,
@@ -473,7 +492,15 @@ impl<'a> AppState<'a> {
         // user can do about one failing — so it stays in the log rather than painting an
         // error over whatever they are actually doing. A track change during startup
         // would otherwise report a failure for something they never asked for.
+        //
+        // Quiet is not the same as leaving the screen wrong, though. If its own "Sending"
+        // line is still up, retire it: nothing else clears the status bar on its own, so
+        // it would go on claiming a publish is in flight that has definitively failed —
+        // the same dishonest status this whole change exists to remove, inverted.
         if origin == PublishOrigin::Automatic {
+            if self.status_bar.shows(PENDING_LABEL, message) {
+                let _ = self.clear_status_message();
+            }
             return;
         }
 
@@ -569,6 +596,14 @@ impl<'a> AppState<'a> {
         log::info!("NostrEvents subscription ready");
 
         let tab_title = self.active_tab_title();
+
+        // A second worker would report against entries queued for the first, offsetting
+        // every outcome from here on. Unreachable today — `NostrEvents::key` is the
+        // `Arc<Client>` pointer, so tears never rebuilds the stream — but the queue is
+        // only positionally matched, and this is the one place that assumption could
+        // break silently.
+        self.fail_pending_publishes("the connection was re-established");
+
         self.command_sender = Some(command_sender);
         let outcome = self.nostr.update(NostrMessage::ConnectionReady);
         let _ = self.dispatch_nostr(outcome);
@@ -1607,6 +1642,50 @@ mod tests {
         let _ = state.resolve_publish(Err(String::from("refused")));
 
         assert_eq!(state.status_bar.message(), Some("[ERR: Send] refused"));
+    }
+
+    #[test]
+    fn an_automatic_failure_retires_its_own_pending_line() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+
+        let _ = state.resolve_publish(Err(String::from("refused")));
+
+        // Quiet, but not leaving the screen claiming a publish is still in flight —
+        // nothing else clears the status bar on its own.
+        assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn an_automatic_failure_leaves_a_newer_status_alone() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        let _ = state.open_mention_tab();
+        let moved_on = state.status_bar.message().map(ToOwned::to_owned);
+
+        let _ = state.resolve_publish(Err(String::from("refused")));
+
+        // Its line is already gone, so there is nothing of its own to retire and it must
+        // not clear what replaced it.
+        assert_eq!(state.status_bar.message(), moved_on.as_deref());
+    }
+
+    #[test]
+    fn becoming_ready_again_clears_publishes_the_old_worker_owed() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.pending_publishes.len(), 1);
+
+        // A second worker reports against its own commands only; entries left from the
+        // first would offset every outcome from here on.
+        let (tx, _rx2) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+
+        assert!(state.pending_publishes.is_empty());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -473,22 +473,11 @@ impl<'a> AppState<'a> {
         }
 
         if !self.dispatch_nostr(outcome) {
-            // Reachable only as a lost worker. An outcome exists, so `model::nostr`
-            // believes it is connected, and the sender is set and cleared in the same
-            // calls that set and clear that belief — so the sender cannot be missing
-            // here, only closed.
+            // Reachable only as a lost worker, which `dispatch_nostr` has now recorded.
+            // An outcome exists, so `model::nostr` believed it was connected, and the
+            // sender is set and cleared in the same calls that set and clear that belief
+            // — so the sender cannot have been missing here, only closed.
             //
-            // Record the loss rather than only reporting it, so the next publish says
-            // "not connected" instead of rediscovering the dead worker every time.
-            // `ConnectionLost`, not `ConnectionClosed`: the latter also clears the
-            // tracked feed subscriptions, which is right when nostui is closing the
-            // connection deliberately and wrong here. The tabs are still open, and their
-            // subscription ids are what a replacement worker needs in order to
-            // unsubscribe — dropping them leaks the subscription relay-side and leaves
-            // the tab on screen receiving nothing.
-            let _ = self.nostr.update(NostrMessage::ConnectionLost);
-            self.command_sender = None;
-
             // `pending_publishes` is deliberately left alone. A worker that exited
             // normally already drained and reported them, and tears keeps a finished
             // run's queued output deliverable, so those reports still arrive; failing
@@ -655,7 +644,11 @@ impl<'a> AppState<'a> {
     /// Returns whether the command actually reached the worker. `false` means it was
     /// dropped and nothing will ever be reported for it — which is what lets
     /// [`Self::begin_publish`] settle a publish immediately instead of waiting forever.
-    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
+    ///
+    /// A send that fails also records the loss here rather than leaving each caller to
+    /// remember: the worker is gone, so every later dispatch would otherwise rediscover
+    /// it, and `model::nostr` would go on believing it is connected.
+    fn dispatch_nostr(&mut self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
             return false;
         };
@@ -667,6 +660,13 @@ impl<'a> AppState<'a> {
 
         if sender.send(command).is_err() {
             log::error!("Failed to send Nostr command: subscription worker is gone");
+
+            // `ConnectionLost`, not `ConnectionClosed`: the latter also clears the tracked
+            // feed subscriptions, which is right when nostui is closing the connection
+            // deliberately and wrong here. The tabs are still open, and their subscription
+            // ids are what a replacement worker needs in order to unsubscribe.
+            let _ = self.nostr.update(NostrMessage::ConnectionLost);
+            self.command_sender = None;
             return false;
         }
 
@@ -1871,6 +1871,25 @@ mod tests {
         let _ = state.on_connection_ready(tx);
 
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn a_failed_dispatch_records_the_loss_wherever_it_happens() {
+        let (mut state, rx) = connected_state();
+
+        // Not a publish: opening a tab goes through the same dispatcher, and the recovery
+        // used to live only in the publish path.
+        drop(rx);
+        let _ = state.open_mention_tab();
+
+        assert!(
+            !state.nostr.is_ready(),
+            "the gateway must stop believing it is connected"
+        );
+
+        // And the belief and the sender move together, so the next dispatch reports
+        // "not connected" instead of rediscovering the dead worker.
+        assert!(state.command_sender.is_none());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -72,6 +72,9 @@ pub struct AppState<'a> {
     pending_publishes: VecDeque<PendingPublish>,
 }
 
+/// Status-bar label shown while a publish is waiting for a relay's answer.
+const PENDING_LABEL: &str = "Sending";
+
 /// Who asked for a publish, which decides how loudly its outcome is reported.
 ///
 /// A note, reaction or repost is something the user did and is waiting on, so its
@@ -437,6 +440,9 @@ impl<'a> AppState<'a> {
             //
             // Record the loss rather than only reporting it, so the next publish says
             // "not connected" instead of rediscovering the dead worker every time.
+            // Yields a `Shutdown` command, which is deliberately dropped rather than
+            // dispatched: the worker it would be addressed to is the one that just went
+            // away. This is only here to stop the gateway believing it is still connected.
             let _ = self.nostr.update(NostrMessage::ConnectionClosed);
             self.command_sender = None;
             self.report_publish_failure(origin, settled_label, &message, "connection lost");
@@ -448,17 +454,9 @@ impl<'a> AppState<'a> {
             settled_label: settled_label.to_owned(),
             message: message.clone(),
         });
-        self.set_status("Sending", message);
+        self.set_status(PENDING_LABEL, message);
 
         true
-    }
-
-    /// The status line [`Self::begin_publish`] writes while a publish is pending.
-    ///
-    /// [`Self::resolve_publish`] compares against it to tell whether the user is still
-    /// looking at this publish when the answer finally arrives.
-    fn pending_status_line(message: &str) -> String {
-        format!("[Sending] {}", message.replace('\n', " "))
     }
 
     /// Report a publish that failed, as loudly as its origin deserves.
@@ -479,7 +477,10 @@ impl<'a> AppState<'a> {
             return;
         }
 
-        self.set_status_error(settled_label, format!("{message}: {reason}"));
+        // Reason first: the status bar is one line, and what a reaction or repost carries
+        // as its content is a bech32 id — long, and far less use to the reader than why
+        // it failed. Truncation should eat the id, not the cause.
+        self.set_status_error(settled_label, format!("{reason} ({message})"));
     }
 
     /// Settle the oldest unreported publish with the relay's answer.
@@ -509,8 +510,7 @@ impl<'a> AppState<'a> {
                 // answer can arrive a full ack timeout later, and announcing a track
                 // change over whatever the user turned to since is noise.
                 let announce = pending.origin == PublishOrigin::User
-                    || self.status_bar.message()
-                        == Some(Self::pending_status_line(&pending.message)).as_deref();
+                    || self.status_bar.shows(PENDING_LABEL, &pending.message);
 
                 if announce {
                     self.set_status(pending.settled_label, pending.message);
@@ -1403,7 +1403,7 @@ mod tests {
         // when more than one is outstanding.
         let message = state.status_bar.message().expect("a status message");
         assert!(
-            message.starts_with("[ERR: Posted] h:") && message.contains("blocked"),
+            message.starts_with("[ERR: Posted] no relay accepted") && message.contains("(h)"),
             "expected the failed publish to be identified, got: {message}"
         );
     }
@@ -1423,7 +1423,7 @@ mod tests {
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Posted] h: not connected")
+            Some("[ERR: Posted] not connected (h)")
         );
 
         // Nothing pending means a later stray outcome cannot settle this as posted.
@@ -1516,13 +1516,13 @@ mod tests {
         let _ = state.resolve_publish(Err(String::from("first")));
         assert_eq!(
             state.status_bar.message(),
-            Some(format!("[ERR: Reacted] {note1}: first").as_str())
+            Some(format!("[ERR: Reacted] first ({note1})").as_str())
         );
 
         let _ = state.resolve_publish(Err(String::from("second")));
         assert_eq!(
             state.status_bar.message(),
-            Some(format!("[ERR: Reposted] {note1}: second").as_str())
+            Some(format!("[ERR: Reposted] second ({note1})").as_str())
         );
 
         Ok(())
@@ -1565,7 +1565,7 @@ mod tests {
         // Unlike a success, this is something the user asked for that did not happen.
         assert_eq!(
             state.status_bar.message(),
-            Some(format!("[ERR: Reacted] {note1}: refused").as_str())
+            Some(format!("[ERR: Reacted] refused ({note1})").as_str())
         );
 
         Ok(())

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -70,10 +70,27 @@ pub struct AppState<'a> {
     /// exactly once, so its reports arrive in the order the entries were pushed and
     /// can be matched positionally rather than by an id.
     pending_publishes: VecDeque<PendingPublish>,
+    /// The publish whose pending line the status bar is currently showing.
+    ///
+    /// Cleared by every other write to the bar, so it answers "is this still mine?"
+    /// exactly, where comparing the rendered text could not tell two publishes of the
+    /// same content apart.
+    status_owner: Option<PublishId>,
+    /// Source of [`PublishId`]s, monotonic for the life of the application.
+    next_publish_id: u64,
 }
 
 /// Status-bar label shown while a publish is waiting for a relay's answer.
 const PENDING_LABEL: &str = "Sending";
+
+/// Identifies one submitted publish, so its own status line can be recognised without
+/// comparing rendered text.
+///
+/// Two publishes can carry the same content — the same track queued twice inside one
+/// ack window — and their pending lines are then identical. Matching on text would let
+/// one settle against the other's line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PublishId(u64);
 
 /// Who asked for a publish, which decides how loudly its outcome is reported.
 ///
@@ -90,6 +107,7 @@ enum PublishOrigin {
 /// A publish that has been handed to the worker but not yet confirmed by a relay.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingPublish {
+    id: PublishId,
     origin: PublishOrigin,
     /// Status-bar label to show once the relay accepts it — the word the status bar has
     /// always used for this kind of event, whether or not it reads as a verb
@@ -390,6 +408,7 @@ impl<'a> AppState<'a> {
 
     /// Show a status message in the status bar.
     fn set_status(&mut self, label: impl Into<String>, message: impl Into<String>) {
+        self.status_owner = None;
         self.status_bar.update(Message::MessageChanged {
             label: label.into(),
             message: message.into(),
@@ -398,6 +417,7 @@ impl<'a> AppState<'a> {
 
     /// Show an error message in the status bar.
     fn set_status_error(&mut self, label: impl Into<String>, message: impl Into<String>) {
+        self.status_owner = None;
         self.status_bar.update(Message::ErrorMessageChanged {
             label: label.into(),
             message: message.into(),
@@ -427,9 +447,15 @@ impl<'a> AppState<'a> {
     ) -> bool {
         let message = message.into();
 
+        // Allocated before the failure paths so every submission can be named, queued or
+        // not. One that never reached the worker owns no status line, so the ownership
+        // check simply does not match for it.
+        let id = PublishId(self.next_publish_id);
+        self.next_publish_id = self.next_publish_id.wrapping_add(1);
+
         // `model::nostr` declines a submission whenever it believes it is disconnected.
         if outcome.is_none() {
-            self.report_publish_failure(origin, settled_label, &message, "not connected");
+            self.report_publish_failure(id, origin, settled_label, &message, "not connected");
             return false;
         }
 
@@ -454,16 +480,19 @@ impl<'a> AppState<'a> {
             // unattributable. One that died without draining leaves them behind instead,
             // but a finished subscription restarts at the next re-evaluation, and the
             // `Ready` that follows clears the queue.
-            self.report_publish_failure(origin, settled_label, &message, "connection lost");
+            self.report_publish_failure(id, origin, settled_label, &message, "connection lost");
             return false;
         }
 
         self.pending_publishes.push_back(PendingPublish {
+            id,
             origin,
             settled_label: settled_label.to_owned(),
             message: message.clone(),
         });
+
         self.set_status(PENDING_LABEL, message);
+        self.status_owner = Some(id);
 
         true
     }
@@ -478,6 +507,7 @@ impl<'a> AppState<'a> {
 
         for pending in abandoned {
             self.report_publish_failure(
+                pending.id,
                 pending.origin,
                 &pending.settled_label,
                 &pending.message,
@@ -489,6 +519,7 @@ impl<'a> AppState<'a> {
     /// Report a publish that failed, as loudly as its origin deserves.
     fn report_publish_failure(
         &mut self,
+        id: PublishId,
         origin: PublishOrigin,
         settled_label: &str,
         message: &str,
@@ -506,7 +537,7 @@ impl<'a> AppState<'a> {
         // it would go on claiming a publish is in flight that has definitively failed —
         // the same dishonest status this whole change exists to remove, inverted.
         if origin == PublishOrigin::Automatic {
-            if self.status_bar.shows(PENDING_LABEL, message) {
+            if self.status_owner == Some(id) {
                 let _ = self.clear_status_message();
             }
             return;
@@ -549,7 +580,7 @@ impl<'a> AppState<'a> {
                 // cleared bar as "moved on" would stop `Music` ever appearing for anyone
                 // who touches the timeline while an ack is outstanding.
                 let announce = pending.origin == PublishOrigin::User
-                    || self.status_bar.shows(PENDING_LABEL, &pending.message)
+                    || self.status_owner == Some(pending.id)
                     || self.status_bar.message().is_none();
 
                 if announce {
@@ -563,6 +594,7 @@ impl<'a> AppState<'a> {
                 // outstanding — a NIP-38 status from a track change alongside a note just
                 // written — an error attributed to neither says nothing useful.
                 self.report_publish_failure(
+                    pending.id,
                     pending.origin,
                     &pending.settled_label,
                     &pending.message,
@@ -620,10 +652,11 @@ impl<'a> AppState<'a> {
         // from here on — but the report of what was lost is worth more than the loading
         // notice, and doing this first would have it overwritten a line later.
         //
-        // Unreachable today: `NostrEvents::key` is the `Arc<Client>` pointer, so a second
-        // worker only appears if the first one's stream ended. The queue is only
-        // positionally matched, and this is the one place that assumption could break
-        // silently.
+        // Reachable, not theoretical: the worker's stream ends on every normal exit, and
+        // tears restarts a finished subscription that is still declared. A worker that
+        // exited cleanly drained first and its reports arrive before its stream ends, so
+        // the queue is normally already empty by now and this does nothing. It is here
+        // for the one that did not.
         self.fail_pending_publishes("the connection was re-established");
 
         Command::none()
@@ -691,6 +724,7 @@ impl<'a> AppState<'a> {
 
     /// Clear the current status message.
     pub fn clear_status_message(&mut self) -> Command<AppMsg> {
+        self.status_owner = None;
         self.status_bar.update(Message::MessageCleared);
         Command::none()
     }
@@ -1673,6 +1707,32 @@ mod tests {
         // Quiet, but not leaving the screen claiming a publish is still in flight —
         // nothing else clears the status bar on its own.
         assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn two_publishes_of_the_same_content_do_not_settle_each_other() {
+        let (mut state, _rx) = connected_state();
+
+        // The same track twice inside one ack window — repeat-one playback, or skipping
+        // back into it. Both pending lines render identically.
+        let _ = state.publish_music_status(create_track("Song"));
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.pending_publishes.len(), 2);
+        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+
+        // The first one fails. Its line is not the one on screen — the second replaced
+        // it — so it must leave that alone rather than clearing a send still in flight.
+        let _ = state.resolve_publish(Err(String::from("refused")));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[Sending] Song - Artist"),
+            "the second publish is still in flight and still owns the line"
+        );
+
+        // And the second one, which does own it, settles normally.
+        let _ = state.resolve_publish(Ok(()));
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crossterm::event::KeyEvent;
 use nostr_sdk::prelude::*;
 use nowhear::Track;
@@ -62,6 +64,22 @@ pub struct AppState<'a> {
     /// Owned here (not in `model::nostr`) so the application layer performs the
     /// I/O while `model` stays side-effect free; set once the worker is ready.
     command_sender: Option<mpsc::UnboundedSender<NostrCommand>>,
+    /// Publishes handed to the worker and not yet reported back, oldest first.
+    ///
+    /// The worker awaits each command inline and reports every `SendEventBuilder`
+    /// exactly once, so its reports arrive in the order the entries were pushed and
+    /// can be matched positionally rather than by an id.
+    pending_publishes: VecDeque<PendingPublish>,
+}
+
+/// A publish that has been handed to the worker but not yet confirmed by a relay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingPublish {
+    /// Status-bar label to show once the relay accepts it — the past-tense word the
+    /// status bar has always shown for this kind of event.
+    settled_label: String,
+    /// What was published, shown while pending and again once settled.
+    message: String,
 }
 
 /// Configuration state - holds all user-configurable settings
@@ -168,7 +186,7 @@ impl<'a> AppState<'a> {
             let outcome = self
                 .nostr
                 .update(NostrMessage::SubscriptionRequested { feed });
-            self.dispatch_nostr(outcome);
+            let _ = self.dispatch_nostr(outcome);
 
             self.set_status("Mention", "loading...");
         } else {
@@ -206,7 +224,7 @@ impl<'a> AppState<'a> {
             let outcome = self
                 .nostr
                 .update(NostrMessage::SubscriptionRequested { feed });
-            self.dispatch_nostr(outcome);
+            let _ = self.dispatch_nostr(outcome);
 
             self.set_status(author_npub, "loading...");
         } else {
@@ -234,7 +252,7 @@ impl<'a> AppState<'a> {
 
         // Unsubscribe the subscriptions associated with the closed tab.
         let outcome = self.nostr.update(NostrMessage::SubscriptionClosed { feed });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
 
         Command::none()
     }
@@ -267,9 +285,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status(label, note_id);
+        self.begin_publish(outcome, label, note_id);
 
         Command::none()
     }
@@ -316,9 +332,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status("Posted", content);
+        self.begin_publish(outcome, "Posted", content);
 
         // Clear UI state.
         self.editor.update(EditorMessage::ComposingCanceled);
@@ -340,9 +354,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status("Music", content);
+        self.begin_publish(outcome, "Music", content);
 
         Command::none()
     }
@@ -372,19 +384,74 @@ impl<'a> AppState<'a> {
     ///
     /// `model::nostr::update` is side-effect free and only reports the command
     /// to send; the application owns the sender and performs the actual I/O.
-    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) {
-        let Some(NostrOutcome::Send(command)) = outcome else {
+    /// Hand a submitted event to the worker and show it as pending.
+    ///
+    /// The status bar says "sending" rather than the past-tense `settled_label` until a
+    /// relay has answered, because until then nothing has been published — the command
+    /// only sits on the worker's queue. [`Self::resolve_publish`] supplies the ending.
+    ///
+    /// When the event never reaches the worker at all — `model::nostr` declines it while
+    /// disconnected, or no worker is listening — there is nothing to wait for and no
+    /// report will arrive, so this settles immediately as an error instead of leaving a
+    /// pending entry that can never be popped.
+    fn begin_publish(
+        &mut self,
+        outcome: Option<NostrOutcome>,
+        settled_label: &str,
+        message: impl Into<String>,
+    ) {
+        let message = message.into();
+
+        if !self.dispatch_nostr(outcome) {
+            self.set_status_error(settled_label, "not connected");
             return;
+        }
+
+        self.pending_publishes.push_back(PendingPublish {
+            settled_label: settled_label.to_owned(),
+            message: message.clone(),
+        });
+        self.set_status("Sending", message);
+    }
+
+    /// Settle the oldest unreported publish with the relay's answer.
+    ///
+    /// Matched positionally rather than by an id: the worker awaits each command inline
+    /// and reports every `SendEventBuilder` exactly once, so reports arrive in the order
+    /// the entries were pushed.
+    pub fn resolve_publish(&mut self, result: Result<(), CommandError>) -> Command<AppMsg> {
+        let Some(pending) = self.pending_publishes.pop_front() else {
+            log::warn!("Publish outcome with nothing pending: {result:?}");
+            return Command::none();
+        };
+
+        match result {
+            Ok(()) => self.set_status(pending.settled_label, pending.message),
+            Err(error) => {
+                log::error!("Failed to publish: {error:?}");
+                self.set_status_error("Send", format!("{error:?}"));
+            }
+        }
+
+        Command::none()
+    }
+
+    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
+        let Some(NostrOutcome::Send(command)) = outcome else {
+            return false;
         };
 
         let Some(sender) = self.command_sender.as_ref() else {
             log::warn!("Dropping Nostr command, worker not ready: {command:?}");
-            return;
+            return false;
         };
 
         if sender.send(command).is_err() {
             log::error!("Failed to send Nostr command: subscription worker is gone");
+            return false;
         }
+
+        true
     }
 
     /// Record that the Nostr subscription is ready and store its command sender,
@@ -398,7 +465,7 @@ impl<'a> AppState<'a> {
         let tab_title = self.active_tab_title();
         self.command_sender = Some(command_sender);
         let outcome = self.nostr.update(NostrMessage::ConnectionReady);
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         self.set_status(tab_title, "loading...");
 
         Command::none()
@@ -451,7 +518,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::HistoryRequested { feed, since });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
 
         self.set_status(tab_title, "loading more...");
 
@@ -572,7 +639,7 @@ impl<'a> AppState<'a> {
     /// Close the Nostr connection: unsubscribe and disconnect from relays.
     pub fn close_connection(&mut self) -> Command<AppMsg> {
         let outcome = self.nostr.update(NostrMessage::ConnectionClosed);
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         self.command_sender = None;
         Command::none()
     }
@@ -588,7 +655,7 @@ impl<'a> AppState<'a> {
             feed,
             sub_id: subscription_id,
         });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         Command::none()
     }
 
@@ -955,8 +1022,8 @@ mod tests {
 
     #[test]
     fn test_react_to_selected_sets_status() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
@@ -964,6 +1031,14 @@ mod tests {
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.react_to_selected();
+
+        // Handed to the worker, but no relay has answered yet.
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Sending] {note1}").as_str())
+        );
+
+        let _ = state.resolve_publish(Ok(()));
 
         assert_eq!(
             state.status_bar.message(),
@@ -975,8 +1050,8 @@ mod tests {
 
     #[test]
     fn test_repost_selected_sets_status() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
@@ -984,6 +1059,14 @@ mod tests {
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.repost_selected();
+
+        // Handed to the worker, but no relay has answered yet.
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Sending] {note1}").as_str())
+        );
+
+        let _ = state.resolve_publish(Ok(()));
 
         assert_eq!(
             state.status_bar.message(),
@@ -1022,7 +1105,7 @@ mod tests {
 
     #[test]
     fn test_submit_note_posts_content_and_resets_editor() {
-        let mut state = AppState::new(Keys::generate().public_key());
+        let (mut state, _rx) = connected_state();
 
         // Compose "hi" in the editor.
         state.editor.update(EditorMessage::ComposingStarted);
@@ -1037,14 +1120,19 @@ mod tests {
 
         let _ = state.submit_note();
 
-        assert_eq!(state.status_bar.message(), Some("[Posted] hi"));
+        // The editor closes immediately, but nothing is posted until a relay says so.
+        assert_eq!(state.status_bar.message(), Some("[Sending] hi"));
         assert!(!state.editor.is_active());
+
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(state.status_bar.message(), Some("[Posted] hi"));
     }
 
     #[test]
     fn test_submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         // Select a note and start replying to it.
         let event = create_text_note(&keys, "original", Timestamp::from(1000))?;
@@ -1059,17 +1147,25 @@ mod tests {
 
         let _ = state.submit_note();
 
-        assert_eq!(state.status_bar.message(), Some("[Posted] y"));
+        assert_eq!(state.status_bar.message(), Some("[Sending] y"));
         assert!(!state.editor.is_active());
+
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(state.status_bar.message(), Some("[Posted] y"));
 
         Ok(())
     }
 
     #[test]
     fn test_publish_music_status_sets_status() {
-        let mut state = AppState::new(Keys::generate().public_key());
+        let (mut state, _rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
+
+        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+
+        let _ = state.resolve_publish(Ok(()));
 
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
     }
@@ -1173,6 +1269,81 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let _ = state.on_connection_ready(tx);
         (state, rx)
+    }
+
+    #[test]
+    fn publish_failure_reports_an_error_instead_of_success() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+
+        let _ = state.resolve_publish(Err(CommandError::SendEventFailed {
+            error: String::from("relay refused"),
+        }));
+
+        let message = state.status_bar.message().expect("a status message");
+        assert!(
+            message.starts_with("[ERR: Send]") && message.contains("relay refused"),
+            "expected the failure to be reported, got: {message}"
+        );
+    }
+
+    #[test]
+    fn publishing_while_disconnected_does_not_claim_success() {
+        // Not connected: `model::nostr` declines the submission, so nothing is queued
+        // and no outcome will ever arrive to settle it.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Music] not connected")
+        );
+
+        // Nothing pending means a later stray outcome cannot settle this as posted.
+        assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn publishes_settle_in_submission_order() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        // Two publishes outstanding at once, reaction first.
+        let _ = state.react_to_selected();
+        let _ = state.publish_music_status(create_track("Song"));
+        assert_eq!(state.pending_publishes.len(), 2);
+
+        // The first outcome settles the first submission, not the most recent one.
+        let _ = state.resolve_publish(Ok(()));
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reacted] {note1}").as_str())
+        );
+
+        let _ = state.resolve_publish(Ok(()));
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn an_unmatched_publish_outcome_is_ignored() {
+        let (mut state, _rx) = connected_state();
+        let before = state.status_bar.message().map(ToOwned::to_owned);
+
+        // Nothing was submitted, so there is nothing for this to settle — and in
+        // particular it must not report a success against whatever is on screen.
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(state.status_bar.message(), before.as_deref());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -72,9 +72,22 @@ pub struct AppState<'a> {
     pending_publishes: VecDeque<PendingPublish>,
 }
 
+/// Who asked for a publish, which decides how loudly its outcome is reported.
+///
+/// A note, reaction or repost is something the user did and is waiting on, so its
+/// answer is worth interrupting whatever is on screen. A NIP-38 status event fires by
+/// itself on every track change; its answer is worth showing only while the user is
+/// still looking at it, and its failures are not actionable at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishOrigin {
+    User,
+    Automatic,
+}
+
 /// A publish that has been handed to the worker but not yet confirmed by a relay.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingPublish {
+    origin: PublishOrigin,
     /// Status-bar label to show once the relay accepts it — the word the status bar has
     /// always used for this kind of event, whether or not it reads as a verb
     /// ("Posted", "Reacted", "Reposted", but also "Music").
@@ -286,7 +299,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        let _ = self.begin_publish(outcome, label, note_id);
+        let _ = self.begin_publish(outcome, PublishOrigin::User, label, note_id);
 
         Command::none()
     }
@@ -340,7 +353,7 @@ impl<'a> AppState<'a> {
         // This covers the failures known before sending. One the relays report later
         // still loses the text, because getting it back needs a way to put content into
         // the editor that `model::editor` does not have yet: #514.
-        if self.begin_publish(outcome, "Posted", content) {
+        if self.begin_publish(outcome, PublishOrigin::User, "Posted", content) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
 
@@ -361,7 +374,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { event_builder });
-        let _ = self.begin_publish(outcome, "Music", content);
+        let _ = self.begin_publish(outcome, PublishOrigin::Automatic, "Music", content);
 
         Command::none()
     }
@@ -404,6 +417,7 @@ impl<'a> AppState<'a> {
     fn begin_publish(
         &mut self,
         outcome: Option<NostrOutcome>,
+        origin: PublishOrigin,
         settled_label: &str,
         message: impl Into<String>,
     ) -> bool {
@@ -411,7 +425,7 @@ impl<'a> AppState<'a> {
 
         // `model::nostr` declines a submission whenever it believes it is disconnected.
         if outcome.is_none() {
-            self.set_status_error(settled_label, format!("{message}: not connected"));
+            self.report_publish_failure(origin, settled_label, &message, "not connected");
             return false;
         }
 
@@ -420,11 +434,17 @@ impl<'a> AppState<'a> {
             // believes it is connected, and the sender is set and cleared in the same
             // calls that set and clear that belief — so the sender cannot be missing
             // here, only closed.
-            self.set_status_error(settled_label, format!("{message}: connection lost"));
+            //
+            // Record the loss rather than only reporting it, so the next publish says
+            // "not connected" instead of rediscovering the dead worker every time.
+            let _ = self.nostr.update(NostrMessage::ConnectionClosed);
+            self.command_sender = None;
+            self.report_publish_failure(origin, settled_label, &message, "connection lost");
             return false;
         }
 
         self.pending_publishes.push_back(PendingPublish {
+            origin,
             settled_label: settled_label.to_owned(),
             message: message.clone(),
         });
@@ -439,6 +459,27 @@ impl<'a> AppState<'a> {
     /// looking at this publish when the answer finally arrives.
     fn pending_status_line(message: &str) -> String {
         format!("[Sending] {}", message.replace('\n', " "))
+    }
+
+    /// Report a publish that failed, as loudly as its origin deserves.
+    fn report_publish_failure(
+        &mut self,
+        origin: PublishOrigin,
+        settled_label: &str,
+        message: &str,
+        reason: &str,
+    ) {
+        log::error!("Failed to publish {message}: {reason}");
+
+        // Nothing fires an automatic publish but nostui itself, and there is nothing the
+        // user can do about one failing — so it stays in the log rather than painting an
+        // error over whatever they are actually doing. A track change during startup
+        // would otherwise report a failure for something they never asked for.
+        if origin == PublishOrigin::Automatic {
+            return;
+        }
+
+        self.set_status_error(settled_label, format!("{message}: {reason}"));
     }
 
     /// Settle the oldest unreported publish with the relay's answer.
@@ -460,28 +501,32 @@ impl<'a> AppState<'a> {
 
         match result {
             Ok(()) => {
-                // An answer can arrive seconds later — a relay may take its full ack
-                // timeout — by which time the user has moved on and the status bar is
-                // showing something newer. Confirming a success over the top of that is
-                // noise, so it only lands if this publish is still what is on screen.
-                if self.status_bar.message()
-                    == Some(Self::pending_status_line(&pending.message)).as_deref()
-                {
+                // A user's publish always gets its confirmation: they are waiting on it,
+                // and it is what showing "Sending" promised. In particular a newer
+                // publish's pending line replacing theirs is not them moving on.
+                //
+                // An automatic one lands only while it is still what is on screen. Its
+                // answer can arrive a full ack timeout later, and announcing a track
+                // change over whatever the user turned to since is noise.
+                let announce = pending.origin == PublishOrigin::User
+                    || self.status_bar.message()
+                        == Some(Self::pending_status_line(&pending.message)).as_deref();
+
+                if announce {
                     self.set_status(pending.settled_label, pending.message);
                 } else {
                     log::info!("Published: {}", pending.message);
                 }
             }
             Err(reason) => {
-                log::error!("Failed to publish {}: {reason}", pending.message);
-                // Failures are shown whatever else is on screen: the user asked for this
-                // and it did not happen. Keeps the label and the content, because with
-                // more than one publish outstanding — a NIP-38 status from a track change
-                // alongside a note just written — an error attributed to neither says
-                // nothing useful.
-                self.set_status_error(
-                    pending.settled_label,
-                    format!("{}: {reason}", pending.message),
+                // Keeps the label and the content, because with more than one publish
+                // outstanding — a NIP-38 status from a track change alongside a note just
+                // written — an error attributed to neither says nothing useful.
+                self.report_publish_failure(
+                    pending.origin,
+                    &pending.settled_label,
+                    &pending.message,
+                    &reason,
                 );
             }
         }
@@ -1342,8 +1387,13 @@ mod tests {
     fn publish_failure_reports_an_error_instead_of_success() {
         let (mut state, _rx) = connected_state();
 
-        let _ = state.publish_music_status(create_track("Song"));
-        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+        assert_eq!(state.status_bar.message(), Some("[Sending] h"));
 
         let _ = state.resolve_publish(Err(String::from(
             "no relay accepted the event: wss://relay.example: blocked",
@@ -1353,7 +1403,7 @@ mod tests {
         // when more than one is outstanding.
         let message = state.status_bar.message().expect("a status message");
         assert!(
-            message.starts_with("[ERR: Music] Song - Artist:") && message.contains("blocked"),
+            message.starts_with("[ERR: Posted] h:") && message.contains("blocked"),
             "expected the failed publish to be identified, got: {message}"
         );
     }
@@ -1364,14 +1414,32 @@ mod tests {
         // and no outcome will ever arrive to settle it.
         let mut state = AppState::new(Keys::generate().public_key());
 
-        let _ = state.publish_music_status(create_track("Song"));
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] Song - Artist: not connected")
+            Some("[ERR: Posted] h: not connected")
         );
 
         // Nothing pending means a later stray outcome cannot settle this as posted.
+        assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn an_automatic_publish_fails_quietly() {
+        // A track change fires this, not the user — and during startup it can land before
+        // the worker is ready. An error for something they never asked for, painted over
+        // the startup status, is noise they cannot act on.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        assert_eq!(state.status_bar.message(), None);
         assert!(state.pending_publishes.is_empty());
     }
 
@@ -1438,13 +1506,13 @@ mod tests {
         let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
-        // Two publishes outstanding at once, reaction first.
+        // Two publishes outstanding at once, the reaction first. Both user-initiated, so
+        // both report; failures rather than successes, so each names what it belongs to
+        // regardless of which pending line happens to be on screen.
         let _ = state.react_to_selected();
-        let _ = state.publish_music_status(create_track("Song"));
+        let _ = state.repost_selected();
         assert_eq!(state.pending_publishes.len(), 2);
 
-        // Failures rather than successes, so the assertions do not depend on which
-        // pending line happens to be on screen — each error names what it belongs to.
         let _ = state.resolve_publish(Err(String::from("first")));
         assert_eq!(
             state.status_bar.message(),
@@ -1454,7 +1522,7 @@ mod tests {
         let _ = state.resolve_publish(Err(String::from("second")));
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] Song - Artist: second")
+            Some(format!("[ERR: Reposted] {note1}: second").as_str())
         );
 
         Ok(())
@@ -1480,10 +1548,16 @@ mod tests {
     }
 
     #[test]
-    fn a_late_failure_is_shown_even_over_a_newer_status() {
+    fn a_late_failure_is_shown_even_over_a_newer_status() -> Result<()> {
         let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
 
-        let _ = state.publish_music_status(create_track("Song"));
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        let _ = state.react_to_selected();
         let _ = state.open_mention_tab();
 
         let _ = state.resolve_publish(Err(String::from("refused")));
@@ -1491,8 +1565,37 @@ mod tests {
         // Unlike a success, this is something the user asked for that did not happen.
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] Song - Artist: refused")
+            Some(format!("[ERR: Reacted] {note1}: refused").as_str())
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_users_publish_is_confirmed_even_after_a_newer_pending_line() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        let _ = state.react_to_selected();
+
+        // A track change replaces the reaction's pending line while it is still in
+        // flight. That is not the user moving on, and their reaction still deserves its
+        // answer.
+        let _ = state.publish_music_status(create_track("Song"));
+
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reacted] {note1}").as_str())
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -467,10 +467,13 @@ impl<'a> AppState<'a> {
             //
             // Record the loss rather than only reporting it, so the next publish says
             // "not connected" instead of rediscovering the dead worker every time.
-            // Yields a `Shutdown` command, which is deliberately dropped rather than
-            // dispatched: the worker it would be addressed to is the one that just went
-            // away. This is only here to stop the gateway believing it is still connected.
-            let _ = self.nostr.update(NostrMessage::ConnectionClosed);
+            // `ConnectionLost`, not `ConnectionClosed`: the latter also clears the
+            // tracked feed subscriptions, which is right when nostui is closing the
+            // connection deliberately and wrong here. The tabs are still open, and their
+            // subscription ids are what a replacement worker needs in order to
+            // unsubscribe — dropping them leaks the subscription relay-side and leaves
+            // the tab on screen receiving nothing.
+            let _ = self.nostr.update(NostrMessage::ConnectionLost);
             self.command_sender = None;
 
             // `pending_publishes` is deliberately left alone. A worker that exited
@@ -556,13 +559,12 @@ impl<'a> AppState<'a> {
     /// the entries were pushed.
     pub fn resolve_publish(&mut self, result: Result<(), String>) -> Command<AppMsg> {
         let Some(pending) = self.pending_publishes.pop_front() else {
-            // Nothing to attribute it to, so the content and label are unavailable. A
-            // failure is still worth saying: something the user asked for did not happen,
-            // and silence is what this whole change exists to remove.
+            // Logged, not shown. There is no entry, so neither what failed nor whether
+            // the user asked for it is known — and an automatic publish reported this way
+            // would paint exactly the error `report_publish_failure` suppresses. The one
+            // path that retires entries early, `fail_pending_publishes`, reports them as
+            // it goes, so the user has already been told whatever there was to tell.
             log::warn!("Publish outcome with nothing pending: {result:?}");
-            if let Err(reason) = result {
-                self.set_status_error("Send", reason);
-            }
             return Command::none();
         };
 
@@ -571,6 +573,11 @@ impl<'a> AppState<'a> {
                 // A user's publish always gets its confirmation: they are waiting on it,
                 // and it is what showing "Sending" promised. In particular a newer
                 // publish's pending line replacing theirs is not them moving on.
+                //
+                // The cost is deliberate: nostr-sdk waits for every relay, not the first
+                // ack, so this can arrive ten seconds later and land over a status the
+                // user has caused since. Swallowing it instead would leave "Sending" as
+                // the last thing they ever heard about their own note, which is worse.
                 //
                 // An automatic one lands only where it would not be talking over
                 // anything: its own pending line, or an empty bar. Its answer can arrive
@@ -1685,14 +1692,17 @@ mod tests {
     }
 
     #[test]
-    fn an_unattributable_failure_is_still_reported() {
+    fn an_unattributable_failure_is_logged_rather_than_shown() {
         let (mut state, _rx) = connected_state();
+        let before = state.status_bar.message().map(ToOwned::to_owned);
 
-        // No pending entry, so there is no label or content to name — but staying silent
-        // about a failure is the behaviour this change exists to remove.
+        // With no entry, neither what failed nor whether the user asked for it is known,
+        // and an automatic publish surfaced this way would paint exactly the error that
+        // `report_publish_failure` suppresses. The only path that retires entries early
+        // reports them as it goes, so there is nothing left to tell.
         let _ = state.resolve_publish(Err(String::from("refused")));
 
-        assert_eq!(state.status_bar.message(), Some("[ERR: Send] refused"));
+        assert_eq!(state.status_bar.message(), before.as_deref());
     }
 
     #[test]
@@ -1780,6 +1790,31 @@ mod tests {
         let _ = state.on_connection_ready(tx);
 
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn losing_the_worker_keeps_the_tracked_subscriptions() {
+        let (mut state, rx) = connected_state();
+        let feed = FeedKind::Author(Keys::generate().public_key());
+        let sub_id = SubscriptionId::new("author_sub");
+
+        let _ = state
+            .timeline
+            .update(TimelineMessage::TabAdded { feed: feed.clone() });
+        let _ = state.track_subscription_created(feed.clone(), sub_id.clone());
+
+        // The worker goes away without being asked to.
+        drop(rx);
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // The tab is still open, and its subscription id is what a replacement worker
+        // needs to unsubscribe. Losing it leaks the subscription relay-side and leaves
+        // the tab on screen receiving nothing.
+        assert!(
+            state.nostr.is_subscribed(&feed),
+            "a lost worker must not discard what the open tabs are subscribed to"
+        );
+        assert_eq!(state.nostr.find_tab_by_subscription(&sub_id), Some(&feed));
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -446,6 +446,14 @@ impl<'a> AppState<'a> {
             // away. This is only here to stop the gateway believing it is still connected.
             let _ = self.nostr.update(NostrMessage::ConnectionClosed);
             self.command_sender = None;
+
+            // `pending_publishes` is deliberately left alone. A worker that exited
+            // normally already drained and reported them, and tears keeps a finished
+            // run's queued output deliverable, so those reports still arrive; failing
+            // them here would report a loss and then have the real outcome turn up
+            // unattributable. One that died without draining leaves them behind instead,
+            // but a finished subscription restarts at the next re-evaluation, and the
+            // `Ready` that follows clears the queue.
             self.report_publish_failure(origin, settled_label, &message, "connection lost");
             return false;
         }
@@ -533,11 +541,16 @@ impl<'a> AppState<'a> {
                 // and it is what showing "Sending" promised. In particular a newer
                 // publish's pending line replacing theirs is not them moving on.
                 //
-                // An automatic one lands only while it is still what is on screen. Its
-                // answer can arrive a full ack timeout later, and announcing a track
-                // change over whatever the user turned to since is noise.
+                // An automatic one lands only where it would not be talking over
+                // anything: its own pending line, or an empty bar. Its answer can arrive
+                // a full ack timeout later, and a track change announced over whatever
+                // the user turned to since is noise — but an empty bar is not that.
+                // Scrolling clears the status on every timeline message, so treating a
+                // cleared bar as "moved on" would stop `Music` ever appearing for anyone
+                // who touches the timeline while an ack is outstanding.
                 let announce = pending.origin == PublishOrigin::User
-                    || self.status_bar.shows(PENDING_LABEL, &pending.message);
+                    || self.status_bar.shows(PENDING_LABEL, &pending.message)
+                    || self.status_bar.message().is_none();
 
                 if announce {
                     self.set_status(pending.settled_label, pending.message);
@@ -597,17 +610,21 @@ impl<'a> AppState<'a> {
 
         let tab_title = self.active_tab_title();
 
-        // A second worker would report against entries queued for the first, offsetting
-        // every outcome from here on. Unreachable today — `NostrEvents::key` is the
-        // `Arc<Client>` pointer, so tears never rebuilds the stream — but the queue is
-        // only positionally matched, and this is the one place that assumption could
-        // break silently.
-        self.fail_pending_publishes("the connection was re-established");
-
         self.command_sender = Some(command_sender);
         let outcome = self.nostr.update(NostrMessage::ConnectionReady);
         let _ = self.dispatch_nostr(outcome);
         self.set_status(tab_title, "loading...");
+
+        // After the "loading" line, not before it. A second worker reports against its
+        // own commands only, so entries queued for the first would offset every outcome
+        // from here on — but the report of what was lost is worth more than the loading
+        // notice, and doing this first would have it overwritten a line later.
+        //
+        // Unreachable today: `NostrEvents::key` is the `Arc<Client>` pointer, so a second
+        // worker only appears if the first one's stream ended. The queue is only
+        // positionally matched, and this is the one place that assumption could break
+        // silently.
+        self.fail_pending_publishes("the connection was re-established");
 
         Command::none()
     }
@@ -1656,6 +1673,23 @@ mod tests {
         // Quiet, but not leaving the screen claiming a publish is still in flight —
         // nothing else clears the status bar on its own.
         assert_eq!(state.status_bar.message(), None);
+    }
+
+    #[test]
+    fn an_automatic_success_lands_on_a_cleared_bar() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // Scrolling clears the status on every timeline message, and an ack can take ten
+        // seconds — so a cleared bar has to count as "nothing to talk over", or `Music`
+        // would stop appearing for anyone who touches the timeline while one is in
+        // flight.
+        let _ = state.clear_status_message();
+
+        let _ = state.resolve_publish(Ok(()));
+
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
     }
 
     #[test]

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -375,6 +375,13 @@ impl NostrEvents {
                             client.disconnect().await;
                             break;
                         }
+                        // Awaited inline on purpose, and load-bearing: the application
+                        // matches `EventPublished` reports to submissions by position,
+                        // which only holds because this never starts a second publish
+                        // before the first has reported. Spawning this to stop a slow ack
+                        // blocking the loop would silently settle outcomes against the
+                        // wrong publish — that needs a correlation id first. The blocking
+                        // itself is #515.
                         Some(cmd) => {
                             Self::handle_command(cmd, &client, pubkey, keys.as_ref(), Arc::clone(&contact_list_cache), &msg_tx).await;
                         }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -133,7 +133,6 @@ impl NostrEvents {
         }
     }
 
-    /// Handle a single command and send error messages if needed
     /// Decide whether a completed `send_event` actually reached a relay.
     ///
     /// `Ok` from nostr-sdk does not mean the event was accepted: the pool returns
@@ -177,6 +176,7 @@ impl NostrEvents {
         reasons.join(", ")
     }
 
+    /// Run a single command and report its outcome to the application.
     async fn handle_command(
         cmd: NostrCommand,
         client: &Client,
@@ -384,6 +384,20 @@ impl NostrEvents {
                         }
                     }
                 }
+            }
+        }
+
+        // Whatever is still queued will never run now. The application holds a pending
+        // entry per submitted event and settles them in report order, so a publish that
+        // simply vanishes here would sit as "Sending" forever and shift every later
+        // outcome onto the wrong submission.
+        while let Ok(cmd) = cmd_rx.try_recv() {
+            if matches!(cmd, NostrCommand::SendEventBuilder { .. }) {
+                let _ = msg_tx.send(Message::EventPublished {
+                    result: Err(String::from(
+                        "the connection closed before the event was sent",
+                    )),
+                });
             }
         }
     }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -387,6 +387,13 @@ impl NostrEvents {
             }
         }
 
+        // Close before draining, not after. `cmd_rx` would otherwise stay open until this
+        // task returns, and a publish sent in that window would be accepted by the sender
+        // — so the application pushes a pending entry — and then never dequeued by anyone.
+        // Closing first makes those sends fail instead, which the application settles
+        // immediately. Items already buffered are still receivable.
+        cmd_rx.close();
+
         // Whatever is still queued will never run now. The application holds a pending
         // entry per submitted event and settles them in report order, so a publish that
         // simply vanishes here would sit as "Sending" forever and shift every later

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use futures::{
     stream::{self, BoxStream},
@@ -130,6 +134,49 @@ impl NostrEvents {
     }
 
     /// Handle a single command and send error messages if needed
+    /// Decide whether a completed `send_event` actually reached a relay.
+    ///
+    /// `Ok` from nostr-sdk does not mean the event was accepted: the pool returns
+    /// `Ok(output)` once it has tried every relay, recording per-relay rejections and
+    /// ack timeouts in `output.failed` and reserving `Err` for setup problems. An event
+    /// every relay refused therefore arrives here as `Ok` with an empty `success` set.
+    ///
+    /// One relay accepting is enough — the event exists on the network — so a partial
+    /// failure is logged rather than reported.
+    fn relay_verdict(output: &SendEventOutput) -> Result<(), String> {
+        if !output.success.is_empty() {
+            if !output.failed.is_empty() {
+                log::warn!(
+                    "Event {} accepted by {} relay(s), refused by {}",
+                    output.value,
+                    output.success.len(),
+                    Self::describe_failures(&output.failed)
+                );
+            }
+            return Ok(());
+        }
+
+        Err(if output.failed.is_empty() {
+            String::from("no relay accepted the event")
+        } else {
+            format!(
+                "no relay accepted the event: {}",
+                Self::describe_failures(&output.failed)
+            )
+        })
+    }
+
+    /// Render per-relay failures as `url: reason`, in a stable order so the same
+    /// outcome always reads the same way.
+    fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
+        let mut reasons: Vec<String> = failed
+            .iter()
+            .map(|(url, reason)| format!("{url}: {reason}"))
+            .collect();
+        reasons.sort();
+        reasons.join(", ")
+    }
+
     async fn handle_command(
         cmd: NostrCommand,
         client: &Client,
@@ -142,11 +189,10 @@ impl NostrEvents {
             NostrCommand::SendEventBuilder { event_builder } => {
                 let result: Result<(), String> = match keys {
                     Some(keys) => match event_builder.finalize(keys) {
-                        Ok(event) => client
-                            .send_event(&event)
-                            .await
-                            .map(|_| ())
-                            .map_err(|e| e.to_string()),
+                        Ok(event) => match client.send_event(&event).await {
+                            Ok(output) => Self::relay_verdict(&output),
+                            Err(e) => Err(e.to_string()),
+                        },
                         Err(e) => Err(e.to_string()),
                     },
                     None => Err(String::from("cannot send events in read-only mode")),
@@ -154,9 +200,7 @@ impl NostrEvents {
                 // Reported either way: the application shows a publish as pending until
                 // this arrives, so a success that says nothing would leave it pending
                 // forever.
-                let _ = msg_tx.send(Message::EventPublished {
-                    result: result.map_err(|error| CommandError::SendEventFailed { error }),
-                });
+                let _ = msg_tx.send(Message::EventPublished { result });
             }
             NostrCommand::AddRelay { url } => {
                 if let Err(e) = client.add_relay(&url).await {
@@ -397,6 +441,69 @@ impl SubscriptionSource for NostrEvents {
 mod tests {
     use super::*;
     use futures::StreamExt;
+
+    fn relay_url(url: &str) -> RelayUrl {
+        RelayUrl::parse(url).expect("valid relay url")
+    }
+
+    fn send_output(success: &[&str], failed: &[(&str, &str)]) -> SendEventOutput {
+        let mut output: SendEventOutput = Output::new(EventId::from_byte_array([0u8; 32]));
+        for url in success {
+            output.success.insert(relay_url(url), EventSendStatus::Sent);
+        }
+        for (url, reason) in failed {
+            output.failed.insert(relay_url(url), (*reason).to_owned());
+        }
+        output
+    }
+
+    #[test]
+    fn a_send_every_relay_refused_is_a_failure() {
+        // nostr-sdk returns `Ok` once it has tried every relay, so an all-refused send
+        // arrives as `Ok` with nothing in `success`. Reporting that as a publish would
+        // put "Posted" on screen for a note no relay stored.
+        let output = send_output(&[], &[("wss://a.example", "blocked")]);
+
+        let error = NostrEvents::relay_verdict(&output).expect_err("should be a failure");
+        assert!(
+            error.contains("no relay accepted") && error.contains("blocked"),
+            "expected the relay's reason to survive, got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_send_no_relay_answered_is_a_failure() {
+        let output = send_output(&[], &[]);
+
+        assert!(NostrEvents::relay_verdict(&output).is_err());
+    }
+
+    #[test]
+    fn one_relay_accepting_is_enough() {
+        // The event exists on the network, so a partial failure is logged, not reported.
+        let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
+
+        assert_eq!(NostrEvents::relay_verdict(&output), Ok(()));
+    }
+
+    #[test]
+    fn failure_reasons_read_the_same_way_every_time() {
+        // `failed` is a HashMap, so without sorting the same outcome would render in a
+        // different order each run.
+        let output = send_output(
+            &[],
+            &[
+                ("wss://b.example", "blocked"),
+                ("wss://a.example", "bad sig"),
+            ],
+        );
+
+        let error = NostrEvents::relay_verdict(&output).expect_err("should be a failure");
+        assert!(
+            error.find("a.example").expect("a") < error.find("b.example").expect("b"),
+            "expected a stable order, got: {error}"
+        );
+    }
 
     #[test]
     fn followings_use_only_the_latest_contact_list() {

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -401,11 +401,19 @@ impl NostrEvents {
         // immediately. Items already buffered are still receivable.
         cmd_rx.close();
 
+        // Drained with `recv`, not `try_recv`. `send` bumps the message count before it
+        // pushes the value, and `try_recv` reports an empty queue as `Empty` rather than
+        // `Disconnected` while that count is non-zero — so a send caught mid-flight by
+        // the `close` above would end the loop and be left in the channel unread. `recv`
+        // waits it out and returns `None` only once the channel is closed and genuinely
+        // drained; it cannot wait forever, because `close` stops any further send from
+        // starting.
+        //
         // Whatever is still queued will never run now. The application holds a pending
         // entry per submitted event and settles them in report order, so a publish that
-        // simply vanishes here would sit as "Sending" forever and shift every later
+        // simply vanished here would sit as "Sending" forever and shift every later
         // outcome onto the wrong submission.
-        while let Ok(cmd) = cmd_rx.try_recv() {
+        while let Some(cmd) = cmd_rx.recv().await {
             if matches!(cmd, NostrCommand::SendEventBuilder { .. }) {
                 let _ = msg_tx.send(Message::EventPublished {
                     result: Err(String::from(

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -151,11 +151,12 @@ impl NostrEvents {
                     },
                     None => Err(String::from("cannot send events in read-only mode")),
                 };
-                if let Err(e) = result {
-                    let _ = msg_tx.send(Message::Error {
-                        error: CommandError::SendEventFailed { error: e },
-                    });
-                }
+                // Reported either way: the application shows a publish as pending until
+                // this arrives, so a success that says nothing would leave it pending
+                // forever.
+                let _ = msg_tx.send(Message::EventPublished {
+                    result: result.map_err(|error| CommandError::SendEventFailed { error }),
+                });
             }
             NostrCommand::AddRelay { url } => {
                 if let Err(e) = client.add_relay(&url).await {

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -413,14 +413,28 @@ impl NostrEvents {
         // entry per submitted event and settles them in report order, so a publish that
         // simply vanished here would sit as "Sending" forever and shift every later
         // outcome onto the wrong submission.
+        let mut shutdown_requested = false;
+
         while let Some(cmd) = cmd_rx.recv().await {
-            if matches!(cmd, NostrCommand::SendEventBuilder { .. }) {
-                let _ = msg_tx.send(Message::EventPublished {
-                    result: Err(String::from(
-                        "the connection closed before the event was sent",
-                    )),
-                });
+            match cmd {
+                NostrCommand::SendEventBuilder { .. } => {
+                    let _ = msg_tx.send(Message::EventPublished {
+                        result: Err(String::from(
+                            "the connection closed before the event was sent",
+                        )),
+                    });
+                }
+                // Queued behind whatever ended the loop — the notification stream can end
+                // in the same window as a user-initiated disconnect. Dropping it would
+                // leave the shared client connected to every relay, and tears hands that
+                // same `Arc<Client>` to the worker it starts next.
+                NostrCommand::Shutdown => shutdown_requested = true,
+                _ => {}
             }
+        }
+
+        if shutdown_requested {
+            client.disconnect().await;
         }
     }
 }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -345,6 +345,9 @@ impl NostrEvents {
         msg_tx: mpsc::UnboundedSender<Message>,
         mut cmd_rx: mpsc::UnboundedReceiver<NostrCommand>,
     ) {
+        // Set by either route out of the loop below, and acted on once after the drain.
+        let mut shutdown_requested = false;
+
         // Initialize the home feed subscription
         let mut notifications =
             Self::initialize_home_feed(&client, pubkey, Arc::clone(&contact_list_cache), &msg_tx)
@@ -371,8 +374,10 @@ impl NostrEvents {
                 cmd = cmd_rx.recv() => {
                     match cmd {
                         Some(NostrCommand::Shutdown) => {
-                            // Disconnect from all relays and exit
-                            client.disconnect().await;
+                            // Recorded rather than acted on here, so the disconnect has a
+                            // single site below. Draining first also means the publishes
+                            // queued behind this are reported before the relays go.
+                            shutdown_requested = true;
                             break;
                         }
                         // Awaited inline on purpose, and load-bearing: the application
@@ -413,8 +418,6 @@ impl NostrEvents {
         // entry per submitted event and settles them in report order, so a publish that
         // simply vanished here would sit as "Sending" forever and shift every later
         // outcome onto the wrong submission.
-        let mut shutdown_requested = false;
-
         while let Some(cmd) = cmd_rx.recv().await {
             match cmd {
                 NostrCommand::SendEventBuilder { .. } => {

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -24,6 +24,13 @@ pub enum Message {
         since: Timestamp,
     },
     ConnectionClosed,
+    /// The worker went away without being asked to.
+    ///
+    /// Distinct from [`Message::ConnectionClosed`], which is what nostui sends when it
+    /// is closing the connection on purpose and the tracked subscriptions are genuinely
+    /// finished. Here the tabs are still open and their subscription ids are still what
+    /// a replacement worker would need to unsubscribe from, so they are kept.
+    ConnectionLost,
 }
 
 /// Follow-up effect the application must dispatch after a [`Nostr`] update.
@@ -131,6 +138,11 @@ impl Nostr {
                 } else {
                     None
                 }
+            }
+            Message::ConnectionLost => {
+                self.connected = false;
+                // No command: the worker this would be addressed to is the one that left.
+                None
             }
             Message::ConnectionClosed => {
                 let was_connected = self.connected;

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -62,6 +62,12 @@ pub enum Message {
     Notification(Box<ClientNotification>),
     /// An error occurred during command execution
     Error { error: CommandError },
+    /// The outcome of one `SendEventBuilder`.
+    ///
+    /// Reported exactly once per submitted event, in submission order: the worker
+    /// awaits each command inline, so it neither starts the next publish nor reports
+    /// out of order.
+    EventPublished { result: Result<(), CommandError> },
     /// A subscription was created for a specific tab
     SubscriptionCreated {
         feed: FeedKind,

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -67,7 +67,7 @@ pub enum Message {
     /// Reported exactly once per submitted event, in submission order: the worker
     /// awaits each command inline, so it neither starts the next publish nor reports
     /// out of order.
-    EventPublished { result: Result<(), CommandError> },
+    EventPublished { result: Result<(), String> },
     /// A subscription was created for a specific tab
     SubscriptionCreated {
         feed: FeedKind,

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -41,8 +41,6 @@ pub enum NostrCommand {
 /// Errors that can occur during command execution
 #[derive(Debug, Clone)]
 pub enum CommandError {
-    /// Failed to send event to relays
-    SendEventFailed { error: String },
     /// Failed to add relay
     AddRelayFailed { url: String, error: String },
     /// Failed to connect to relay

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -24,15 +24,6 @@ impl StatusBar {
         format!("[{label}] {normalized_message}")
     }
 
-    /// Whether the bar is still showing exactly this label and message.
-    ///
-    /// Asked rather than reconstructed on purpose: a caller that rebuilt the rendered
-    /// string itself would keep comparing against the old shape the day this rendering
-    /// changes, and would simply stop matching instead of failing.
-    pub fn shows(&self, label: &str, message: &str) -> bool {
-        self.message.as_deref() == Some(Self::render(label, message).as_str())
-    }
-
     pub fn update(&mut self, message: Message) {
         match message {
             Message::MessageChanged { label, message } => self.set_message(label, message),
@@ -49,35 +40,6 @@ impl StatusBar {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn shows_agrees_with_what_was_set() {
-        let mut status_bar = StatusBar::default();
-        status_bar.update(Message::MessageChanged {
-            label: "Sending".to_string(),
-            message: "line one\nline two".to_string(),
-        });
-
-        // Asked with the original message, newlines and all. This pairing is the whole
-        // point of `shows`: a caller that rebuilt the rendered string itself would have
-        // to normalise identically, and would quietly stop matching if this did not.
-        assert!(status_bar.shows("Sending", "line one\nline two"));
-        assert!(!status_bar.shows("Sending", "something else"));
-        assert!(!status_bar.shows("Posted", "line one\nline two"));
-    }
-
-    #[test]
-    fn shows_does_not_match_an_error_with_the_same_text() {
-        let mut status_bar = StatusBar::default();
-        status_bar.update(Message::ErrorMessageChanged {
-            label: "Sending".to_string(),
-            message: "hi".to_string(),
-        });
-
-        // Errors render as `ERR: label`, so this is a different line and must not read
-        // as the pending one still standing.
-        assert!(!status_bar.shows("Sending", "hi"));
-    }
 
     #[test]
     fn test_message_getter() {

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -16,8 +16,21 @@ impl StatusBar {
     }
 
     fn set_message(&mut self, label: String, message: String) {
+        self.message = Some(Self::render(&label, &message));
+    }
+
+    fn render(label: &str, message: &str) -> String {
         let normalized_message = message.replace("\n", " ");
-        self.message = Some(format!("[{label}] {normalized_message}"));
+        format!("[{label}] {normalized_message}")
+    }
+
+    /// Whether the bar is still showing exactly this label and message.
+    ///
+    /// Asked rather than reconstructed on purpose: a caller that rebuilt the rendered
+    /// string itself would keep comparing against the old shape the day this rendering
+    /// changes, and would simply stop matching instead of failing.
+    pub fn shows(&self, label: &str, message: &str) -> bool {
+        self.message.as_deref() == Some(Self::render(label, message).as_str())
     }
 
     pub fn update(&mut self, message: Message) {
@@ -36,6 +49,35 @@ impl StatusBar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shows_agrees_with_what_was_set() {
+        let mut status_bar = StatusBar::default();
+        status_bar.update(Message::MessageChanged {
+            label: "Sending".to_string(),
+            message: "line one\nline two".to_string(),
+        });
+
+        // Asked with the original message, newlines and all. This pairing is the whole
+        // point of `shows`: a caller that rebuilt the rendered string itself would have
+        // to normalise identically, and would quietly stop matching if this did not.
+        assert!(status_bar.shows("Sending", "line one\nline two"));
+        assert!(!status_bar.shows("Sending", "something else"));
+        assert!(!status_bar.shows("Posted", "line one\nline two"));
+    }
+
+    #[test]
+    fn shows_does_not_match_an_error_with_the_same_text() {
+        let mut status_bar = StatusBar::default();
+        status_bar.update(Message::ErrorMessageChanged {
+            label: "Sending".to_string(),
+            message: "hi".to_string(),
+        });
+
+        // Errors render as `ERR: label`, so this is a different line and must not read
+        // as the pending one still standing.
+        assert!(!status_bar.shows("Sending", "hi"));
+    }
 
     #[test]
     fn test_message_getter() {

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -16,12 +16,8 @@ impl StatusBar {
     }
 
     fn set_message(&mut self, label: String, message: String) {
-        self.message = Some(Self::render(&label, &message));
-    }
-
-    fn render(label: &str, message: &str) -> String {
         let normalized_message = message.replace("\n", " ");
-        format!("[{label}] {normalized_message}")
+        self.message = Some(format!("[{label}] {normalized_message}"));
     }
 
     pub fn update(&mut self, message: Message) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -447,6 +447,9 @@ impl<'a> TearsApp<'a> {
                 feed,
                 subscription_id,
             } => self.state.track_subscription_created(feed, subscription_id),
+            NostrSubscriptionMessage::EventPublished { result } => {
+                self.state.resolve_publish(result)
+            }
             NostrSubscriptionMessage::Notification(notif) => match *notif {
                 // NOTE: We use `RelayPoolNotification::Message` instead of `RelayPoolNotification::Event`
                 // because:

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -209,9 +209,9 @@ impl<'a> TearsApp<'a> {
                 // What the send is not safe from is the exit itself. The quit applies
                 // synchronously on tears 0.11, so `run` can return while the worker — a
                 // detached task the runtime neither owns nor joins — is still publishing,
-                // and the tokio runtime is dropped moments later. The status bar has
-                // already said "Posted" by then. #511 covers making that claim honest, and
-                // #512 covers giving the send a chance to land.
+                // and the tokio runtime is dropped moments later. The status bar says
+                // "Sending" at that point rather than claiming success, so the user is at
+                // least not told it worked; #512 covers giving the send a chance to land.
                 let _ = self.state.close_connection();
 
                 Command::quit()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,8 +60,10 @@ impl<'a> Application for TearsApp<'a> {
         // Store config separately for keybindings access
         let config = flags.config.clone();
 
-        // Initialize global state
-        let state = AppState::new_with_config(flags.pubkey, flags.config);
+        // Initialize global state. Without signing keys the application is read-only, and
+        // it needs to know that before a publish is queued rather than after.
+        let read_only = flags.keys.is_none();
+        let state = AppState::new_with_config(flags.pubkey, flags.config, read_only);
 
         // Initialize components
         let components = Components::new();


### PR DESCRIPTION
Closes #511.

## The bug

Three paths published events and immediately claimed success:

| site | status shown at enqueue |
| --- | --- |
| `submit_note` | `[Posted] <content>` |
| `react_to_selected` / `repost_selected` | `[Reacted] <id>` / `[Reposted] <id>` |
| `publish_music_status` (NIP-38, fires on every track change) | `[Music] <track>` |

All three set that status at the moment the command was pushed onto the worker's channel. Nothing had reached a relay yet.

The worst case is not a race. `model::nostr` returns `None` for `EventSubmitted` while disconnected, so the command was **dropped outright** — and the status still said the note was posted. Same for a submission made before the worker is ready. No error was ever shown, because the only failure report came from a code path that never ran.

The near-miss case was a real race: the send fails, the generic `Message::Error` path overwrites the status with an error. Correct by accident, and only because the error happened to arrive.

## The fix

A publish is now pending until a relay answers.

- On submit, the status bar shows `[Sending] <content>` — same content, honest verb.
- On success, it settles to the past-tense label it always showed: `[Posted] hi`, `[Reacted] npub…`. The happy-path text is unchanged.
- On failure it settles as `[ERR: Send] …` instead of leaving an optimistic message for something else to overwrite.
- If the submission never reaches the worker — disconnected, or no worker yet — it settles **immediately** as `[ERR: <label>] not connected`, because no report will ever arrive for it and a pending entry that can never be popped would desynchronise every later publish.

The worker reports success as well as failure, over a new `EventPublished { result }` message rather than the generic `Error` one, so a success is distinguishable from silence.

**Outcomes are matched to submissions positionally, not by id.** The worker awaits `handle_command` inline inside its `select!` arm, so it never starts a second publish while one is in flight, and it reports every `SendEventBuilder` exactly once. Reports therefore arrive in the order entries were queued, and a `VecDeque` matches them without threading a correlation id through four layers. `publishes_settle_in_submission_order` pins that.

`dispatch_nostr` now returns whether it actually handed the command off. That is what distinguishes "waiting for a relay" from "this will never be answered".

## What this does not fix

Quitting immediately after publishing can still lose the send — the runtime is dropped moments later and takes the worker with it. That is **#512**, and this PR is its prerequisite: with outcomes now reported, the drain-then-quit shape the tears migration guide recommends becomes expressible, which is a better fix than the `main`-side lock wait #512 currently records.

## Tests

Five tests asserted the old optimistic status; they now assert the pending state *and* the settled state, so the happy-path text is still pinned. Note that four of them were passing while entirely disconnected — they were encoding the bug.

New coverage:

- `publish_failure_reports_an_error_instead_of_success`
- `publishing_while_disconnected_does_not_claim_success` — the case that was silently wrong
- `publishes_settle_in_submission_order` — two outstanding at once
- `an_unmatched_publish_outcome_is_ignored` — a stray outcome must not report success against whatever is on screen

`just fmt`, `just lint`, `just test` pass (377 + 3 + 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi