### PR TITLE
build: run typos as part of just lint

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ build:
   cargo build --all-features --workspace
 
 lint:
+  typos
   cargo clippy --all-targets --all-features --workspace -- -D warnings
 
 test:


### PR DESCRIPTION
## Why

CI runs six jobs; `just` covered five of them. There was no local equivalent of the **Spell Check with Typos** job, so `just fmt && just lint && just test` passing read as "CI will pass" when it did not check spelling at all.

That gap was not theoretical: #513 carried a typo in a test name (`a_success_does_not_wipe_another_publishs_failure`) through ten rounds of local verification, and it was only caught when CI ran.

## What

```diff
 lint:
+  typos
   cargo clippy --all-targets --all-features --workspace -- -D warnings
```

Before clippy on purpose: `typos` takes about five seconds against clippy's forty-five, and a `just` recipe stops at the first failing line — so a typo is reported straight away rather than after a full lint run.

## Notes

- Needs the `typos` binary locally (`cargo install typos-cli`). CI is untouched and keeps using the `crate-ci/typos` action, so the two cannot drift on version-specific behaviour in a way that matters — both read the repo's `_typos.toml`.
- Verified both directions: `just lint` passes on `main` as-is, and fails with `error: \`teh\` should be \`the\`` when a typo is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi