### PR TITLE
fix: do not report a publish as done until a relay says so

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -395,9 +395,15 @@ impl<'a> AppState<'a> {
             id: None,
             event_builder,
         });
-        let _ = self.dispatch_nostr(outcome);
 
-        self.set_status(PublishKind::MusicStatus.settled_label(), content);
+        // Only once it is on its way. #521 keeps a relay refusing this quiet, but "never
+        // handed over at all" is a different thing — a track change before the worker is
+        // ready, or after it has gone — and announcing it then would be the same false
+        // claim this change removes everywhere else. The line still means "attempted",
+        // not "accepted"; that is what #521 is for.
+        if self.dispatch_nostr(outcome) {
+            self.set_status(PublishKind::MusicStatus.settled_label(), content);
+        }
 
         Command::none()
     }
@@ -1283,6 +1289,18 @@ mod tests {
         // line reports what nostui attempted, as it always has (#521).
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn an_undispatched_music_status_is_not_announced() {
+        // Not connected, so the command is declined before it reaches the worker.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // #521 keeps a relay refusing this quiet, but "never handed over" is a different
+        // thing — announcing it would be the same false claim removed everywhere else.
+        assert_eq!(state.status_bar.message(), None);
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -292,7 +292,7 @@ impl<'a> AppState<'a> {
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
         if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not connected");
+            self.abandon_publish(id, "not sent");
         }
 
         Command::none()
@@ -342,7 +342,7 @@ impl<'a> AppState<'a> {
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
         if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not connected");
+            self.abandon_publish(id, "not sent");
         }
 
         // Clear UI state.
@@ -367,7 +367,7 @@ impl<'a> AppState<'a> {
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
         if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not connected");
+            self.abandon_publish(id, "not sent");
         }
 
         Command::none()
@@ -429,6 +429,10 @@ impl<'a> AppState<'a> {
         self.next_publish_id = self.next_publish_id.wrapping_add(1);
         let message = message.into();
 
+        // Nothing expires this. A worker that dies without reaching its exit drain — a
+        // panic, an abort — never reports, so the entry stays and the bar reads "Sending"
+        // for the life of the process. Recovering needs the application to notice the
+        // worker died, which it cannot do today: #519.
         self.pending_publishes.insert(
             id,
             PendingPublish {
@@ -455,6 +459,11 @@ impl<'a> AppState<'a> {
             return Command::none();
         };
 
+        // Both arms write the bar whatever is on it. An answer can arrive a full ack
+        // timeout after the submit, so this can land over a status the user has caused
+        // since — a tab they opened while waiting. Deciding who may write over whom is
+        // #516; doing it here would be the arbitration policy growing a case at a time,
+        // which is what that issue exists to stop.
         match result {
             Ok(()) => self.set_status(pending.settled_label, pending.message),
             Err(reason) => {
@@ -472,6 +481,11 @@ impl<'a> AppState<'a> {
     }
 
     /// Give up on a publish that was never handed over, so it does not sit as "Sending".
+    ///
+    /// The reason stays vague on purpose. A dispatch fails because the gateway declined
+    /// it, because no worker is listening yet, or because the worker died — and this
+    /// layer cannot tell those apart, so naming one would sometimes hide a dead worker
+    /// behind "not connected" (#519). The distinction is in the log.
     fn abandon_publish(&mut self, id: PublishId, reason: &str) {
         let Some(pending) = self.pending_publishes.remove(&id) else {
             return;
@@ -1346,7 +1360,7 @@ mod tests {
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] not connected (Song - Artist)")
+            Some("[ERR: Music] not sent (Song - Artist)")
         );
         assert!(state.pending_publishes.is_empty());
     }
@@ -1569,7 +1583,8 @@ mod tests {
     fn test_notify_subscription_error_sets_error_status() {
         let mut state = AppState::new(Keys::generate().public_key());
 
-        let _ = state.notify_subscription_error(CommandError::SendEventFailed {
+        let _ = state.notify_subscription_error(CommandError::AddRelayFailed {
+            url: String::from("wss://relay.example"),
             error: "x".to_owned(),
         });
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -435,6 +435,11 @@ impl<'a> AppState<'a> {
     /// to send; the application owns the sender and performs the actual I/O.
     fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
+            // The gateway declined it, which it does whenever it believes it is not
+            // connected. Logged because this is the likeliest of the three ways a
+            // dispatch fails, and the status bar deliberately does not name a cause it
+            // cannot establish — leaving this silent would put the reason nowhere.
+            log::warn!("Nostr command declined: not connected");
             return false;
         };
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -465,9 +465,11 @@ impl<'a> AppState<'a> {
         let message = message.into();
 
         // Nothing expires this. A worker that dies without reaching its exit drain — a
-        // panic, an abort — never reports, so the entry stays and the bar reads "Sending"
-        // for the life of the process. Recovering needs the application to notice the
-        // worker died, which it cannot do today: #519.
+        // panic, an abort — never reports whatever was in flight, so that one entry stays
+        // and the bar reads "Sending" until something else writes it. It is one entry,
+        // not a leak: every later publish finds the channel closed, so `abandon_publish`
+        // settles it. Clearing the stranded one needs the application to notice the worker
+        // died, which it cannot do today: #519.
         self.pending_publishes.insert(
             id,
             PendingPublish {
@@ -1423,6 +1425,24 @@ mod tests {
             Some("[ERR: Music] not sent (Song - Artist)")
         );
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn the_dispatched_command_carries_the_id_the_publish_is_tracked_under() {
+        let (mut state, mut rx) = connected_state();
+        while rx.try_recv().is_ok() {}
+
+        let _ = state.publish_music_status(create_track("Song"));
+        let tracked = only_pending(&state);
+
+        let Ok(NostrCommand::SendEventBuilder { id: sent, .. }) = rx.try_recv() else {
+            panic!("a publish should have been dispatched");
+        };
+
+        // The two halves of the correlation. If they ever disagree, no report can find
+        // its submission and every publish strands on "Sending" — silently, since each
+        // half is individually plausible.
+        assert_eq!(sent, tracked);
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -490,7 +490,8 @@ impl<'a> AppState<'a> {
         result: Result<(), String>,
     ) -> Command<AppMsg> {
         let Some(pending) = self.pending_publishes.remove(&id) else {
-            log::warn!("Publish outcome for an unknown submission: {result:?}");
+            // The id is the only thing that says which submission this was meant for.
+            log::warn!("Publish outcome for an unknown submission {id:?}: {result:?}");
             return Command::none();
         };
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -72,6 +72,8 @@ pub struct AppState<'a> {
     pending_publishes: HashMap<PublishId, PendingPublish>,
     /// Source of [`PublishId`]s, monotonic for the life of the application.
     next_publish_id: u64,
+    /// Whether the configured key can only read — an `npub` rather than a signing key.
+    read_only: bool,
 }
 
 /// What is being published, which decides how the status bar names it.
@@ -139,10 +141,15 @@ impl<'a> AppState<'a> {
     }
 
     /// Initialize AppState with the specified public key and config
-    pub fn new_with_config(current_user_pubkey: PublicKey, config: Config) -> Self {
+    pub fn new_with_config(
+        current_user_pubkey: PublicKey,
+        config: Config,
+        read_only: bool,
+    ) -> Self {
         Self {
             user: UserState::new_with_pubkey(current_user_pubkey),
             config: ConfigState { config },
+            read_only,
             ..Default::default()
         }
     }
@@ -382,6 +389,14 @@ impl<'a> AppState<'a> {
             return Command::none();
         };
 
+        // Nothing to broadcast a status with. Every send would fail in the worker, and
+        // #521 keeps that off the bar — so attempting it would mean a guaranteed failure,
+        // on every track change, that the user is never told about. The feature needs a
+        // signing key; without one it simply does not run.
+        if self.read_only {
+            return Command::none();
+        }
+
         let content = status.content();
         let event_builder = status.live_status_builder();
 
@@ -487,18 +502,20 @@ impl<'a> AppState<'a> {
     /// because until then nothing has been published — the command only sits on the
     /// worker's queue. [`Self::resolve_publish`] supplies the ending.
     ///
-    /// A submission that never reaches the worker settles here instead, since no report
-    /// will ever arrive for it.
+    /// A submission that never reaches the worker has to be settled instead, since no
+    /// report will arrive for it — [`Self::publish`] does that, which is why the two are
+    /// not called separately.
     fn begin_publish(&mut self, kind: PublishKind, message: impl Into<String>) -> PublishId {
         let id = PublishId(self.next_publish_id);
         self.next_publish_id = self.next_publish_id.wrapping_add(1);
         let message = message.into();
 
         // Nothing expires this. A worker that dies without reaching its exit drain — a
-        // panic, an abort — never reports whatever was in flight, so that one entry stays
-        // and the bar reads "Sending" until something else writes it. It is one entry,
-        // not a leak: every later publish finds the channel closed, so `abandon_publish`
-        // settles it. Clearing the stranded one needs the application to notice the worker
+        // panic, an abort at quit — reports none of what it was holding, so every entry
+        // outstanding at that moment stays and reads "Sending" until something else
+        // writes the bar. Publishes issued *after* the death do settle themselves, since
+        // they find the channel closed; it is the ones already tracked that strand, and
+        // there can be several. Clearing them needs the application to notice the worker
         // died, which it cannot do today: #519.
         self.pending_publishes.insert(
             id,
@@ -1289,6 +1306,24 @@ mod tests {
         // line reports what nostui attempted, as it always has (#521).
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
         assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn read_only_mode_does_not_broadcast_a_music_status() {
+        // An `npub` configuration: connected, but with no key to sign with.
+        let mut state =
+            AppState::new_with_config(Keys::generate().public_key(), Config::default(), true);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+        while rx.try_recv().is_ok() {}
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // Every send would fail in the worker, and #521 keeps that off the bar — so
+        // attempting it would be a guaranteed failure, on every track change, that the
+        // user is never told about.
+        assert!(rx.try_recv().is_err());
+        assert_eq!(state.status_bar.message(), Some("[Home] loading..."));
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -456,7 +456,7 @@ impl<'a> AppState<'a> {
             .update(NostrMessage::EventSubmitted { id, event_builder });
 
         if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not sent");
+            self.abandon_publish(id);
         }
     }
 
@@ -529,27 +529,25 @@ impl<'a> AppState<'a> {
 
     /// Give up on a publish that was never handed over, so it does not sit as "Sending".
     ///
-    /// The reason stays vague on purpose. A dispatch fails because the gateway declined
-    /// it, because no worker is listening yet, or because the worker died — and this
-    /// layer cannot tell those apart, so naming one would sometimes hide a dead worker
-    /// behind "not connected" (#519). The distinction is in the log.
-    fn abandon_publish(&mut self, id: PublishId, reason: &str) {
+    /// The cause is what the gateway believes, which is the most this layer can honestly
+    /// say: a dispatch fails either because the gateway knows it is not connected, or
+    /// because it thinks it is and the worker turned out to be gone. Both are worth
+    /// telling the user, and neither claims more than is known.
+    fn abandon_publish(&mut self, id: PublishId) {
         let Some(pending) = self.pending_publishes.remove(&id) else {
             return;
         };
 
-        // The gateway's own belief is the closest thing to a cause available here, and
-        // the status bar deliberately does not name one it cannot establish — so this is
-        // where the distinction has to live.
         let cause = if self.nostr.is_ready() {
-            "no worker to send it to"
+            "connection lost"
         } else {
             "not connected"
         };
+
         log::error!("Publish not sent, {cause}: {}", pending.message);
         self.set_status_error(
             pending.kind.subject(),
-            format!("{reason} ({})", pending.message),
+            format!("{cause} ({})", pending.message),
         );
     }
 
@@ -1439,9 +1437,11 @@ mod tests {
 
         let _ = state.publish_music_status(create_track("Song"));
 
+        // The gateway still believed it was connected, so this is a lost connection
+        // rather than never having had one — the two are worth telling apart.
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] not sent (Song - Artist)")
+            Some("[ERR: Music] connection lost (Song - Artist)")
         );
 
         // Nothing is left tracking it. An entry here would sit on "Sending" for good,
@@ -1459,7 +1459,7 @@ mod tests {
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] not sent (Song - Artist)")
+            Some("[ERR: Music] not connected (Song - Artist)")
         );
         assert!(state.pending_publishes.is_empty());
     }

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -392,44 +392,38 @@ impl<'a> AppState<'a> {
         Command::none()
     }
 
-    /// Publish a NIP-38 live status event for the currently playing track and
-    /// show it in the status bar. No-op when the track is missing the fields
-    /// required to build a status.
+    /// Show the currently playing track, and broadcast it as a NIP-38 live status.
+    /// No-op when the track is missing the fields required to build a status.
+    ///
+    /// The two halves are independent on purpose. The line says what is playing, which
+    /// is true whether or not a relay ever hears about it; tying it to the broadcast
+    /// would take the indicator away from anyone in read-only mode, and from anyone
+    /// whose track changes before the worker is ready.
     pub fn publish_music_status(&mut self, track: Track) -> Command<AppMsg> {
         let Some(status) = MusicStatus::new(track) else {
             return Command::none();
         };
 
-        // Nothing to broadcast a status with, and unlike the publishes above there is
-        // nobody to tell: #521 keeps a music failure off the bar, so attempting it would
-        // mean a guaranteed failure on every track change that the user never sees. The
-        // feature needs a signing key; without one it simply does not run.
+        self.set_status(NOW_PLAYING_LABEL, status.content());
+
+        // Broadcasting needs a key to sign with. Without one every send fails in the
+        // worker, and #521 keeps that off the bar — so it would be a guaranteed failure,
+        // on every track change, that the user is never told about.
         if self.read_only {
             return Command::none();
         }
-
-        let content = status.content();
-        let event_builder = status.live_status_builder();
 
         // Deliberately not tracked as a publish. Confirmation exists so the user is not
         // told their own action succeeded when it did not; a NIP-38 status is fired by a
         // track change, not by them, and there is nothing for them to do about a relay
         // refusing it. Routing it through the pending path would put an error on the bar
         // on every track change — many relays reject kind 30315 — for something they
-        // never asked for. The line stays what it was: what nostui attempted. #521.
+        // never asked for. Whether the line should say more than "playing" is #521.
         let outcome = self.nostr.update(NostrMessage::EventSubmitted {
             id: None,
-            event_builder,
+            event_builder: status.live_status_builder(),
         });
-
-        // Only once it is on its way. #521 keeps a relay refusing this quiet, but "never
-        // handed over at all" is a different thing — a track change before the worker is
-        // ready, or after it has gone — and announcing it then would be the same false
-        // claim this change removes everywhere else. The line still means "attempted",
-        // not "accepted"; that is what #521 is for.
-        if self.dispatch_nostr(outcome) {
-            self.set_status(NOW_PLAYING_LABEL, content);
-        }
+        let _ = self.dispatch_nostr(outcome);
 
         Command::none()
     }
@@ -1377,23 +1371,27 @@ mod tests {
 
         let _ = state.publish_music_status(create_track("Song"));
 
-        // Every send would fail in the worker, and #521 keeps that off the bar — so
-        // attempting it would be a guaranteed failure, on every track change, that the
-        // user is never told about.
+        // Nothing is sent: every send would fail in the worker, and #521 keeps that off
+        // the bar, so it would be a guaranteed failure the user never sees.
         assert!(rx.try_recv().is_err());
-        assert_eq!(state.status_bar.message(), Some("[Home] loading..."));
+
+        // The indicator is not a casualty of that. It says what is playing, which is as
+        // true without a signing key as with one.
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
     }
 
     #[test]
-    fn an_undispatched_music_status_is_not_announced() {
-        // Not connected, so the command is declined before it reaches the worker.
+    fn the_now_playing_line_does_not_depend_on_reaching_a_relay() {
+        // Not connected, so the broadcast is declined before it reaches the worker.
         let mut state = AppState::new(Keys::generate().public_key());
 
         let _ = state.publish_music_status(create_track("Song"));
 
-        // #521 keeps a relay refusing this quiet, but "never handed over" is a different
-        // thing — announcing it would be the same false claim removed everywhere else.
-        assert_eq!(state.status_bar.message(), None);
+        // The line says what is playing, which is true either way. Tying it to the
+        // broadcast would take the indicator away whenever a track changes before the
+        // worker is ready — likely at startup, since the two come up independently.
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        assert!(state.pending_publishes.is_empty());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -329,7 +329,7 @@ impl<'a> AppState<'a> {
         let event_builder = build(note);
         log::info!("{} event: {note_id}", kind.subject());
 
-        self.publish(kind, note_id, event_builder);
+        let _ = self.publish(kind, note_id, event_builder);
 
         Command::none()
     }
@@ -373,10 +373,13 @@ impl<'a> AppState<'a> {
             EventBuilder::new(Kind::TextNote, &content)
         };
 
-        self.publish(PublishKind::Note, &content, event_builder);
-
-        // Clear UI state.
-        self.editor.update(EditorMessage::ComposingCanceled);
+        // Only discard the draft once it is actually on its way. Closing the editor
+        // loses the text for good — the next `ComposingStarted` clears the buffer — and
+        // this change is what makes a pre-send failure knowable in time to keep it. A
+        // failure the relays report later still loses it: #514.
+        if self.publish(PublishKind::Note, &content, event_builder) {
+            self.editor.update(EditorMessage::ComposingCanceled);
+        }
 
         Command::none()
     }
@@ -479,12 +482,15 @@ impl<'a> AppState<'a> {
     /// The three steps live together because they only make sense together — a tracked
     /// publish that was never dispatched sits on "Sending" for good, and a dispatch with
     /// nothing tracking it can never be settled by its report.
+    ///
+    /// Returns whether it is on its way. `false` means it already failed, and a caller
+    /// about to discard what it published — the editor's buffer — should keep it.
     fn publish(
         &mut self,
         kind: PublishKind,
         message: impl Into<String>,
         event_builder: EventBuilder,
-    ) {
+    ) -> bool {
         let id = self.begin_publish(kind, message);
         let outcome = self.nostr.update(NostrMessage::EventSubmitted {
             id: Some(id),
@@ -493,7 +499,10 @@ impl<'a> AppState<'a> {
 
         if !self.dispatch_nostr(outcome) {
             self.abandon_publish(id);
+            return false;
         }
+
+        true
     }
 
     /// Hand a submitted event to the worker and show it as pending.
@@ -1488,6 +1497,38 @@ mod tests {
             message.starts_with("[ERR: Reaction] no relay accepted") && message.contains(&note_id),
             "expected the reason and the content, got: {message}"
         );
+    }
+
+    #[test]
+    fn a_submission_that_fails_before_it_is_sent_keeps_the_draft() {
+        // Not connected, so the failure is known before the command is queued.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        // Closing the editor loses the text for good: the next `ComposingStarted` clears
+        // the buffer, so there is no way back to it.
+        assert!(state.editor.is_active());
+        assert_eq!(state.editor.get_content(), "h");
+    }
+
+    #[test]
+    fn a_submission_that_is_on_its_way_closes_the_editor() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        assert!(!state.editor.is_active());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -79,7 +79,15 @@ pub struct AppState<'a> {
     read_only: bool,
 }
 
-/// What is being published, which decides how the status bar names it.
+/// Status-bar label for the now-playing line.
+///
+/// Deliberately not a [`PublishKind`]: it names what is playing, not what a relay took.
+/// Borrowing the past-tense vocabulary would make an unconfirmed line read exactly like a
+/// confirmed one, which is the ambiguity the rest of this removes. #521 covers whether
+/// the wording itself should change.
+const NOW_PLAYING_LABEL: &str = "Music";
+
+/// What the user is publishing, which decides how the status bar names it.
 ///
 /// One value rather than a pair of labels: a publish that failed must not be described
 /// with the word for one that succeeded, and passing "Posted" and "Note" separately
@@ -89,7 +97,6 @@ enum PublishKind {
     Note,
     Reaction,
     Repost,
-    MusicStatus,
 }
 
 impl PublishKind {
@@ -100,7 +107,6 @@ impl PublishKind {
             Self::Note => "Posted",
             Self::Reaction => "Reacted",
             Self::Repost => "Reposted",
-            Self::MusicStatus => "Music",
         }
     }
 
@@ -111,7 +117,6 @@ impl PublishKind {
             Self::Note => "Note",
             Self::Reaction => "Reaction",
             Self::Repost => "Repost",
-            Self::MusicStatus => "Music",
         }
     }
 }
@@ -423,7 +428,7 @@ impl<'a> AppState<'a> {
         // claim this change removes everywhere else. The line still means "attempted",
         // not "accepted"; that is what #521 is for.
         if self.dispatch_nostr(outcome) {
-            self.set_status(PublishKind::MusicStatus.settled_label(), content);
+            self.set_status(NOW_PLAYING_LABEL, content);
         }
 
         Command::none()
@@ -1532,13 +1537,13 @@ mod tests {
         let _ = state.resolve_publish(
             id,
             Err(String::from(
-                "no relay accepted the event: wss://relay.example: blocked",
+                "no relay confirmed the event: wss://relay.example: blocked",
             )),
         );
 
         let message = state.status_bar.message().expect("a status message");
         assert!(
-            message.starts_with("[ERR: Reaction] no relay accepted") && message.contains(&note_id),
+            message.starts_with("[ERR: Reaction] no relay confirmed") && message.contains(&note_id),
             "expected the reason and the content, got: {message}"
         );
     }

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1430,6 +1430,26 @@ mod tests {
     }
 
     #[test]
+    fn a_publish_is_settled_when_the_worker_has_gone() {
+        let (mut state, rx) = connected_state();
+
+        // The gateway still believes it is connected — this is the other way a dispatch
+        // fails, and the one the disconnected test cannot reach.
+        drop(rx);
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Music] not sent (Song - Artist)")
+        );
+
+        // Nothing is left tracking it. An entry here would sit on "Sending" for good,
+        // since the worker that would have reported it is the one that went away.
+        assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
     fn publishing_while_disconnected_does_not_claim_success() {
         // Not connected: `model::nostr` declines the submission, so nothing is queued and
         // no outcome will ever arrive to settle it.

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -385,7 +385,19 @@ impl<'a> AppState<'a> {
         let content = status.content();
         let event_builder = status.live_status_builder();
 
-        self.publish(PublishKind::MusicStatus, &content, event_builder);
+        // Deliberately not tracked as a publish. Confirmation exists so the user is not
+        // told their own action succeeded when it did not; a NIP-38 status is fired by a
+        // track change, not by them, and there is nothing for them to do about a relay
+        // refusing it. Routing it through the pending path would put an error on the bar
+        // on every track change — many relays reject kind 30315 — for something they
+        // never asked for. The line stays what it was: what nostui attempted. #521.
+        let outcome = self.nostr.update(NostrMessage::EventSubmitted {
+            id: None,
+            event_builder,
+        });
+        let _ = self.dispatch_nostr(outcome);
+
+        self.set_status(PublishKind::MusicStatus.settled_label(), content);
 
         Command::none()
     }
@@ -415,6 +427,8 @@ impl<'a> AppState<'a> {
     ///
     /// `model::nostr::update` is side-effect free and only reports the command
     /// to send; the application owns the sender and performs the actual I/O.
+    #[must_use = "a command that never reached the worker will never be reported, and a \
+                  publish left tracking it sits on \"Sending\" for good"]
     fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
             // Not logged. Most `None`s are ordinary — `ConnectionReady` and
@@ -451,9 +465,10 @@ impl<'a> AppState<'a> {
         event_builder: EventBuilder,
     ) {
         let id = self.begin_publish(kind, message);
-        let outcome = self
-            .nostr
-            .update(NostrMessage::EventSubmitted { id, event_builder });
+        let outcome = self.nostr.update(NostrMessage::EventSubmitted {
+            id: Some(id),
+            event_builder,
+        });
 
         if !self.dispatch_nostr(outcome) {
             self.abandon_publish(id);
@@ -1263,13 +1278,11 @@ mod tests {
         let (mut state, _rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
-        let id = only_pending(&state);
 
-        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
-
-        let _ = state.resolve_publish(id, Ok(()));
-
+        // Not tracked as a publish: a track change is not something the user did, so the
+        // line reports what nostui attempted, as it always has (#521).
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        assert!(state.pending_publishes.is_empty());
     }
 
     #[test]
@@ -1374,6 +1387,31 @@ mod tests {
         id
     }
 
+    /// A connected state with a note selected and a reaction to it in flight.
+    ///
+    /// A reaction stands in for "something the user did". Those are the publishes this
+    /// change confirms; a NIP-38 status is not one of them.
+    fn state_with_a_pending_reaction() -> (
+        AppState<'static>,
+        mpsc::UnboundedReceiver<NostrCommand>,
+        PublishId,
+        String,
+    ) {
+        let (mut state, mut rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event =
+            create_text_note(&keys, "hello", Timestamp::from(1000)).expect("a valid text note");
+        let Ok(note_id) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+        while rx.try_recv().is_ok() {}
+
+        let _ = state.react_to_selected();
+        let id = only_pending(&state);
+        (state, rx, id, note_id)
+    }
+
     fn connected_state() -> (AppState<'static>, mpsc::UnboundedReceiver<NostrCommand>) {
         let mut state = AppState::new(Keys::generate().public_key());
         let (tx, rx) = mpsc::unbounded_channel();
@@ -1383,10 +1421,7 @@ mod tests {
 
     #[test]
     fn publish_failure_reports_an_error_instead_of_success() {
-        let (mut state, _rx) = connected_state();
-
-        let _ = state.publish_music_status(create_track("Song"));
-        let id = only_pending(&state);
+        let (mut state, _rx, id, note_id) = state_with_a_pending_reaction();
 
         let _ = state.resolve_publish(
             id,
@@ -1397,8 +1432,7 @@ mod tests {
 
         let message = state.status_bar.message().expect("a status message");
         assert!(
-            message.starts_with("[ERR: Music] no relay accepted")
-                && message.contains("(Song - Artist)"),
+            message.starts_with("[ERR: Reaction] no relay accepted") && message.contains(&note_id),
             "expected the reason and the content, got: {message}"
         );
     }
@@ -1435,13 +1469,17 @@ mod tests {
         // fails, and the one the disconnected test cannot reach.
         drop(rx);
 
-        let _ = state.publish_music_status(create_track("Song"));
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+        let _ = state.submit_note();
 
         // The gateway still believed it was connected, so this is a lost connection
         // rather than never having had one — the two are worth telling apart.
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] connection lost (Song - Artist)")
+            Some("[ERR: Note] connection lost (h)")
         );
 
         // Nothing is left tracking it. An entry here would sit on "Sending" for good,
@@ -1455,22 +1493,22 @@ mod tests {
         // no outcome will ever arrive to settle it.
         let mut state = AppState::new(Keys::generate().public_key());
 
-        let _ = state.publish_music_status(create_track("Song"));
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+        let _ = state.submit_note();
 
         assert_eq!(
             state.status_bar.message(),
-            Some("[ERR: Music] not connected (Song - Artist)")
+            Some("[ERR: Note] not connected (h)")
         );
         assert!(state.pending_publishes.is_empty());
     }
 
     #[test]
     fn the_dispatched_command_carries_the_id_the_publish_is_tracked_under() {
-        let (mut state, mut rx) = connected_state();
-        while rx.try_recv().is_ok() {}
-
-        let _ = state.publish_music_status(create_track("Song"));
-        let tracked = only_pending(&state);
+        let (_state, mut rx, tracked, _note_id) = state_with_a_pending_reaction();
 
         let Ok(NostrCommand::SendEventBuilder { id: sent, .. }) = rx.try_recv() else {
             panic!("a publish should have been dispatched");
@@ -1479,7 +1517,7 @@ mod tests {
         // The two halves of the correlation. If they ever disagree, no report can find
         // its submission and every publish strands on "Sending" — silently, since each
         // half is individually plausible.
-        assert_eq!(sent, tracked);
+        assert_eq!(sent, Some(tracked));
     }
 
     #[test]
@@ -1495,16 +1533,19 @@ mod tests {
         // Two outstanding at once.
         let _ = state.react_to_selected();
         let reaction = only_pending(&state);
-        let _ = state.publish_music_status(create_track("Song"));
+        let _ = state.repost_selected();
 
         // Answered out of order — which is the point of correlating rather than queueing.
-        let music = *state
+        let repost = *state
             .pending_publishes
             .keys()
             .find(|id| **id != reaction)
             .expect("two pending publishes");
-        let _ = state.resolve_publish(music, Ok(()));
-        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        let _ = state.resolve_publish(repost, Ok(()));
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reposted] {note1}").as_str())
+        );
 
         let _ = state.resolve_publish(reaction, Ok(()));
         assert_eq!(
@@ -1528,13 +1569,13 @@ mod tests {
 
     #[test]
     fn a_publish_settles_only_once() {
-        let (mut state, _rx) = connected_state();
-
-        let _ = state.publish_music_status(create_track("Song"));
-        let id = only_pending(&state);
+        let (mut state, _rx, id, note_id) = state_with_a_pending_reaction();
 
         let _ = state.resolve_publish(id, Ok(()));
-        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reacted] {note_id}").as_str())
+        );
 
         // A duplicate report must not re-settle it over whatever is on screen by then.
         let _ = state.clear_status_message();

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -73,6 +73,9 @@ pub struct AppState<'a> {
     /// Source of [`PublishId`]s, monotonic for the life of the application.
     next_publish_id: u64,
     /// Whether the configured key can only read — an `npub` rather than a signing key.
+    ///
+    /// Known here so a publish that could never succeed is refused before it is queued,
+    /// rather than failing in the worker after the caller has moved on.
     read_only: bool,
 }
 
@@ -392,10 +395,10 @@ impl<'a> AppState<'a> {
             return Command::none();
         };
 
-        // Nothing to broadcast a status with. Every send would fail in the worker, and
-        // #521 keeps that off the bar — so attempting it would mean a guaranteed failure,
-        // on every track change, that the user is never told about. The feature needs a
-        // signing key; without one it simply does not run.
+        // Nothing to broadcast a status with, and unlike the publishes above there is
+        // nobody to tell: #521 keeps a music failure off the bar, so attempting it would
+        // mean a guaranteed failure on every track change that the user never sees. The
+        // feature needs a signing key; without one it simply does not run.
         if self.read_only {
             return Command::none();
         }
@@ -492,6 +495,16 @@ impl<'a> AppState<'a> {
         event_builder: EventBuilder,
     ) -> bool {
         let id = self.begin_publish(kind, message);
+
+        // Refused here rather than by the worker. Without a signing key every send fails,
+        // so queueing it buys a round trip and a delayed error — and for a note it costs
+        // the draft, because `submit_note` would have closed the editor by the time the
+        // answer came back.
+        if self.read_only {
+            self.abandon_publish(id);
+            return false;
+        }
+
         let outcome = self.nostr.update(NostrMessage::EventSubmitted {
             id: Some(id),
             event_builder,
@@ -585,7 +598,9 @@ impl<'a> AppState<'a> {
             return;
         };
 
-        let cause = if self.nostr.is_ready() {
+        let cause = if self.read_only {
+            "read-only mode"
+        } else if self.nostr.is_ready() {
             "connection lost"
         } else {
             "not connected"
@@ -1314,6 +1329,35 @@ mod tests {
         // Not tracked as a publish: a track change is not something the user did, so the
         // line reports what nostui attempted, as it always has (#521).
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+        assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn read_only_mode_refuses_a_note_and_keeps_the_draft() {
+        // Connected, but with no key to sign with — so the send would fail in the worker,
+        // by which time the editor would have been closed and the text lost.
+        let mut state =
+            AppState::new_with_config(Keys::generate().public_key(), Config::default(), true);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+        while rx.try_recv().is_ok() {}
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        assert!(state.editor.is_active());
+        assert_eq!(state.editor.get_content(), "h");
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Note] read-only mode (h)")
+        );
+
+        // Nothing was queued, so no report will arrive to settle a phantom entry.
+        assert!(rx.try_recv().is_err());
         assert!(state.pending_publishes.is_empty());
     }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -322,13 +322,7 @@ impl<'a> AppState<'a> {
         let event_builder = build(note);
         log::info!("{} event: {note_id}", kind.subject());
 
-        let id = self.begin_publish(kind, note_id);
-        let outcome = self
-            .nostr
-            .update(NostrMessage::EventSubmitted { id, event_builder });
-        if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not sent");
-        }
+        self.publish(kind, note_id, event_builder);
 
         Command::none()
     }
@@ -372,13 +366,7 @@ impl<'a> AppState<'a> {
             EventBuilder::new(Kind::TextNote, &content)
         };
 
-        let id = self.begin_publish(PublishKind::Note, &content);
-        let outcome = self
-            .nostr
-            .update(NostrMessage::EventSubmitted { id, event_builder });
-        if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not sent");
-        }
+        self.publish(PublishKind::Note, &content, event_builder);
 
         // Clear UI state.
         self.editor.update(EditorMessage::ComposingCanceled);
@@ -397,13 +385,7 @@ impl<'a> AppState<'a> {
         let content = status.content();
         let event_builder = status.live_status_builder();
 
-        let id = self.begin_publish(PublishKind::MusicStatus, &content);
-        let outcome = self
-            .nostr
-            .update(NostrMessage::EventSubmitted { id, event_builder });
-        if !self.dispatch_nostr(outcome) {
-            self.abandon_publish(id, "not sent");
-        }
+        self.publish(PublishKind::MusicStatus, &content, event_builder);
 
         Command::none()
     }
@@ -435,11 +417,11 @@ impl<'a> AppState<'a> {
     /// to send; the application owns the sender and performs the actual I/O.
     fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
-            // The gateway declined it, which it does whenever it believes it is not
-            // connected. Logged because this is the likeliest of the three ways a
-            // dispatch fails, and the status bar deliberately does not name a cause it
-            // cannot establish — leaving this silent would put the reason nowhere.
-            log::warn!("Nostr command declined: not connected");
+            // Not logged. Most `None`s are ordinary — `ConnectionReady` and
+            // `SubscriptionCreated` never dispatch, `SubscriptionRequested` declines the
+            // home feed and anything already subscribed — so warning here would fill the
+            // log with false alarms on every successful startup. Where it matters, the
+            // caller knows what it was trying to send and says so.
             return false;
         };
 
@@ -454,6 +436,28 @@ impl<'a> AppState<'a> {
         }
 
         true
+    }
+
+    /// Publish an event: track it, hand it to the worker, and settle it at once if the
+    /// worker never got it.
+    ///
+    /// The three steps live together because they only make sense together — a tracked
+    /// publish that was never dispatched sits on "Sending" for good, and a dispatch with
+    /// nothing tracking it can never be settled by its report.
+    fn publish(
+        &mut self,
+        kind: PublishKind,
+        message: impl Into<String>,
+        event_builder: EventBuilder,
+    ) {
+        let id = self.begin_publish(kind, message);
+        let outcome = self
+            .nostr
+            .update(NostrMessage::EventSubmitted { id, event_builder });
+
+        if !self.dispatch_nostr(outcome) {
+            self.abandon_publish(id, "not sent");
+        }
     }
 
     /// Hand a submitted event to the worker and show it as pending.
@@ -534,7 +538,15 @@ impl<'a> AppState<'a> {
             return;
         };
 
-        log::error!("Publish not sent, {reason}: {}", pending.message);
+        // The gateway's own belief is the closest thing to a cause available here, and
+        // the status bar deliberately does not name one it cannot establish — so this is
+        // where the distinction has to live.
+        let cause = if self.nostr.is_ready() {
+            "no worker to send it to"
+        } else {
+            "not connected"
+        };
+        log::error!("Publish not sent, {cause}: {}", pending.message);
         self.set_status_error(
             pending.kind.subject(),
             format!("{reason} ({})", pending.message),

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crossterm::event::KeyEvent;
 use nostr_sdk::prelude::*;
 use nowhear::Track;
@@ -12,7 +14,7 @@ use crate::{
         editor::{Editor, Message as EditorMessage},
         fps::{Fps, Message as FpsMessage},
         nostr::{Message as NostrMessage, Nostr, NostrOutcome},
-        nostr_gateway::{CommandError, NostrCommand},
+        nostr_gateway::{CommandError, NostrCommand, PublishId},
         status_bar::{Message, StatusBar},
         timeline::{
             tab::TimelineOutcome, text_note::TextNote, Message as TimelineMessage, Timeline,
@@ -62,7 +64,28 @@ pub struct AppState<'a> {
     /// Owned here (not in `model::nostr`) so the application layer performs the
     /// I/O while `model` stays side-effect free; set once the worker is ready.
     command_sender: Option<mpsc::UnboundedSender<NostrCommand>>,
+    /// Publishes handed to the worker and not yet answered, by the id they were sent
+    /// under.
+    ///
+    /// Keyed rather than ordered: an outcome that never arrives leaves one stale entry
+    /// instead of shifting every later answer onto the wrong submission.
+    pending_publishes: HashMap<PublishId, PendingPublish>,
+    /// Source of [`PublishId`]s, monotonic for the life of the application.
+    next_publish_id: u64,
 }
+
+/// A publish handed to the worker and waiting for a relay's answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingPublish {
+    /// Status-bar label to show once a relay accepts it — the word the bar has always
+    /// used for this kind of event ("Posted", "Reacted", "Reposted", "Music").
+    settled_label: String,
+    /// What was published, shown while pending and again once settled.
+    message: String,
+}
+
+/// Status-bar label shown while a publish is waiting for a relay's answer.
+const PENDING_LABEL: &str = "Sending";
 
 /// Configuration state - holds all user-configurable settings
 #[derive(Debug, Clone, Default)]
@@ -168,7 +191,7 @@ impl<'a> AppState<'a> {
             let outcome = self
                 .nostr
                 .update(NostrMessage::SubscriptionRequested { feed });
-            self.dispatch_nostr(outcome);
+            let _ = self.dispatch_nostr(outcome);
 
             self.set_status("Mention", "loading...");
         } else {
@@ -206,7 +229,7 @@ impl<'a> AppState<'a> {
             let outcome = self
                 .nostr
                 .update(NostrMessage::SubscriptionRequested { feed });
-            self.dispatch_nostr(outcome);
+            let _ = self.dispatch_nostr(outcome);
 
             self.set_status(author_npub, "loading...");
         } else {
@@ -234,7 +257,7 @@ impl<'a> AppState<'a> {
 
         // Unsubscribe the subscriptions associated with the closed tab.
         let outcome = self.nostr.update(NostrMessage::SubscriptionClosed { feed });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
 
         Command::none()
     }
@@ -264,12 +287,13 @@ impl<'a> AppState<'a> {
         let event_builder = build(note);
         log::info!("{label} event: {note_id}");
 
+        let id = self.begin_publish(label, note_id);
         let outcome = self
             .nostr
-            .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status(label, note_id);
+            .update(NostrMessage::EventSubmitted { id, event_builder });
+        if !self.dispatch_nostr(outcome) {
+            self.abandon_publish(id, "not connected");
+        }
 
         Command::none()
     }
@@ -313,12 +337,13 @@ impl<'a> AppState<'a> {
             EventBuilder::new(Kind::TextNote, &content)
         };
 
+        let id = self.begin_publish("Posted", &content);
         let outcome = self
             .nostr
-            .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status("Posted", content);
+            .update(NostrMessage::EventSubmitted { id, event_builder });
+        if !self.dispatch_nostr(outcome) {
+            self.abandon_publish(id, "not connected");
+        }
 
         // Clear UI state.
         self.editor.update(EditorMessage::ComposingCanceled);
@@ -337,12 +362,13 @@ impl<'a> AppState<'a> {
         let content = status.content();
         let event_builder = status.live_status_builder();
 
+        let id = self.begin_publish("Music", &content);
         let outcome = self
             .nostr
-            .update(NostrMessage::EventSubmitted { event_builder });
-        self.dispatch_nostr(outcome);
-
-        self.set_status("Music", content);
+            .update(NostrMessage::EventSubmitted { id, event_builder });
+        if !self.dispatch_nostr(outcome) {
+            self.abandon_publish(id, "not connected");
+        }
 
         Command::none()
     }
@@ -372,19 +398,90 @@ impl<'a> AppState<'a> {
     ///
     /// `model::nostr::update` is side-effect free and only reports the command
     /// to send; the application owns the sender and performs the actual I/O.
-    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) {
+    fn dispatch_nostr(&self, outcome: Option<NostrOutcome>) -> bool {
         let Some(NostrOutcome::Send(command)) = outcome else {
-            return;
+            return false;
         };
 
         let Some(sender) = self.command_sender.as_ref() else {
             log::warn!("Dropping Nostr command, worker not ready: {command:?}");
-            return;
+            return false;
         };
 
         if sender.send(command).is_err() {
             log::error!("Failed to send Nostr command: subscription worker is gone");
+            return false;
         }
+
+        true
+    }
+
+    /// Hand a submitted event to the worker and show it as pending.
+    ///
+    /// The bar says "Sending" rather than `settled_label` until a relay has answered,
+    /// because until then nothing has been published — the command only sits on the
+    /// worker's queue. [`Self::resolve_publish`] supplies the ending.
+    ///
+    /// A submission that never reaches the worker settles here instead, since no report
+    /// will ever arrive for it.
+    fn begin_publish(&mut self, settled_label: &str, message: impl Into<String>) -> PublishId {
+        let id = PublishId(self.next_publish_id);
+        self.next_publish_id = self.next_publish_id.wrapping_add(1);
+        let message = message.into();
+
+        self.pending_publishes.insert(
+            id,
+            PendingPublish {
+                settled_label: settled_label.to_owned(),
+                message: message.clone(),
+            },
+        );
+        self.set_status(PENDING_LABEL, message);
+
+        id
+    }
+
+    /// Settle the publish this outcome belongs to.
+    ///
+    /// An id with no entry is ignored: it can only mean the entry was already settled,
+    /// and guessing which submission it meant is how a wrong note gets reported.
+    pub fn resolve_publish(
+        &mut self,
+        id: PublishId,
+        result: Result<(), String>,
+    ) -> Command<AppMsg> {
+        let Some(pending) = self.pending_publishes.remove(&id) else {
+            log::warn!("Publish outcome for an unknown submission: {result:?}");
+            return Command::none();
+        };
+
+        match result {
+            Ok(()) => self.set_status(pending.settled_label, pending.message),
+            Err(reason) => {
+                log::error!("Failed to publish {}: {reason}", pending.message);
+                // Reason first: the bar is one line, and what a reaction or repost carries
+                // as content is a bech32 id — long, and far less use than why it failed.
+                self.set_status_error(
+                    pending.settled_label,
+                    format!("{reason} ({})", pending.message),
+                );
+            }
+        }
+
+        Command::none()
+    }
+
+    /// Give up on a publish that was never handed over, so it does not sit as "Sending".
+    fn abandon_publish(&mut self, id: PublishId, reason: &str) {
+        let Some(pending) = self.pending_publishes.remove(&id) else {
+            return;
+        };
+
+        log::error!("Publish not sent, {reason}: {}", pending.message);
+        self.set_status_error(
+            pending.settled_label,
+            format!("{reason} ({})", pending.message),
+        );
     }
 
     /// Record that the Nostr subscription is ready and store its command sender,
@@ -398,7 +495,7 @@ impl<'a> AppState<'a> {
         let tab_title = self.active_tab_title();
         self.command_sender = Some(command_sender);
         let outcome = self.nostr.update(NostrMessage::ConnectionReady);
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         self.set_status(tab_title, "loading...");
 
         Command::none()
@@ -451,7 +548,7 @@ impl<'a> AppState<'a> {
         let outcome = self
             .nostr
             .update(NostrMessage::HistoryRequested { feed, since });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
 
         self.set_status(tab_title, "loading more...");
 
@@ -572,7 +669,7 @@ impl<'a> AppState<'a> {
     /// Close the Nostr connection: unsubscribe and disconnect from relays.
     pub fn close_connection(&mut self) -> Command<AppMsg> {
         let outcome = self.nostr.update(NostrMessage::ConnectionClosed);
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         self.command_sender = None;
         Command::none()
     }
@@ -588,7 +685,7 @@ impl<'a> AppState<'a> {
             feed,
             sub_id: subscription_id,
         });
-        self.dispatch_nostr(outcome);
+        let _ = self.dispatch_nostr(outcome);
         Command::none()
     }
 
@@ -955,8 +1052,8 @@ mod tests {
 
     #[test]
     fn test_react_to_selected_sets_status() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
@@ -964,6 +1061,15 @@ mod tests {
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.react_to_selected();
+        let id = only_pending(&state);
+
+        // Handed to the worker; no relay has answered yet.
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Sending] {note1}").as_str())
+        );
+
+        let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(
             state.status_bar.message(),
@@ -975,8 +1081,8 @@ mod tests {
 
     #[test]
     fn test_repost_selected_sets_status() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
         let Ok(note1) = event.id.to_bech32();
@@ -984,6 +1090,15 @@ mod tests {
         let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
 
         let _ = state.repost_selected();
+        let id = only_pending(&state);
+
+        // Handed to the worker; no relay has answered yet.
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Sending] {note1}").as_str())
+        );
+
+        let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(
             state.status_bar.message(),
@@ -1022,7 +1137,7 @@ mod tests {
 
     #[test]
     fn test_submit_note_posts_content_and_resets_editor() {
-        let mut state = AppState::new(Keys::generate().public_key());
+        let (mut state, _rx) = connected_state();
 
         // Compose "hi" in the editor.
         state.editor.update(EditorMessage::ComposingStarted);
@@ -1036,15 +1151,21 @@ mod tests {
         }
 
         let _ = state.submit_note();
+        let id = only_pending(&state);
+
+        // The editor closes, but nothing is posted until a relay says so.
+        assert_eq!(state.status_bar.message(), Some("[Sending] hi"));
+        assert!(!state.editor.is_active());
+
+        let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(state.status_bar.message(), Some("[Posted] hi"));
-        assert!(!state.editor.is_active());
     }
 
     #[test]
     fn test_submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
+        let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
-        let mut state = AppState::new(keys.public_key());
 
         // Select a note and start replying to it.
         let event = create_text_note(&keys, "original", Timestamp::from(1000))?;
@@ -1058,18 +1179,28 @@ mod tests {
         });
 
         let _ = state.submit_note();
+        let id = only_pending(&state);
+
+        assert_eq!(state.status_bar.message(), Some("[Sending] y"));
+        assert!(!state.editor.is_active());
+
+        let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(state.status_bar.message(), Some("[Posted] y"));
-        assert!(!state.editor.is_active());
 
         Ok(())
     }
 
     #[test]
     fn test_publish_music_status_sets_status() {
-        let mut state = AppState::new(Keys::generate().public_key());
+        let (mut state, _rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
+        let id = only_pending(&state);
+
+        assert_eq!(state.status_bar.message(), Some("[Sending] Song - Artist"));
+
+        let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
     }
@@ -1168,11 +1299,116 @@ mod tests {
     // the #458 regression where `load_more_timeline` set the status but never
     // dispatched `LoadMore`.
 
+    /// The id of the one outstanding publish, for tests that settle it by hand.
+    fn only_pending(state: &AppState<'_>) -> PublishId {
+        let mut ids = state.pending_publishes.keys();
+        let id = *ids.next().expect("a publish should be pending");
+        assert!(ids.next().is_none(), "expected exactly one pending publish");
+        id
+    }
+
     fn connected_state() -> (AppState<'static>, mpsc::UnboundedReceiver<NostrCommand>) {
         let mut state = AppState::new(Keys::generate().public_key());
         let (tx, rx) = mpsc::unbounded_channel();
         let _ = state.on_connection_ready(tx);
         (state, rx)
+    }
+
+    #[test]
+    fn publish_failure_reports_an_error_instead_of_success() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        let id = only_pending(&state);
+
+        let _ = state.resolve_publish(
+            id,
+            Err(String::from(
+                "no relay accepted the event: wss://relay.example: blocked",
+            )),
+        );
+
+        let message = state.status_bar.message().expect("a status message");
+        assert!(
+            message.starts_with("[ERR: Music] no relay accepted")
+                && message.contains("(Song - Artist)"),
+            "expected the reason and the content, got: {message}"
+        );
+    }
+
+    #[test]
+    fn publishing_while_disconnected_does_not_claim_success() {
+        // Not connected: `model::nostr` declines the submission, so nothing is queued and
+        // no outcome will ever arrive to settle it.
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let _ = state.publish_music_status(create_track("Song"));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Music] not connected (Song - Artist)")
+        );
+        assert!(state.pending_publishes.is_empty());
+    }
+
+    #[test]
+    fn outcomes_settle_the_submission_they_belong_to() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        // Two outstanding at once.
+        let _ = state.react_to_selected();
+        let reaction = only_pending(&state);
+        let _ = state.publish_music_status(create_track("Song"));
+
+        // Answered out of order — which is the point of correlating rather than queueing.
+        let music = *state
+            .pending_publishes
+            .keys()
+            .find(|id| **id != reaction)
+            .expect("two pending publishes");
+        let _ = state.resolve_publish(music, Ok(()));
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+
+        let _ = state.resolve_publish(reaction, Ok(()));
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[Reacted] {note1}").as_str())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn an_outcome_for_an_unknown_submission_is_ignored() {
+        let (mut state, _rx) = connected_state();
+        let before = state.status_bar.message().map(ToOwned::to_owned);
+
+        // Nothing is pending under this id, so there is nothing it could honestly settle.
+        let _ = state.resolve_publish(PublishId(99), Ok(()));
+
+        assert_eq!(state.status_bar.message(), before.as_deref());
+    }
+
+    #[test]
+    fn a_publish_settles_only_once() {
+        let (mut state, _rx) = connected_state();
+
+        let _ = state.publish_music_status(create_track("Song"));
+        let id = only_pending(&state);
+
+        let _ = state.resolve_publish(id, Ok(()));
+        assert_eq!(state.status_bar.message(), Some("[Music] Song - Artist"));
+
+        // A duplicate report must not re-settle it over whatever is on screen by then.
+        let _ = state.clear_status_message();
+        let _ = state.resolve_publish(id, Ok(()));
+        assert_eq!(state.status_bar.message(), None);
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -74,12 +74,47 @@ pub struct AppState<'a> {
     next_publish_id: u64,
 }
 
+/// What is being published, which decides how the status bar names it.
+///
+/// One value rather than a pair of labels: a publish that failed must not be described
+/// with the word for one that succeeded, and passing "Posted" and "Note" separately
+/// would let them drift apart at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishKind {
+    Note,
+    Reaction,
+    Repost,
+    MusicStatus,
+}
+
+impl PublishKind {
+    /// How the bar names it once a relay has accepted it — past tense, and the wording
+    /// the bar has always used.
+    const fn settled_label(self) -> &'static str {
+        match self {
+            Self::Note => "Posted",
+            Self::Reaction => "Reacted",
+            Self::Repost => "Reposted",
+            Self::MusicStatus => "Music",
+        }
+    }
+
+    /// How the bar names it when it did not happen. Never the past tense: an error line
+    /// reading "Posted" would claim exactly what this whole change exists to stop.
+    const fn subject(self) -> &'static str {
+        match self {
+            Self::Note => "Note",
+            Self::Reaction => "Reaction",
+            Self::Repost => "Repost",
+            Self::MusicStatus => "Music",
+        }
+    }
+}
+
 /// A publish handed to the worker and waiting for a relay's answer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingPublish {
-    /// Status-bar label to show once a relay accepts it — the word the bar has always
-    /// used for this kind of event ("Posted", "Reacted", "Reposted", "Music").
-    settled_label: String,
+    kind: PublishKind,
     /// What was published, shown while pending and again once settled.
     message: String,
 }
@@ -264,19 +299,19 @@ impl<'a> AppState<'a> {
 
     /// Submit a NIP-25 reaction for the currently selected note.
     pub fn react_to_selected(&mut self) -> Command<AppMsg> {
-        self.submit_engagement_for_selected("Reacted", TextNote::reaction_builder)
+        self.submit_engagement_for_selected(PublishKind::Reaction, TextNote::reaction_builder)
     }
 
     /// Submit a NIP-18 repost for the currently selected note.
     pub fn repost_selected(&mut self) -> Command<AppMsg> {
-        self.submit_engagement_for_selected("Reposted", TextNote::repost_builder)
+        self.submit_engagement_for_selected(PublishKind::Repost, TextNote::repost_builder)
     }
 
-    /// Build an engagement event for the selected note with `build`, submit it,
-    /// and show `label` in the status bar. No-op when nothing is selected.
+    /// Build an engagement event for the selected note with `build` and submit it.
+    /// No-op when nothing is selected.
     fn submit_engagement_for_selected(
         &mut self,
-        label: &str,
+        kind: PublishKind,
         build: fn(&TextNote) -> EventBuilder,
     ) -> Command<AppMsg> {
         let Some(note) = self.timeline.selected_note() else {
@@ -285,9 +320,9 @@ impl<'a> AppState<'a> {
 
         let note_id = note.bech32_id();
         let event_builder = build(note);
-        log::info!("{label} event: {note_id}");
+        log::info!("{} event: {note_id}", kind.subject());
 
-        let id = self.begin_publish(label, note_id);
+        let id = self.begin_publish(kind, note_id);
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
@@ -337,7 +372,7 @@ impl<'a> AppState<'a> {
             EventBuilder::new(Kind::TextNote, &content)
         };
 
-        let id = self.begin_publish("Posted", &content);
+        let id = self.begin_publish(PublishKind::Note, &content);
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
@@ -362,7 +397,7 @@ impl<'a> AppState<'a> {
         let content = status.content();
         let event_builder = status.live_status_builder();
 
-        let id = self.begin_publish("Music", &content);
+        let id = self.begin_publish(PublishKind::MusicStatus, &content);
         let outcome = self
             .nostr
             .update(NostrMessage::EventSubmitted { id, event_builder });
@@ -424,7 +459,7 @@ impl<'a> AppState<'a> {
     ///
     /// A submission that never reaches the worker settles here instead, since no report
     /// will ever arrive for it.
-    fn begin_publish(&mut self, settled_label: &str, message: impl Into<String>) -> PublishId {
+    fn begin_publish(&mut self, kind: PublishKind, message: impl Into<String>) -> PublishId {
         let id = PublishId(self.next_publish_id);
         self.next_publish_id = self.next_publish_id.wrapping_add(1);
         let message = message.into();
@@ -436,7 +471,7 @@ impl<'a> AppState<'a> {
         self.pending_publishes.insert(
             id,
             PendingPublish {
-                settled_label: settled_label.to_owned(),
+                kind,
                 message: message.clone(),
             },
         );
@@ -465,13 +500,13 @@ impl<'a> AppState<'a> {
         // #516; doing it here would be the arbitration policy growing a case at a time,
         // which is what that issue exists to stop.
         match result {
-            Ok(()) => self.set_status(pending.settled_label, pending.message),
+            Ok(()) => self.set_status(pending.kind.settled_label(), pending.message),
             Err(reason) => {
                 log::error!("Failed to publish {}: {reason}", pending.message);
                 // Reason first: the bar is one line, and what a reaction or repost carries
                 // as content is a bech32 id — long, and far less use than why it failed.
                 self.set_status_error(
-                    pending.settled_label,
+                    pending.kind.subject(),
                     format!("{reason} ({})", pending.message),
                 );
             }
@@ -493,7 +528,7 @@ impl<'a> AppState<'a> {
 
         log::error!("Publish not sent, {reason}: {}", pending.message);
         self.set_status_error(
-            pending.settled_label,
+            pending.kind.subject(),
             format!("{reason} ({})", pending.message),
         );
     }
@@ -1348,6 +1383,30 @@ mod tests {
                 && message.contains("(Song - Artist)"),
             "expected the reason and the content, got: {message}"
         );
+    }
+
+    #[test]
+    fn a_failed_note_is_not_called_posted() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+        let id = only_pending(&state);
+
+        let _ = state.resolve_publish(id, Err(String::from("refused")));
+
+        // `[ERR: Posted]` for a note no relay took would be the same false claim this
+        // whole change removes, just in a different tense.
+        let message = state.status_bar.message().expect("a status message");
+        assert!(
+            message.starts_with("[ERR: Note]"),
+            "a failure must not be named with the word for a success, got: {message}"
+        );
+        assert!(!message.contains("Posted"), "got: {message}");
     }
 
     #[test]

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -144,6 +144,12 @@ impl NostrEvents {
     /// One relay accepting is enough — the event exists on the network — so a partial
     /// failure is logged rather than reported.
     ///
+    /// "Confirmed", not "accepted", in what it reports. `failed` collects ack timeouts
+    /// and dropped sockets alongside outright `OK false` rejections, and those are not
+    /// the same thing: a relay can store the event and answer too late to be heard. The
+    /// user would then be told it was refused for a note that is on the relay, and would
+    /// write it again. Saying only that nothing confirmed it is what is actually known.
+    ///
     /// "Accepting" means an `OK true`, checked rather than assumed. `success` also holds
     /// `EventSendStatus::Sent` — written to a socket, never acknowledged — under any
     /// policy but `AckPolicy::all`, so counting the set's size would make this correct
@@ -172,22 +178,22 @@ impl NostrEvents {
         // failure undiagnosable anywhere.
         if output.failed.is_empty() {
             log::error!(
-                "No relay accepted event {}, and none reported why",
+                "No relay confirmed event {}, and none reported why",
                 output.value
             );
         } else {
             log::error!(
-                "No relay accepted event {}: {}",
+                "No relay confirmed event {}: {}",
                 output.value,
                 Self::describe_failures(&output.failed)
             );
         }
 
         Err(if output.failed.is_empty() {
-            String::from("no relay accepted the event")
+            String::from("no relay confirmed the event")
         } else {
             format!(
-                "no relay accepted the event: {}",
+                "no relay confirmed the event: {}",
                 Self::summarise_failures(&output.failed)
             )
         })
@@ -568,16 +574,16 @@ mod tests {
     }
 
     #[test]
-    fn a_send_every_relay_refused_is_a_failure() {
+    fn a_send_no_relay_confirmed_is_a_failure() {
         // The premise of this whole change: nostr-sdk returns `Ok` once it has tried
-        // every relay, so an all-refused send arrives as `Ok` with nothing in `success`.
-        // Reporting that as published would put "Posted" on screen for a note no relay
-        // stored — which is the bug this exists to remove.
+        // every relay, so a send nothing confirmed arrives as `Ok` with nothing in
+        // `success`. Reporting that as published would put "Posted" on screen for a note
+        // no relay is known to hold — which is the bug this exists to remove.
         let output = send_output(&[], &[("wss://a.example", "blocked")]);
 
         let error = NostrEvents::relay_verdict(&output).expect_err("should be a failure");
         assert!(
-            error.contains("no relay accepted") && error.contains("blocked"),
+            error.contains("no relay confirmed") && error.contains("blocked"),
             "expected the relay's reason to survive, got: {error}"
         );
     }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -166,11 +166,18 @@ impl NostrEvents {
         // Everything to the log, a summary to the caller: this string ends up on one
         // line of the status bar, and losing reasons from the log too would leave the
         // failure undiagnosable anywhere.
-        log::error!(
-            "No relay accepted event {}: {}",
-            output.value,
-            Self::describe_failures(&output.failed)
-        );
+        if output.failed.is_empty() {
+            log::error!(
+                "No relay accepted event {}, and none reported why",
+                output.value
+            );
+        } else {
+            log::error!(
+                "No relay accepted event {}: {}",
+                output.value,
+                Self::describe_failures(&output.failed)
+            );
+        }
 
         Err(if output.failed.is_empty() {
             String::from("no relay accepted the event")
@@ -253,10 +260,12 @@ impl NostrEvents {
                     None => Err(String::from("cannot send events in read-only mode")),
                 };
 
-                // Reported either way. The application shows a publish as pending until
-                // this arrives, so a success that says nothing would leave it pending for
-                // good.
-                let _ = msg_tx.send(Message::EventPublished { id, result });
+                // Reported either way, when anybody is waiting. The application shows a
+                // publish as pending until this arrives, so a success that says nothing
+                // would leave it pending for good.
+                if let Some(id) = id {
+                    let _ = msg_tx.send(Message::EventPublished { id, result });
+                }
             }
             NostrCommand::AddRelay { url } => {
                 if let Err(e) = client.add_relay(&url).await {
@@ -443,17 +452,26 @@ impl NostrEvents {
             }
         }
 
-        // Close first, then drain. `cmd_rx` would otherwise stay open until this task
-        // returns, and a publish sent in that window would be accepted by the sender and
-        // dequeued by nobody. Drained with `recv` rather than `try_recv` because `send`
-        // bumps the message count before it pushes the value, so `try_recv` reports an
-        // empty queue as `Empty` while a send is mid-flight and would end the loop early;
-        // `recv` waits it out and returns `None` only once the channel is closed and
-        // genuinely drained.
+        Self::report_unsent(&mut cmd_rx, &msg_tx).await;
+    }
+
+    /// Fail every publish still queued when the worker stops.
+    ///
+    /// Close first, then drain. `cmd_rx` would otherwise stay open until the task
+    /// returns, and a publish sent in that window would be accepted by the sender and
+    /// dequeued by nobody — leaving the application tracking one that can never be
+    /// reported. Drained with `recv` rather than `try_recv` because `send` bumps the
+    /// message count before it pushes the value, so `try_recv` reports an empty queue as
+    /// `Empty` while a send is mid-flight and would end the loop early; `recv` waits it
+    /// out and returns `None` only once the channel is closed and genuinely drained.
+    async fn report_unsent(
+        cmd_rx: &mut mpsc::UnboundedReceiver<NostrCommand>,
+        msg_tx: &mpsc::UnboundedSender<Message>,
+    ) {
         cmd_rx.close();
 
         while let Some(cmd) = cmd_rx.recv().await {
-            if let NostrCommand::SendEventBuilder { id, .. } = cmd {
+            if let NostrCommand::SendEventBuilder { id: Some(id), .. } = cmd {
                 let _ = msg_tx.send(Message::EventPublished {
                     id,
                     result: Err(String::from(
@@ -516,6 +534,7 @@ impl SubscriptionSource for NostrEvents {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::nostr_gateway::PublishId;
     use futures::StreamExt;
 
     fn relay_url(url: &str) -> RelayUrl {
@@ -624,6 +643,54 @@ mod tests {
 
         assert!(error.contains("(and 4 more)"), "got: {error}");
         assert!(!error.contains("relay5.example"), "got: {error}");
+    }
+
+    #[tokio::test]
+    async fn a_queued_publish_is_failed_when_the_worker_stops() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let (msg_tx, mut msg_rx) = mpsc::unbounded_channel();
+
+        for cmd in [
+            NostrCommand::SendEventBuilder {
+                id: Some(PublishId(7)),
+                event_builder: EventBuilder::new(Kind::TextNote, "hi"),
+            },
+            // Nobody waiting on this one, and this one is not a publish at all.
+            NostrCommand::SendEventBuilder {
+                id: None,
+                event_builder: EventBuilder::new(Kind::TextNote, "background"),
+            },
+            NostrCommand::Subscribe {
+                feed: FeedKind::Home,
+            },
+        ] {
+            cmd_tx.send(cmd).expect("the receiver is alive");
+        }
+
+        NostrEvents::report_unsent(&mut cmd_rx, &msg_tx).await;
+
+        // The tracked one is reported, so the application does not leave it on "Sending".
+        let Some(Message::EventPublished { id, result }) = msg_rx.recv().await else {
+            panic!("the queued publish should have been reported");
+        };
+        assert_eq!(id, PublishId(7));
+        assert!(result.is_err());
+
+        // Nothing else is: no one is waiting on the other two.
+        assert!(msg_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn draining_shuts_the_channel_so_nothing_is_accepted_and_lost() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let (msg_tx, _msg_rx) = mpsc::unbounded_channel();
+
+        NostrEvents::report_unsent(&mut cmd_rx, &msg_tx).await;
+
+        // A send after this point must fail rather than land in a channel no one reads —
+        // that is what `close` before the drain buys, and what tells the application to
+        // settle the publish itself.
+        assert!(cmd_tx.send(NostrCommand::Shutdown).is_err());
     }
 
     #[test]

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -143,6 +143,11 @@ impl NostrEvents {
     ///
     /// One relay accepting is enough — the event exists on the network — so a partial
     /// failure is logged rather than reported.
+    ///
+    /// "Accepting" means an entry in `success`, which the caller's `AckPolicy::all`
+    /// makes equivalent to an `OK true`. That policy is set explicitly at the send for
+    /// this reason: under `AckPolicy::none` the same field would hold events merely
+    /// written to a socket.
     fn relay_verdict(output: &SendEventOutput) -> Result<(), String> {
         if !output.success.is_empty() {
             if !output.failed.is_empty() {
@@ -230,10 +235,17 @@ impl NostrEvents {
             NostrCommand::SendEventBuilder { id, event_builder } => {
                 let result: Result<(), String> = match keys {
                     Some(keys) => match event_builder.finalize(keys) {
-                        Ok(event) => match client.send_event(&event).await {
-                            Ok(output) => Self::relay_verdict(&output),
-                            Err(e) => Err(e.to_string()),
-                        },
+                        // `AckPolicy::all` is nostr-sdk's default, and stating it here
+                        // rather than inheriting it is what makes `relay_verdict` sound:
+                        // under any other policy a relay lands in `output.success` as
+                        // `Sent` — dispatched, not acknowledged — and reporting that as
+                        // published is the claim this whole change removes.
+                        Ok(event) => {
+                            match client.send_event(&event).ack_policy(AckPolicy::all()).await {
+                                Ok(output) => Self::relay_verdict(&output),
+                                Err(e) => Err(e.to_string()),
+                            }
+                        }
                         Err(e) => Err(e.to_string()),
                     },
                     None => Err(String::from("cannot send events in read-only mode")),

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use futures::{
     stream::{self, BoxStream},
@@ -130,6 +134,50 @@ impl NostrEvents {
     }
 
     /// Handle a single command and send error messages if needed
+    /// Decide whether a completed `send_event` actually reached a relay.
+    ///
+    /// `Ok` from nostr-sdk does not mean the event was accepted: the pool returns
+    /// `Ok(output)` once it has tried every relay, recording per-relay rejections and
+    /// ack timeouts in `output.failed` and reserving `Err` for setup problems. An event
+    /// every relay refused therefore arrives as `Ok` with an empty `success` set, and
+    /// reporting that as published would be the very claim this is here to stop.
+    ///
+    /// One relay accepting is enough — the event exists on the network — so a partial
+    /// failure is logged rather than reported.
+    fn relay_verdict(output: &SendEventOutput) -> Result<(), String> {
+        if !output.success.is_empty() {
+            if !output.failed.is_empty() {
+                log::warn!(
+                    "Event {} accepted by {} relay(s), refused by {}",
+                    output.value,
+                    output.success.len(),
+                    Self::describe_failures(&output.failed)
+                );
+            }
+            return Ok(());
+        }
+
+        Err(if output.failed.is_empty() {
+            String::from("no relay accepted the event")
+        } else {
+            format!(
+                "no relay accepted the event: {}",
+                Self::describe_failures(&output.failed)
+            )
+        })
+    }
+
+    /// Render per-relay failures as `url: reason`, in a stable order so the same outcome
+    /// always reads the same way — `failed` is a `HashMap`.
+    fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
+        let mut reasons: Vec<String> = failed
+            .iter()
+            .map(|(url, reason)| format!("{url}: {reason}"))
+            .collect();
+        reasons.sort();
+        reasons.join(", ")
+    }
+
     async fn handle_command(
         cmd: NostrCommand,
         client: &Client,
@@ -139,23 +187,22 @@ impl NostrEvents {
         msg_tx: &mpsc::UnboundedSender<Message>,
     ) {
         match cmd {
-            NostrCommand::SendEventBuilder { event_builder } => {
+            NostrCommand::SendEventBuilder { id, event_builder } => {
                 let result: Result<(), String> = match keys {
                     Some(keys) => match event_builder.finalize(keys) {
-                        Ok(event) => client
-                            .send_event(&event)
-                            .await
-                            .map(|_| ())
-                            .map_err(|e| e.to_string()),
+                        Ok(event) => match client.send_event(&event).await {
+                            Ok(output) => Self::relay_verdict(&output),
+                            Err(e) => Err(e.to_string()),
+                        },
                         Err(e) => Err(e.to_string()),
                     },
                     None => Err(String::from("cannot send events in read-only mode")),
                 };
-                if let Err(e) = result {
-                    let _ = msg_tx.send(Message::Error {
-                        error: CommandError::SendEventFailed { error: e },
-                    });
-                }
+
+                // Reported either way. The application shows a publish as pending until
+                // this arrives, so a success that says nothing would leave it pending for
+                // good.
+                let _ = msg_tx.send(Message::EventPublished { id, result });
             }
             NostrCommand::AddRelay { url } => {
                 if let Err(e) = client.add_relay(&url).await {
@@ -339,6 +386,26 @@ impl NostrEvents {
                         }
                     }
                 }
+            }
+        }
+
+        // Close first, then drain. `cmd_rx` would otherwise stay open until this task
+        // returns, and a publish sent in that window would be accepted by the sender and
+        // dequeued by nobody. Drained with `recv` rather than `try_recv` because `send`
+        // bumps the message count before it pushes the value, so `try_recv` reports an
+        // empty queue as `Empty` while a send is mid-flight and would end the loop early;
+        // `recv` waits it out and returns `None` only once the channel is closed and
+        // genuinely drained.
+        cmd_rx.close();
+
+        while let Some(cmd) = cmd_rx.recv().await {
+            if let NostrCommand::SendEventBuilder { id, .. } = cmd {
+                let _ = msg_tx.send(Message::EventPublished {
+                    id,
+                    result: Err(String::from(
+                        "the connection closed before the event was sent",
+                    )),
+                });
             }
         }
     }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -133,7 +133,6 @@ impl NostrEvents {
         }
     }
 
-    /// Handle a single command and send error messages if needed
     /// Decide whether a completed `send_event` actually reached a relay.
     ///
     /// `Ok` from nostr-sdk does not mean the event was accepted: the pool returns
@@ -167,6 +166,12 @@ impl NostrEvents {
         })
     }
 
+    /// How many relays' reasons a failure message names before summarising the rest.
+    ///
+    /// The status bar is one non-wrapping line, and this string competes with the content
+    /// that follows it. Every relay's reason would push that off the end.
+    const REPORTED_FAILURES: usize = 2;
+
     /// Render per-relay failures as `url: reason`, in a stable order so the same outcome
     /// always reads the same way — `failed` is a `HashMap`.
     fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
@@ -175,9 +180,18 @@ impl NostrEvents {
             .map(|(url, reason)| format!("{url}: {reason}"))
             .collect();
         reasons.sort();
-        reasons.join(", ")
+
+        let hidden = reasons.len().saturating_sub(Self::REPORTED_FAILURES);
+        reasons.truncate(Self::REPORTED_FAILURES);
+
+        if hidden == 0 {
+            reasons.join(", ")
+        } else {
+            format!("{} (and {hidden} more)", reasons.join(", "))
+        }
     }
 
+    /// Run a single command and report its outcome to the application.
     async fn handle_command(
         cmd: NostrCommand,
         client: &Client,
@@ -463,6 +477,87 @@ impl SubscriptionSource for NostrEvents {
 mod tests {
     use super::*;
     use futures::StreamExt;
+
+    fn relay_url(url: &str) -> RelayUrl {
+        RelayUrl::parse(url).expect("valid relay url")
+    }
+
+    fn send_output(success: &[&str], failed: &[(&str, &str)]) -> SendEventOutput {
+        let mut output: SendEventOutput = Output::new(EventId::from_byte_array([0u8; 32]));
+        for url in success {
+            output.success.insert(relay_url(url), EventSendStatus::Sent);
+        }
+        for (url, reason) in failed {
+            output.failed.insert(relay_url(url), (*reason).to_owned());
+        }
+        output
+    }
+
+    #[test]
+    fn a_send_every_relay_refused_is_a_failure() {
+        // The premise of this whole change: nostr-sdk returns `Ok` once it has tried
+        // every relay, so an all-refused send arrives as `Ok` with nothing in `success`.
+        // Reporting that as published would put "Posted" on screen for a note no relay
+        // stored — which is the bug this exists to remove.
+        let output = send_output(&[], &[("wss://a.example", "blocked")]);
+
+        let error = NostrEvents::relay_verdict(&output).expect_err("should be a failure");
+        assert!(
+            error.contains("no relay accepted") && error.contains("blocked"),
+            "expected the relay's reason to survive, got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_send_no_relay_answered_is_a_failure() {
+        assert!(NostrEvents::relay_verdict(&send_output(&[], &[])).is_err());
+    }
+
+    #[test]
+    fn one_relay_accepting_is_enough() {
+        // The event exists on the network, so a partial failure is logged, not reported.
+        let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
+
+        assert_eq!(NostrEvents::relay_verdict(&output), Ok(()));
+    }
+
+    #[test]
+    fn failure_reasons_read_the_same_way_every_time() {
+        // `failed` is a `HashMap`, so without sorting the same outcome would render
+        // differently from run to run.
+        let output = send_output(
+            &[],
+            &[
+                ("wss://b.example", "blocked"),
+                ("wss://a.example", "bad sig"),
+            ],
+        );
+
+        let error = NostrEvents::relay_verdict(&output).expect_err("should be a failure");
+        assert!(
+            error.find("a.example").expect("a") < error.find("b.example").expect("b"),
+            "expected a stable order, got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_failure_message_does_not_grow_with_the_relay_count() {
+        // The status bar is one non-wrapping line and the published content follows this
+        // string, so naming every relay would push the content off the end.
+        let failed: Vec<(String, String)> = (0..6)
+            .map(|i| (format!("wss://relay{i}.example"), format!("reason {i}")))
+            .collect();
+        let borrowed: Vec<(&str, &str)> = failed
+            .iter()
+            .map(|(url, reason)| (url.as_str(), reason.as_str()))
+            .collect();
+
+        let error = NostrEvents::relay_verdict(&send_output(&[], &borrowed))
+            .expect_err("should be a failure");
+
+        assert!(error.contains("(and 4 more)"), "got: {error}");
+        assert!(!error.contains("relay5.example"), "got: {error}");
+    }
 
     #[test]
     fn followings_use_only_the_latest_contact_list() {

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -263,8 +263,19 @@ impl NostrEvents {
                 // Reported either way, when anybody is waiting. The application shows a
                 // publish as pending until this arrives, so a success that says nothing
                 // would leave it pending for good.
-                if let Some(id) = id {
-                    let _ = msg_tx.send(Message::EventPublished { id, result });
+                match id {
+                    Some(id) => {
+                        let _ = msg_tx.send(Message::EventPublished { id, result });
+                    }
+                    // Nobody is waiting on it, but a failure still has to land somewhere:
+                    // #521 keeps it off the status bar, not out of the log. Read-only
+                    // mode fails every one of these, and without this there would be no
+                    // trace of it anywhere.
+                    None => {
+                        if let Err(reason) = result {
+                            log::error!("Untracked publish failed: {reason}");
+                        }
+                    }
                 }
             }
             NostrCommand::AddRelay { url } => {

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -267,6 +267,11 @@ impl NostrEvents {
                         }
                         Err(e) => Err(e.to_string()),
                     },
+                    // Unreachable as things stand: the application refuses a publish
+                    // before queueing it when there is no signing key, and the NIP-38
+                    // status short-circuits for the same reason. Kept anyway — this is
+                    // the layer that actually holds the keys, and a future publish path
+                    // that forgot the check would otherwise sign nothing and say nothing.
                     None => Err(String::from("cannot send events in read-only mode")),
                 };
 

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -144,12 +144,14 @@ impl NostrEvents {
     /// One relay accepting is enough — the event exists on the network — so a partial
     /// failure is logged rather than reported.
     ///
-    /// "Accepting" means an entry in `success`, which the caller's `AckPolicy::all`
-    /// makes equivalent to an `OK true`. That policy is set explicitly at the send for
-    /// this reason: under `AckPolicy::none` the same field would hold events merely
-    /// written to a socket.
+    /// "Accepting" means an `OK true`, checked rather than assumed. `success` also holds
+    /// `EventSendStatus::Sent` — written to a socket, never acknowledged — under any
+    /// policy but `AckPolicy::all`, so counting the set's size would make this correct
+    /// only for as long as nobody changes the policy at the send. Checking the status
+    /// makes a change there report failure loudly instead of reinstating the claim this
+    /// exists to remove.
     fn relay_verdict(output: &SendEventOutput) -> Result<(), String> {
-        if !output.success.is_empty() {
+        if output.success.values().any(EventSendStatus::is_ack) {
             if !output.failed.is_empty() {
                 log::warn!(
                     "Event {} accepted by {} relay(s), refused by {}",
@@ -552,11 +554,16 @@ mod tests {
     }
 
     #[test]
-    fn one_relay_accepting_is_enough() {
-        // The event exists on the network, so a partial failure is logged, not reported.
+    fn a_send_nobody_acknowledged_is_not_a_publish() {
+        // `Sent` means written to a socket without waiting for an `OK`. It appears under
+        // any policy but `AckPolicy::all`, so if that setting is ever dropped from the
+        // send this must report failure rather than quietly calling it published.
+        //
+        // The accepting direction cannot be tested from here: `EventSendStatus::Ack`
+        // wraps an `EventSendAcknowledgement` with no public constructor.
         let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
 
-        assert_eq!(NostrEvents::relay_verdict(&output), Ok(()));
+        assert!(NostrEvents::relay_verdict(&output).is_err());
     }
 
     #[test]

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -183,24 +183,29 @@ impl NostrEvents {
     /// gets all of them.
     const REPORTED_FAILURES: usize = 2;
 
-    /// Render per-relay failures as `url: reason`, in a stable order so the same outcome
-    /// always reads the same way — `failed` is a `HashMap`.
-    fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
+    /// Per-relay failures as `url: reason`, in a stable order so the same outcome always
+    /// reads the same way — `failed` is a `HashMap`.
+    ///
+    /// The one place this rendering exists. The log line and the status line describe the
+    /// same failure and must not be able to describe it differently, so the short form
+    /// below shortens this rather than rebuilding it.
+    fn sorted_failures(failed: &HashMap<RelayUrl, String>) -> Vec<String> {
         let mut reasons: Vec<String> = failed
             .iter()
             .map(|(url, reason)| format!("{url}: {reason}"))
             .collect();
         reasons.sort();
-        reasons.join(", ")
+        reasons
+    }
+
+    /// Every reason, for the log.
+    fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
+        Self::sorted_failures(failed).join(", ")
     }
 
     /// The same list, shortened for a status bar that can show one line of it.
     fn summarise_failures(failed: &HashMap<RelayUrl, String>) -> String {
-        let mut reasons: Vec<String> = failed
-            .iter()
-            .map(|(url, reason)| format!("{url}: {reason}"))
-            .collect();
-        reasons.sort();
+        let mut reasons = Self::sorted_failures(failed);
 
         let hidden = reasons.len().saturating_sub(Self::REPORTED_FAILURES);
         reasons.truncate(Self::REPORTED_FAILURES);
@@ -558,6 +563,28 @@ mod tests {
         assert!(
             error.find("a.example").expect("a") < error.find("b.example").expect("b"),
             "expected a stable order, got: {error}"
+        );
+    }
+
+    #[test]
+    fn the_short_failure_list_is_a_prefix_of_the_full_one() {
+        // The log line and the status line describe the same failure. They may differ in
+        // length; they must not differ in what they say about the relays they both name.
+        let failed: Vec<(String, String)> = (0..5)
+            .map(|i| (format!("wss://relay{i}.example"), format!("reason {i}")))
+            .collect();
+        let map: HashMap<RelayUrl, String> = failed
+            .iter()
+            .map(|(url, reason)| (relay_url(url), reason.clone()))
+            .collect();
+
+        let full = NostrEvents::describe_failures(&map);
+        let short = NostrEvents::summarise_failures(&map);
+        let named = short.split(" (and ").next().expect("the named part");
+
+        assert!(
+            full.starts_with(named),
+            "the short form must name the same relays in the same order\n full:  {full}\n short: {short}"
         );
     }
 

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -156,7 +156,11 @@ impl NostrEvents {
                 log::warn!(
                     "Event {} accepted by {} relay(s), refused by {}",
                     output.value,
-                    output.success.len(),
+                    output
+                        .success
+                        .values()
+                        .filter(|status| status.is_ack())
+                        .count(),
                     Self::describe_failures(&output.failed)
                 );
             }

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -599,8 +599,10 @@ mod tests {
         // any policy but `AckPolicy::all`, so if that setting is ever dropped from the
         // send this must report failure rather than quietly calling it published.
         //
-        // The accepting direction cannot be tested from here: `EventSendStatus::Ack`
-        // wraps an `EventSendAcknowledgement` with no public constructor.
+        // The accepting direction is not covered by a unit test: `EventSendStatus::Ack`
+        // wraps an `EventSendAcknowledgement` with no public constructor, so it cannot be
+        // built here. It is reachable end to end — nostr-sdk ships a `local-relay`
+        // feature — which is #523.
         let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
 
         assert!(NostrEvents::relay_verdict(&output).is_err());

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -156,25 +156,46 @@ impl NostrEvents {
             return Ok(());
         }
 
+        // Everything to the log, a summary to the caller: this string ends up on one
+        // line of the status bar, and losing reasons from the log too would leave the
+        // failure undiagnosable anywhere.
+        log::error!(
+            "No relay accepted event {}: {}",
+            output.value,
+            Self::describe_failures(&output.failed)
+        );
+
         Err(if output.failed.is_empty() {
             String::from("no relay accepted the event")
         } else {
             format!(
                 "no relay accepted the event: {}",
-                Self::describe_failures(&output.failed)
+                Self::summarise_failures(&output.failed)
             )
         })
     }
 
-    /// How many relays' reasons a failure message names before summarising the rest.
+    /// How many relays' reasons a *reported* failure names before summarising the rest.
     ///
-    /// The status bar is one non-wrapping line, and this string competes with the content
-    /// that follows it. Every relay's reason would push that off the end.
+    /// The status bar is one non-wrapping line and the published content follows this
+    /// string, so naming every relay would push the content off the end. The log is not
+    /// so constrained, and is the only place the reasons can be read at leisure — so it
+    /// gets all of them.
     const REPORTED_FAILURES: usize = 2;
 
     /// Render per-relay failures as `url: reason`, in a stable order so the same outcome
     /// always reads the same way — `failed` is a `HashMap`.
     fn describe_failures(failed: &HashMap<RelayUrl, String>) -> String {
+        let mut reasons: Vec<String> = failed
+            .iter()
+            .map(|(url, reason)| format!("{url}: {reason}"))
+            .collect();
+        reasons.sort();
+        reasons.join(", ")
+    }
+
+    /// The same list, shortened for a status bar that can show one line of it.
+    fn summarise_failures(failed: &HashMap<RelayUrl, String>) -> String {
         let mut reasons: Vec<String> = failed
             .iter()
             .map(|(url, reason)| format!("{url}: {reason}"))

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -2,11 +2,12 @@ use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 
 use crate::domain::nostr::FeedKind;
-use crate::model::nostr_gateway::NostrCommand;
+use crate::model::nostr_gateway::{NostrCommand, PublishId};
 
 pub enum Message {
     ConnectionReady,
     EventSubmitted {
+        id: PublishId,
         event_builder: EventBuilder,
     },
     SubscriptionRequested {
@@ -80,9 +81,10 @@ impl Nostr {
                 self.connected = true;
                 None
             }
-            Message::EventSubmitted { event_builder } => {
+            Message::EventSubmitted { id, event_builder } => {
                 if self.connected {
                     Some(NostrOutcome::Send(NostrCommand::SendEventBuilder {
+                        id,
                         event_builder,
                     }))
                 } else {
@@ -251,12 +253,14 @@ mod tests {
         let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::EventSubmitted {
+            id: PublishId(1),
             event_builder: event_builder.clone(),
         });
 
         assert_eq!(
             outcome,
             Some(NostrOutcome::Send(NostrCommand::SendEventBuilder {
+                id: PublishId(1),
                 event_builder
             }))
         );
@@ -267,7 +271,10 @@ mod tests {
         let mut nostr = Nostr::new();
         let event_builder = EventBuilder::new(Kind::TextNote, "test");
 
-        let outcome = nostr.update(Message::EventSubmitted { event_builder });
+        let outcome = nostr.update(Message::EventSubmitted {
+            id: PublishId(1),
+            event_builder,
+        });
 
         assert_eq!(outcome, None);
     }

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -7,7 +7,8 @@ use crate::model::nostr_gateway::{NostrCommand, PublishId};
 pub enum Message {
     ConnectionReady,
     EventSubmitted {
-        id: PublishId,
+        /// Where to report the outcome, or `None` for a send nobody is waiting on.
+        id: Option<PublishId>,
         event_builder: EventBuilder,
     },
     SubscriptionRequested {
@@ -253,14 +254,14 @@ mod tests {
         let _ = nostr.update(Message::ConnectionReady);
 
         let outcome = nostr.update(Message::EventSubmitted {
-            id: PublishId(1),
+            id: Some(PublishId(1)),
             event_builder: event_builder.clone(),
         });
 
         assert_eq!(
             outcome,
             Some(NostrOutcome::Send(NostrCommand::SendEventBuilder {
-                id: PublishId(1),
+                id: Some(PublishId(1)),
                 event_builder
             }))
         );
@@ -272,7 +273,7 @@ mod tests {
         let event_builder = EventBuilder::new(Kind::TextNote, "test");
 
         let outcome = nostr.update(Message::EventSubmitted {
-            id: PublishId(1),
+            id: Some(PublishId(1)),
             event_builder,
         });
 

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -52,8 +52,6 @@ pub enum NostrCommand {
 /// Errors that can occur during command execution
 #[derive(Debug, Clone)]
 pub enum CommandError {
-    /// Failed to send event to relays
-    SendEventFailed { error: String },
     /// Failed to add relay
     AddRelayFailed { url: String, error: String },
     /// Failed to connect to relay

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -17,11 +17,22 @@ use tokio::sync::mpsc;
 
 use crate::domain::nostr::FeedKind;
 
+/// Identifies one submitted event, so its outcome can be matched back to it.
+///
+/// Correlated rather than matched by order: an outcome that never arrives — a worker
+/// that died, a command dropped on the way — then leaves one stale entry behind instead
+/// of shifting every later outcome onto the wrong submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PublishId(pub u64);
+
 /// Commands that can be sent to the Nostr subscription
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NostrCommand {
     /// Send an event to relays
-    SendEventBuilder { event_builder: EventBuilder },
+    SendEventBuilder {
+        id: PublishId,
+        event_builder: EventBuilder,
+    },
     /// Add a new relay
     AddRelay { url: String },
     /// Remove a relay
@@ -62,6 +73,14 @@ pub enum Message {
     Notification(Box<ClientNotification>),
     /// An error occurred during command execution
     Error { error: CommandError },
+    /// The outcome of one `SendEventBuilder`, reported whether it succeeded or not.
+    ///
+    /// Sent exactly once per submitted event. A publish the application never hears
+    /// about stays pending; it cannot be mistaken for another one's answer.
+    EventPublished {
+        id: PublishId,
+        result: Result<(), String>,
+    },
     /// A subscription was created for a specific tab
     SubscriptionCreated {
         feed: FeedKind,

--- a/src/model/nostr_gateway.rs
+++ b/src/model/nostr_gateway.rs
@@ -30,7 +30,8 @@ pub struct PublishId(pub u64);
 pub enum NostrCommand {
     /// Send an event to relays
     SendEventBuilder {
-        id: PublishId,
+        /// Where to report the outcome, or `None` for a send nobody is waiting on.
+        id: Option<PublishId>,
         event_builder: EventBuilder,
     },
     /// Add a new relay

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -209,9 +209,9 @@ impl<'a> TearsApp<'a> {
                 // What the send is not safe from is the exit itself. The quit applies
                 // synchronously on tears 0.11, so `run` can return while the worker — a
                 // detached task the runtime neither owns nor joins — is still publishing,
-                // and the tokio runtime is dropped moments later. The status bar has
-                // already said "Posted" by then. #511 covers making that claim honest, and
-                // #512 covers giving the send a chance to land.
+                // and the tokio runtime is dropped moments later. The status bar says
+                // "Sending" at that point rather than claiming success, so the user is at
+                // least not told it worked; #512 covers giving the send a chance to land.
                 let _ = self.state.close_connection();
 
                 Command::quit()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -61,7 +61,10 @@ impl<'a> Application for TearsApp<'a> {
         let config = flags.config.clone();
 
         // Initialize global state
-        let state = AppState::new_with_config(flags.pubkey, flags.config);
+        // Without signing keys the application can only read, and it needs to know that
+        // before it attempts a publish nothing could ever complete.
+        let read_only = flags.keys.is_none();
+        let state = AppState::new_with_config(flags.pubkey, flags.config, read_only);
 
         // Initialize components
         let components = Components::new();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -447,6 +447,9 @@ impl<'a> TearsApp<'a> {
                 feed,
                 subscription_id,
             } => self.state.track_subscription_created(feed, subscription_id),
+            NostrSubscriptionMessage::EventPublished { id, result } => {
+                self.state.resolve_publish(id, result)
+            }
             NostrSubscriptionMessage::Notification(notif) => match *notif {
                 // NOTE: We use `RelayPoolNotification::Message` instead of `RelayPoolNotification::Event`
                 // because:


### PR DESCRIPTION
Closes #511. Replaces #513 — see "Why this replaces #513" below.

## The bug

Three paths published events and immediately claimed success:

| site | status at enqueue |
| --- | --- |
| `submit_note` | `[Posted] <content>` |
| `react_to_selected` / `repost_selected` | `[Reacted] <id>` / `[Reposted] <id>` |
| `publish_music_status` (NIP-38, on every track change) | `[Music] <track>` |

All three set that the moment the command was pushed onto the worker's channel. The worst case is not a race: `model::nostr` returns `None` for `EventSubmitted` while disconnected, so the command was **dropped outright** and the status still said the note was posted.

## The fix

A publish is pending until a relay answers. `[Sending] <content>` on submit, then the past-tense label on success or an error on failure. A submission that never reaches the worker settles immediately, since no report will ever arrive for it.

**`Ok` from `send_event` is not the answer.** nostr-sdk returns `Ok(output)` once it has tried every relay, putting per-relay rejections and ack timeouts in `output.failed` and reserving `Err` for setup problems — so an event every relay refused arrives as `Ok` with an empty `success` set. `relay_verdict` reads the output; one relay accepting is enough, since the event then exists on the network, and a partial failure is logged.

**Outcomes are correlated, not queued.** `PublishId` travels on the command and comes back on the report. Matching by queue position instead would be sound only while every submission is reported exactly once *and* in order, which makes correctness depend on every path where that could fail — and fails badly, shifting **every** later publish onto the wrong submission. With an id, a report that never arrives leaves one stale entry and nothing else; a duplicate settles nothing. Both are tested.

## Why this replaces #513

#513 did the same job with positional matching and grew from 212 to 1102 insertions across fifteen review rounds — roughly 80% of it added *in response to review*, and most of it forced by positional matching: an exit drain, connection-loss recovery, queue clearing on reconnect, and a status-bar arbitration policy. The findings kept coming because each round reviewed the previous round's additions.

The maintainer declined to merge that accumulation. This is the re-scope: correlation ids remove the need for most of it by construction, and everything else is split out.

| Split out | Issue |
| --- | --- |
| Status-bar arbitration (who may write over whom) — to be solved correct-by-construction | **#516** |
| Draft lost when the relays reject a note, including read-only mode | **#514** |
| A slow relay ack stalls the whole worker | **#515** |
| A tab opened while the worker is dead stays on "loading..." | **#518** |
| nostui does not notice when the worker dies | **#519** |

Each carries the design work from #513 so none of it has to be rediscovered.

**378 insertions**, against 1102.

## Tests

Five existing tests asserted the old optimistic status — four of them passing while entirely disconnected, i.e. encoding the bug. They now assert the pending state *and* the settled state.

New: failure reported as an error; publishing while disconnected claiming nothing; **outcomes settling out of order** against the right submissions; an unknown id ignored; a duplicate report settling nothing.

`just fmt`, `just lint`, `just test` pass (378 + 3 + 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi