### PR TITLE
perf: stop redrawing for ticks that change no displayed value

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -124,7 +124,7 @@ Drop the option wherever nostui is launched — a shell alias, a `.desktop` entr
 **Note:**
 There is no direct replacement, and no remaining option that behaves like the old throttle.
 
-`--tick-rate` is not one, despite the way it reads. An idle nostui repaints about once a second: the tick refreshes the "ticks per sec" counter on that cadence and declines the redraw on every tick in between, so the tick rate sets how often the application wakes up, not how often it draws. Raising it costs update passes rather than frames.
+`--tick-rate` is not one, despite the way it reads. An idle nostui repaints at most about once a second: the tick refreshes the "ticks per sec" counter on that cadence and declines the redraw on every tick in between, so the tick rate sets how often the application wakes up, not how often it draws. Raising it costs update passes rather than frames. (Below one tick per second there are no ticks in between, so each one redraws — but that is fewer repaints, not more.)
 
 What has no ceiling any more is relay traffic. Redraws follow inbound events instead of being clamped to 16 fps, so a busy home feed can redraw more often than it used to.
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -122,9 +122,11 @@ Drop the option wherever nostui is launched — a shell alias, a `.desktop` entr
 `--tick-rate` is unaffected. It controls how often the application processes a tick, which is also what the FPS display measures.
 
 **Note:**
-There is no direct replacement, and redraw volume can move in either direction. Idle nostui redraws once per tick, so `--tick-rate` currently sets the idle floor and lowering it is the nearest thing to the old throttle — but that is a side effect of how the tick is handled today, not a rendering control, and [#510](https://github.com/akiomik/nostui/issues/510) plans to remove it. Under a busy feed there is no longer any ceiling: redraws follow inbound relay traffic rather than being clamped to 16 fps, so a heavy home feed can redraw more often than it used to.
+There is no direct replacement, and no remaining option that behaves like the old throttle.
 
-The same applies upward, and it is the direction most likely to surprise: a `--tick-rate` you raised on 0.1.x cost extra update passes but never more than 16 renders per second. It now costs a full render per tick even when nothing is happening, so `--tick-rate 200` means 200 renders per second on a completely idle screen. If you raised it, lower it back.
+`--tick-rate` is not one, despite the way it reads. An idle nostui repaints about once a second: the tick refreshes the "ticks per sec" counter on that cadence and declines the redraw on every tick in between, so the tick rate sets how often the application wakes up, not how often it draws. Raising it costs update passes rather than frames.
+
+What has no ceiling any more is relay traffic. Redraws follow inbound events instead of being clamped to 16 fps, so a busy home feed can redraw more often than it used to.
 
 ### Deprecations
 

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -3,6 +3,8 @@
 //! This module defines the message types for the tears application.
 //! These are independent from the existing application::msg system.
 
+use std::time::Instant;
+
 use crossterm::event::KeyEvent;
 use nowhear::{MediaEvent, MediaSourceError};
 
@@ -30,8 +32,12 @@ pub enum SystemMsg {
     Quit,
     /// Terminal resize event
     Resize(u16, u16),
-    /// Tick for FPS calculation
-    Tick,
+    /// Tick for FPS calculation, stamped when the runtime received it
+    ///
+    /// The instant travels with the message so the FPS tracker measures against
+    /// the moment the tick arrived rather than reading the clock itself, which
+    /// is what lets a test drive a whole measurement interval (#510).
+    Tick(Instant),
     /// Show an error message
     ShowError(String),
     /// Key input event

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -3,8 +3,6 @@
 //! This module defines the message types for the tears application.
 //! These are independent from the existing application::msg system.
 
-use std::time::Instant;
-
 use crossterm::event::KeyEvent;
 use nowhear::{MediaEvent, MediaSourceError};
 
@@ -32,12 +30,8 @@ pub enum SystemMsg {
     Quit,
     /// Terminal resize event
     Resize(u16, u16),
-    /// Tick for FPS calculation, stamped when the runtime received it
-    ///
-    /// The instant travels with the message so the FPS tracker measures against
-    /// the moment the tick arrived rather than reading the clock itself, which
-    /// is what lets a test drive a whole measurement interval (#510).
-    Tick(Instant),
+    /// Tick for FPS calculation
+    Tick,
     /// Show an error message
     ShowError(String),
     /// Key input event

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use crossterm::event::KeyEvent;
 use nostr_sdk::prelude::*;
@@ -12,7 +13,7 @@ use crate::{
     domain::nostr::{nip10::ReplyTagsBuilder, nip38::MusicStatus, FeedKind, Profile},
     model::{
         editor::{Editor, Message as EditorMessage},
-        fps::{Fps, Message as FpsMessage},
+        fps::{Fps, FpsOutcome, Message as FpsMessage},
         nostr::{Message as NostrMessage, Nostr, NostrOutcome},
         nostr_gateway::{CommandError, NostrCommand, PublishId},
         status_bar::{Message, StatusBar},
@@ -703,9 +704,16 @@ impl<'a> AppState<'a> {
     }
 
     /// Record a frame tick for FPS tracking.
-    pub fn record_tick(&mut self) -> Command<AppMsg> {
-        self.fps.update(FpsMessage::FrameRecorded { now: None });
-        Command::none()
+    ///
+    /// The rate on screen is recomputed once a second, so the ticks in between
+    /// leave every displayed value exactly as it was and decline the redraw they
+    /// would otherwise cost. Without that an idle nostui would re-render the whole
+    /// timeline at the tick rate to refresh a counter that did not change (#510).
+    pub fn record_tick(&mut self, now: Instant) -> Command<AppMsg> {
+        match self.fps.update(FpsMessage::FrameRecorded { now }) {
+            Some(FpsOutcome::DisplayUpdated) => Command::none(),
+            None => Command::none().without_redraw(),
+        }
     }
 
     /// Move the selection to the previous timeline item.

--- a/src/model/fps.rs
+++ b/src/model/fps.rs
@@ -22,12 +22,13 @@ pub enum Message {
     FrameRecorded {
         /// When the tick was handled.
         ///
-        /// Must not precede an instant already recorded. Intervals are measured
-        /// by subtracting, which `Instant` reserves the right to panic on rather
-        /// than saturate. `AppState::record_tick` satisfies this by stamping at
-        /// dispatch, on the one update loop; a caller that stamped where the tick
-        /// was produced would not, because independent subscription tasks push
-        /// into a shared queue and can be reordered by it.
+        /// Expected not to precede an instant already recorded.
+        /// `AppState::record_tick` satisfies that by stamping at dispatch, on the
+        /// one update loop; a caller that stamped where the tick was produced would
+        /// not, because independent subscription tasks push into a shared queue and
+        /// can be reordered by it. `update` measures saturatingly rather than trust
+        /// the caller, so violating this skews a debug counter instead of panicking
+        /// the update loop on an `Instant` subtraction.
         now: Instant,
     },
 }
@@ -71,7 +72,7 @@ impl Fps {
                 };
 
                 self.app_frames += 1;
-                let elapsed = (now - started_at).as_secs_f64();
+                let elapsed = now.saturating_duration_since(started_at).as_secs_f64();
 
                 if elapsed < 1.0 {
                     return None;
@@ -104,8 +105,7 @@ mod tests {
         let fps1 = Fps::new();
         let fps2 = Fps::default();
 
-        assert_eq!(fps1.app_fps, fps2.app_fps);
-        assert_eq!(fps1.app_frames, fps2.app_frames);
+        assert_eq!(fps1, fps2);
     }
 
     #[test]

--- a/src/model/fps.rs
+++ b/src/model/fps.rs
@@ -19,7 +19,17 @@ pub enum FpsOutcome {
 }
 
 pub enum Message {
-    FrameRecorded { now: Instant },
+    FrameRecorded {
+        /// When the tick was handled.
+        ///
+        /// Must not precede an instant already recorded. Intervals are measured
+        /// by subtracting, which `Instant` reserves the right to panic on rather
+        /// than saturate. `AppState::record_tick` satisfies this by stamping at
+        /// dispatch, on the one update loop; a caller that stamped where the tick
+        /// was produced would not, because independent subscription tasks push
+        /// into a shared queue and can be reordered by it.
+        now: Instant,
+    },
 }
 
 /// FPS measurement data

--- a/src/model/fps.rs
+++ b/src/model/fps.rs
@@ -23,7 +23,7 @@ pub enum Message {
 }
 
 /// FPS measurement data
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Fps {
     app_fps: Option<f64>,
     app_frames: u32,
@@ -61,7 +61,14 @@ impl Fps {
                 };
 
                 self.app_frames += 1;
-                let elapsed = (now - started_at).as_secs_f64();
+                // Saturating, because the ticks are stamped by two independent
+                // subscription tasks (the timer, and the terminal events nostui
+                // ignores — #525) and pushed into one queue, so a later-stamped
+                // message can reach this ahead of an earlier one. Such a tick is
+                // folded into the next interval instead of subtracting backwards,
+                // which `Instant` currently saturates and may go back to panicking
+                // on.
+                let elapsed = now.saturating_duration_since(started_at).as_secs_f64();
 
                 if elapsed < 1.0 {
                     return None;
@@ -74,12 +81,6 @@ impl Fps {
                 Some(FpsOutcome::DisplayUpdated)
             }
         }
-    }
-}
-
-impl Default for Fps {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -212,6 +213,35 @@ mod tests {
             "Expected ~60 FPS, got {app_fps2}"
         );
         assert_eq!(fps.app_frames, 0, "Frame count should be reset");
+    }
+
+    /// A tick stamped before the interval opened has to be folded into it rather
+    /// than subtracting backwards. `Instant`'s saturating subtraction gives the same
+    /// answer today, so this pins the behaviour rather than guarding the explicit
+    /// `saturating_duration_since` — the point is that a reordered tick must not
+    /// close an interval that has not elapsed.
+    #[test]
+    fn test_a_tick_stamped_before_the_interval_started_does_not_end_it() {
+        let mut fps = Fps::new();
+        let start = Instant::now();
+
+        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
+        assert_eq!(
+            fps.update(Message::FrameRecorded {
+                now: start - Duration::from_millis(1),
+            }),
+            None
+        );
+        assert_eq!(fps.app_frames, 1);
+
+        // The interval still ends where it was going to, having counted that tick
+        assert_eq!(
+            fps.update(Message::FrameRecorded {
+                now: start + Duration::from_secs(1),
+            }),
+            Some(FpsOutcome::DisplayUpdated)
+        );
+        assert_eq!(fps.app_fps, Some(2.0));
     }
 
     /// A rate identical to the one already on screen is still reported: the model

--- a/src/model/fps.rs
+++ b/src/model/fps.rs
@@ -1,7 +1,25 @@
 use std::time::Instant;
 
+/// Follow-ups the FPS tracker asks the application to perform.
+///
+/// Like the rest of `model`, `Fps` is side-effect free: `update` mutates state
+/// and returns `Some(outcome)`, or `None` when nothing is required of the
+/// application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FpsOutcome {
+    /// The rate the widget displays was recomputed.
+    ///
+    /// Reported once per measurement interval; the ticks in between leave the
+    /// displayed value untouched, which is what lets the application decline the
+    /// redraw they would otherwise cost (#510). A recomputed rate can be
+    /// numerically identical to the one already on screen — this reports that the
+    /// value was measured again, not that the rendered text differs, which is the
+    /// widget's business and not the model's.
+    DisplayUpdated,
+}
+
 pub enum Message {
-    FrameRecorded { now: Option<Instant> },
+    FrameRecorded { now: Instant },
 }
 
 /// FPS measurement data
@@ -9,7 +27,13 @@ pub enum Message {
 pub struct Fps {
     app_fps: Option<f64>,
     app_frames: u32,
-    last_update: Instant,
+    /// Start of the interval being measured, set by the first tick.
+    ///
+    /// `None` until then. Reading the clock in `new` instead would anchor the
+    /// first interval to construction rather than to the ticks it measures, so
+    /// the first reading would depend on how long startup took and no test could
+    /// drive a whole interval without also racing the wall clock.
+    interval_started_at: Option<Instant>,
 }
 
 impl Fps {
@@ -18,7 +42,7 @@ impl Fps {
         Self {
             app_fps: None,
             app_frames: 0,
-            last_update: Instant::now(),
+            interval_started_at: None,
         }
     }
 
@@ -26,19 +50,28 @@ impl Fps {
         self.app_fps
     }
 
-    pub fn update(&mut self, message: Message) {
+    pub fn update(&mut self, message: Message) -> Option<FpsOutcome> {
         match message {
             Message::FrameRecorded { now } => {
-                self.app_frames += 1;
-                let now = now.unwrap_or_else(Instant::now);
-                let elapsed = (now - self.last_update).as_secs_f64();
+                let Some(started_at) = self.interval_started_at else {
+                    // The first tick starts the first interval rather than being
+                    // counted in it: there is no earlier tick to measure from.
+                    self.interval_started_at = Some(now);
+                    return None;
+                };
 
-                if elapsed >= 1.0 {
-                    let fps = self.app_frames as f64 / elapsed;
-                    self.app_fps = Some(fps);
-                    self.last_update = now;
-                    self.app_frames = 0;
+                self.app_frames += 1;
+                let elapsed = (now - started_at).as_secs_f64();
+
+                if elapsed < 1.0 {
+                    return None;
                 }
+
+                self.app_fps = Some(f64::from(self.app_frames) / elapsed);
+                self.interval_started_at = Some(now);
+                self.app_frames = 0;
+
+                Some(FpsOutcome::DisplayUpdated)
             }
         }
     }
@@ -74,10 +107,20 @@ mod tests {
     #[test]
     fn test_fps_frame_counting() {
         let mut fps = Fps::new();
+        let start = Instant::now();
+
+        // The first tick only starts the interval
+        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
+        assert_eq!(fps.app_frames, 0);
 
         // Record frames quickly
-        for _ in 0..10 {
-            fps.update(Message::FrameRecorded { now: None });
+        for i in 1..=10 {
+            let outcome = fps.update(Message::FrameRecorded {
+                now: start + Duration::from_millis(i * 10),
+            });
+
+            // Nothing is displayed yet, so nothing is asked of the application
+            assert_eq!(outcome, None);
             assert_eq!(fps.app_fps, None);
         }
 
@@ -90,19 +133,23 @@ mod tests {
         let mut fps = Fps::new();
         let start = Instant::now();
 
+        // The first tick starts the interval the rest are measured against
+        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
+
         // Record 59 frames over approximately 1 second (just before threshold)
-        for i in 0..59 {
-            let now = Some(start + Duration::from_millis(i * 1000 / 60));
-            fps.update(Message::FrameRecorded { now });
+        for i in 1..60 {
+            let now = start + Duration::from_millis(i * 1000 / 60);
+            let outcome = fps.update(Message::FrameRecorded { now });
 
             // Should not trigger FPS calculation yet
+            assert_eq!(outcome, None);
             assert_eq!(fps.app_fps(), None);
         }
 
         // 60th frame at exactly 1.0 second should trigger FPS calculation
-        let now = Some(start + Duration::from_secs(1));
-        fps.update(Message::FrameRecorded { now });
-        assert!(fps.app_fps.is_some());
+        let now = start + Duration::from_secs(1);
+        let outcome = fps.update(Message::FrameRecorded { now });
+        assert_eq!(outcome, Some(FpsOutcome::DisplayUpdated));
         let app_fps = fps.app_fps.expect("FPS calculation should succeed");
 
         // Should be approximately 60 FPS (60 frames / 1.0 second)
@@ -120,16 +167,22 @@ mod tests {
         let mut fps = Fps::new();
         let start = Instant::now();
 
+        // The first tick starts the interval the rest are measured against
+        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
+
         // First interval: 29 frames before 1 second
-        for i in 0..29 {
-            let now = Some(start + Duration::from_millis(i * 1000 / 30));
-            fps.update(Message::FrameRecorded { now });
+        for i in 1..30 {
+            let now = start + Duration::from_millis(i * 1000 / 30);
+            assert_eq!(fps.update(Message::FrameRecorded { now }), None);
             assert_eq!(fps.app_fps, None);
         }
 
         // Trigger first FPS calculation at 1 second mark (30th frame)
-        let now = Some(start + Duration::from_secs(1));
-        fps.update(Message::FrameRecorded { now });
+        let now = start + Duration::from_secs(1);
+        assert_eq!(
+            fps.update(Message::FrameRecorded { now }),
+            Some(FpsOutcome::DisplayUpdated)
+        );
         let app_fps1 = fps.app_fps.expect("Should calculate FPS");
         assert!(
             (app_fps1 - 30.0).abs() < 0.01,
@@ -138,19 +191,46 @@ mod tests {
         assert_eq!(fps.app_frames, 0, "Frame count should be reset");
 
         // Second interval: 59 frames in next second
-        for i in 0..59 {
-            let now = Some(start + Duration::from_secs(1) + Duration::from_millis(i * 1000 / 60));
-            fps.update(Message::FrameRecorded { now });
+        for i in 1..60 {
+            let now = start + Duration::from_secs(1) + Duration::from_millis(i * 1000 / 60);
+            assert_eq!(
+                fps.update(Message::FrameRecorded { now }),
+                None,
+                "the interval that has not elapsed yet displays nothing new"
+            );
         }
 
         // Trigger second FPS calculation at 2 second mark (60th frame in this interval)
-        let now = Some(start + Duration::from_secs(2));
-        fps.update(Message::FrameRecorded { now });
+        let now = start + Duration::from_secs(2);
+        assert_eq!(
+            fps.update(Message::FrameRecorded { now }),
+            Some(FpsOutcome::DisplayUpdated)
+        );
         let app_fps2 = fps.app_fps.expect("Should calculate FPS");
         assert!(
             (app_fps2 - 60.0).abs() < 0.01,
             "Expected ~60 FPS, got {app_fps2}"
         );
         assert_eq!(fps.app_frames, 0, "Frame count should be reset");
+    }
+
+    /// A rate identical to the one already on screen is still reported: the model
+    /// knows the value was recomputed, not how the widget renders it. Reporting
+    /// costs one redraw per second, which is the cadence #510 asks for anyway.
+    #[test]
+    fn test_an_unchanged_rate_is_still_reported() {
+        let mut fps = Fps::new();
+        let start = Instant::now();
+
+        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
+
+        for second in 1..=2 {
+            let now = start + Duration::from_secs(second);
+            assert_eq!(
+                fps.update(Message::FrameRecorded { now }),
+                Some(FpsOutcome::DisplayUpdated)
+            );
+            assert_eq!(fps.app_fps, Some(1.0));
+        }
     }
 }

--- a/src/model/fps.rs
+++ b/src/model/fps.rs
@@ -61,14 +61,7 @@ impl Fps {
                 };
 
                 self.app_frames += 1;
-                // Saturating, because the ticks are stamped by two independent
-                // subscription tasks (the timer, and the terminal events nostui
-                // ignores — #525) and pushed into one queue, so a later-stamped
-                // message can reach this ahead of an earlier one. Such a tick is
-                // folded into the next interval instead of subtracting backwards,
-                // which `Instant` currently saturates and may go back to panicking
-                // on.
-                let elapsed = now.saturating_duration_since(started_at).as_secs_f64();
+                let elapsed = (now - started_at).as_secs_f64();
 
                 if elapsed < 1.0 {
                     return None;
@@ -213,35 +206,6 @@ mod tests {
             "Expected ~60 FPS, got {app_fps2}"
         );
         assert_eq!(fps.app_frames, 0, "Frame count should be reset");
-    }
-
-    /// A tick stamped before the interval opened has to be folded into it rather
-    /// than subtracting backwards. `Instant`'s saturating subtraction gives the same
-    /// answer today, so this pins the behaviour rather than guarding the explicit
-    /// `saturating_duration_since` — the point is that a reordered tick must not
-    /// close an interval that has not elapsed.
-    #[test]
-    fn test_a_tick_stamped_before_the_interval_started_does_not_end_it() {
-        let mut fps = Fps::new();
-        let start = Instant::now();
-
-        assert_eq!(fps.update(Message::FrameRecorded { now: start }), None);
-        assert_eq!(
-            fps.update(Message::FrameRecorded {
-                now: start - Duration::from_millis(1),
-            }),
-            None
-        );
-        assert_eq!(fps.app_frames, 1);
-
-        // The interval still ends where it was going to, having counted that tick
-        assert_eq!(
-            fps.update(Message::FrameRecorded {
-                now: start + Duration::from_secs(1),
-            }),
-            Some(FpsOutcome::DisplayUpdated)
-        );
-        assert_eq!(fps.app_fps, Some(2.0));
     }
 
     /// A rate identical to the one already on screen is still reported: the model

--- a/src/presentation/widgets/fps.rs
+++ b/src/presentation/widgets/fps.rs
@@ -56,7 +56,8 @@ mod tests {
     fn test_render_some() {
         let mut fps = Fps::new();
         let now = Instant::now();
-        // The first tick starts the interval; two more land inside it
+        // The first tick starts the interval, the second lands inside it, and
+        // the third closes it a second later — two frames measured over one second
         fps.update(Message::FrameRecorded { now });
         fps.update(Message::FrameRecorded {
             now: now + Duration::from_millis(500),

--- a/src/presentation/widgets/fps.rs
+++ b/src/presentation/widgets/fps.rs
@@ -56,9 +56,13 @@ mod tests {
     fn test_render_some() {
         let mut fps = Fps::new();
         let now = Instant::now();
-        fps.update(Message::FrameRecorded { now: Some(now) });
+        // The first tick starts the interval; two more land inside it
+        fps.update(Message::FrameRecorded { now });
         fps.update(Message::FrameRecorded {
-            now: Some(now + Duration::from_secs(1)),
+            now: now + Duration::from_millis(500),
+        });
+        fps.update(Message::FrameRecorded {
+            now: now + Duration::from_secs(1),
         });
 
         let widget = FpsWidget::new(fps);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -130,7 +130,7 @@ impl<'a> Application for TearsApp<'a> {
             .map(|msg| AppMsg::Nostr(NostrMsg::SubscriptionMessage(msg))),
             // Timer subscription - interval validated during initialization
             Subscription::new(self.tick_timer.clone()).map(|msg| match msg {
-                TimerEvent::Tick => AppMsg::System(SystemMsg::Tick(Instant::now())),
+                TimerEvent::Tick => AppMsg::System(SystemMsg::Tick),
             }),
             Subscription::new(TerminalEvents::new()).map(|result| match result {
                 Ok(event) => {
@@ -140,9 +140,9 @@ impl<'a> Application for TearsApp<'a> {
                         Event::Resize(width, height) => {
                             AppMsg::System(SystemMsg::Resize(width, height))
                         }
-                        // Ignore other events for now. Stamped like a real tick, which
-                        // is what the FPS counter then treats it as — noted in #525.
-                        _ => AppMsg::System(SystemMsg::Tick(Instant::now())),
+                        // Ignore other events for now. The FPS display counts them as
+                        // ticks all the same — noted in #525.
+                        _ => AppMsg::System(SystemMsg::Tick),
                     }
                 }
                 Err(e) => AppMsg::System(SystemMsg::ShowError(e.to_string())),
@@ -227,14 +227,19 @@ impl<'a> TearsApp<'a> {
                 // Terminal resize is handled automatically by ratatui
                 Command::none()
             }
-            // Count ticks for the FPS display. This measures how often the application
-            // processes a tick, which is not how often it renders: the runtime renders
-            // once per pass that leaves the view dirty, and a tick only dirties it on the
-            // one pass per second that recomputes the displayed rate. So on an idle
-            // nostui the counter reads `--tick-rate` while the screen is repainted once a
-            // second, and under relay traffic the renders the events add are ones the
-            // counter knows nothing about.
-            SystemMsg::Tick(now) => self.state.record_tick(now),
+            // Count ticks for the FPS display. The instant is read here, as the tick is
+            // handled, rather than travelling on the message from the subscription task
+            // that produced it: the counter is meant to fall behind when the update loop
+            // does, and a production stamp would keep reading `--tick-rate` no matter how
+            // long a tick waited in the queue.
+            //
+            // What it measures is therefore how often the application processes a tick,
+            // which is not how often it renders: the runtime renders once per pass that
+            // leaves the view dirty, and a tick only dirties it on the one pass per second
+            // that recomputes the displayed rate. So an idle nostui repaints once a second
+            // while ticking at `--tick-rate`, and under relay traffic the renders the
+            // events add are ones the counter knows nothing about.
+            SystemMsg::Tick => self.state.record_tick(Instant::now()),
             SystemMsg::ShowError(error) => self.state.show_error(error),
             SystemMsg::KeyInput(key) => self.handle_key_input(key),
         }
@@ -507,7 +512,6 @@ impl<'a> TearsApp<'a> {
 mod tests {
     use std::borrow::Cow;
     use std::num::NonZeroU64;
-    use std::time::Duration;
 
     use nostr_sdk::prelude::Event as NostrEvent;
     use tears::testing::TestStore;
@@ -904,40 +908,25 @@ mod tests {
     /// #510(b): an idle nostui ticks at `--tick-rate` but the rate it displays is
     /// only recomputed once a second, so the ticks in between must not repaint the
     /// whole timeline to refresh a counter that did not change.
+    ///
+    /// Only this direction can be driven from a test: the tick is stamped as it is
+    /// handled, so reaching the tick that does recompute would mean waiting a real
+    /// second. That the recomputing tick redraws is covered where the decision is
+    /// made — `Fps::update` reporting `DisplayUpdated` (see `model::fps`) — and an
+    /// inverted mapping in `record_tick` fails this test.
     #[test]
     fn test_tick_that_changes_no_displayed_value_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
-        let start = Instant::now();
 
-        // A second's worth of ticks at the default rate: the first opens the
-        // measurement interval, the rest fall inside it. None of them changes a
-        // displayed value, so none of them may redraw.
-        for i in 0..16 {
-            store.send(AppMsg::System(SystemMsg::Tick(
-                start + Duration::from_millis(i * 62),
-            )));
+        // The first tick opens the measurement interval and the rest fall inside
+        // it: a test runs far quicker than the second it takes to close.
+        for _ in 0..16 {
+            store.send(AppMsg::System(SystemMsg::Tick));
 
             assert!(!store.redraw_requested());
             assert_eq!(store.state().state.fps.app_fps(), None);
         }
 
-        store.finish();
-    }
-
-    /// The other direction: the one tick per second that does refresh the displayed
-    /// rate has to redraw, or the counter would freeze at whatever was last painted.
-    #[test]
-    fn test_tick_that_refreshes_the_displayed_rate_redraws() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
-        let start = Instant::now();
-
-        store.send(AppMsg::System(SystemMsg::Tick(start)));
-        store.send(AppMsg::System(SystemMsg::Tick(
-            start + Duration::from_secs(1),
-        )));
-
-        assert!(store.redraw_requested());
-        assert_eq!(store.state().state.fps.app_fps(), Some(1.0));
         store.finish();
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::sync::Arc;
+use std::time::Instant;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use nostr_sdk::prelude::*;
@@ -129,7 +130,7 @@ impl<'a> Application for TearsApp<'a> {
             .map(|msg| AppMsg::Nostr(NostrMsg::SubscriptionMessage(msg))),
             // Timer subscription - interval validated during initialization
             Subscription::new(self.tick_timer.clone()).map(|msg| match msg {
-                TimerEvent::Tick => AppMsg::System(SystemMsg::Tick),
+                TimerEvent::Tick => AppMsg::System(SystemMsg::Tick(Instant::now())),
             }),
             Subscription::new(TerminalEvents::new()).map(|result| match result {
                 Ok(event) => {
@@ -139,7 +140,9 @@ impl<'a> Application for TearsApp<'a> {
                         Event::Resize(width, height) => {
                             AppMsg::System(SystemMsg::Resize(width, height))
                         }
-                        _ => AppMsg::System(SystemMsg::Tick), // Ignore other events for now
+                        // Ignore other events for now. Stamped like a real tick, which
+                        // is what the FPS counter then treats it as — noted in #525.
+                        _ => AppMsg::System(SystemMsg::Tick(Instant::now())),
                     }
                 }
                 Err(e) => AppMsg::System(SystemMsg::ShowError(e.to_string())),
@@ -225,11 +228,13 @@ impl<'a> TearsApp<'a> {
                 Command::none()
             }
             // Count ticks for the FPS display. This measures how often the application
-            // processes a tick, which is no longer the same as how often it renders: the
-            // runtime renders once per pass that leaves the view dirty. An idle nostui has
-            // only the tick to dirty it, so the two rates still coincide there, but every
-            // inbound relay event adds a pass the tick knows nothing about.
-            SystemMsg::Tick => self.state.record_tick(),
+            // processes a tick, which is not how often it renders: the runtime renders
+            // once per pass that leaves the view dirty, and a tick only dirties it on the
+            // one pass per second that recomputes the displayed rate. So on an idle
+            // nostui the counter reads `--tick-rate` while the screen is repainted once a
+            // second, and under relay traffic the renders the events add are ones the
+            // counter knows nothing about.
+            SystemMsg::Tick(now) => self.state.record_tick(now),
             SystemMsg::ShowError(error) => self.state.show_error(error),
             SystemMsg::KeyInput(key) => self.handle_key_input(key),
         }
@@ -502,6 +507,7 @@ impl<'a> TearsApp<'a> {
 mod tests {
     use std::borrow::Cow;
     use std::num::NonZeroU64;
+    use std::time::Duration;
 
     use nostr_sdk::prelude::Event as NostrEvent;
     use tears::testing::TestStore;
@@ -892,6 +898,46 @@ mod tests {
 
         assert_eq!(store.state().state.timeline.len(), 1);
         assert!(store.redraw_requested());
+        store.finish();
+    }
+
+    /// #510(b): an idle nostui ticks at `--tick-rate` but the rate it displays is
+    /// only recomputed once a second, so the ticks in between must not repaint the
+    /// whole timeline to refresh a counter that did not change.
+    #[test]
+    fn test_tick_that_changes_no_displayed_value_does_not_redraw() {
+        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let start = Instant::now();
+
+        // A second's worth of ticks at the default rate: the first opens the
+        // measurement interval, the rest fall inside it. None of them changes a
+        // displayed value, so none of them may redraw.
+        for i in 0..16 {
+            store.send(AppMsg::System(SystemMsg::Tick(
+                start + Duration::from_millis(i * 62),
+            )));
+
+            assert!(!store.redraw_requested());
+            assert_eq!(store.state().state.fps.app_fps(), None);
+        }
+
+        store.finish();
+    }
+
+    /// The other direction: the one tick per second that does refresh the displayed
+    /// rate has to redraw, or the counter would freeze at whatever was last painted.
+    #[test]
+    fn test_tick_that_refreshes_the_displayed_rate_redraws() {
+        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let start = Instant::now();
+
+        store.send(AppMsg::System(SystemMsg::Tick(start)));
+        store.send(AppMsg::System(SystemMsg::Tick(
+            start + Duration::from_secs(1),
+        )));
+
+        assert!(store.redraw_requested());
+        assert_eq!(store.state().state.fps.app_fps(), Some(1.0));
         store.finish();
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -907,31 +907,28 @@ mod tests {
     }
 
     /// #510(b): an idle nostui ticks at `--tick-rate` but the rate it displays is
-    /// only recomputed once a second, so the ticks in between must not repaint the
-    /// whole timeline to refresh a counter that did not change.
+    /// only recomputed once a second, so a tick that recomputed nothing must not
+    /// repaint the whole timeline to refresh a counter that did not change.
     ///
-    /// Only this direction can be driven from a test: the tick is stamped as it is
-    /// handled, so reaching the tick that does recompute would mean waiting a real
-    /// second. That the recomputing tick redraws is covered where the decision is
-    /// made — `Fps::update` reporting `DisplayUpdated` (see `model::fps`) — and an
-    /// inverted mapping in `record_tick` fails this test.
+    /// One tick, because the first is the only one whose outcome does not depend on
+    /// the clock: it opens the measurement interval and returns before any interval
+    /// is measured, so no amount of scheduling delay can turn it into a recompute.
+    /// Later ticks reach `record_tick` through the same `None` arm, and which of
+    /// `Fps::update`'s two `None` paths produced it is pinned in `model::fps`.
     ///
-    /// The same stamping leaves this test reading the real clock: it holds while the
-    /// sends below all land inside one second, which sixteen synchronous `update`
-    /// calls have many orders of magnitude of room for, but is not a property the
-    /// test can assert.
+    /// The tick that does recompute cannot be driven from here at all: it is stamped
+    /// as it is handled, so reaching it would mean waiting a real second. That
+    /// direction is likewise covered where the decision is made — `Fps::update`
+    /// reporting `DisplayUpdated`. An inverted mapping in `record_tick` fails this
+    /// test.
     #[test]
     fn test_tick_that_changes_no_displayed_value_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
-        // The first tick opens the measurement interval and the rest fall inside it.
-        for _ in 0..16 {
-            store.send(AppMsg::System(SystemMsg::Tick));
+        store.send(AppMsg::System(SystemMsg::Tick));
 
-            assert!(!store.redraw_requested());
-            assert_eq!(store.state().state.fps.app_fps(), None);
-        }
-
+        assert!(!store.redraw_requested());
+        assert_eq!(store.state().state.fps.app_fps(), None);
         store.finish();
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -235,10 +235,11 @@ impl<'a> TearsApp<'a> {
             //
             // What it measures is therefore how often the application processes a tick,
             // which is not how often it renders: the runtime renders once per pass that
-            // leaves the view dirty, and a tick only dirties it on the one pass per second
-            // that recomputes the displayed rate. So an idle nostui repaints once a second
-            // while ticking at `--tick-rate`, and under relay traffic the renders the
-            // events add are ones the counter knows nothing about.
+            // leaves the view dirty, and a tick only dirties it on the pass that recomputes
+            // the displayed rate. So an idle nostui repaints at most once a second while
+            // ticking at `--tick-rate` — a rate below 1/s has no ticks in between to
+            // decline, and every one of them redraws — and under relay traffic the renders
+            // the events add are ones the counter knows nothing about.
             SystemMsg::Tick => self.state.record_tick(Instant::now()),
             SystemMsg::ShowError(error) => self.state.show_error(error),
             SystemMsg::KeyInput(key) => self.handle_key_input(key),
@@ -914,12 +915,16 @@ mod tests {
     /// second. That the recomputing tick redraws is covered where the decision is
     /// made — `Fps::update` reporting `DisplayUpdated` (see `model::fps`) — and an
     /// inverted mapping in `record_tick` fails this test.
+    ///
+    /// The same stamping leaves this test reading the real clock: it holds while the
+    /// sends below all land inside one second, which sixteen synchronous `update`
+    /// calls have many orders of magnitude of room for, but is not a property the
+    /// test can assert.
     #[test]
     fn test_tick_that_changes_no_displayed_value_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
-        // The first tick opens the measurement interval and the rest fall inside
-        // it: a test runs far quicker than the second it takes to close.
+        // The first tick opens the measurement interval and the rest fall inside it.
         for _ in 0..16 {
             store.send(AppMsg::System(SystemMsg::Tick));
 


### PR DESCRIPTION
Part **(b)** of #510, on top of #524 (part (a)).

## What was wrong

`SystemMsg::Tick` reached `AppState::record_tick`, which bumped the FPS counter and returned a redrawing command. On tears 0.11 the runtime renders whenever an update pass leaves the view dirty and parks when it does not — so a completely idle nostui re-rendered the whole timeline at `--tick-rate`, 16 times a second by default, to refresh a counter whose displayed value changes once a second. The park never engaged.

## The change

`Fps::update` already knew which tick mattered: it recomputes only once the interval has elapsed. It now says so, returning `Option<FpsOutcome>` like the other side-effect-free `model` components, and `record_tick` declines the redraw for every tick that recomputed nothing.

Idle redraws go from `--tick-rate` per second to one. The FPS line still updates once a second and still reads as ticks per second.

The `without_redraw` declaration is true here, not merely convenient: the FPS line is the only time-dependent thing on screen — note timestamps are absolute wall clock (`text_note.rs`'s `formatted_created_at`), not relative — so a tick that did not recompute the rate leaves the rendered view identical.

## One supporting change, and why it is in this PR

**`Fps` starts its first interval at the first tick rather than at construction.** Anchoring to construction made every reading depend on how long startup took — a latent flake the existing tests were only narrowly avoiding, and one my first attempt at these tests walked straight into. The first tick now opens the interval instead of being counted inside it, which is also the more accurate measure: N+1 ticks one second apart are N intervals, not N+1. Steady-state readings are unchanged (at `--tick-rate 16` the counter reads about 16 either way — `tick_timer_from_rate` truncates that rate to a 62 ms interval, so the figure was never exactly 16.0), and three existing tests' expected frame counts shift by one for that reason.

`Fps::update` also takes the instant as a parameter rather than reading the clock itself, replacing the test-only `now: Option<Instant>` seam with one the caller always uses. `record_tick` reads `Instant::now()` at the point the tick is handled — deliberately not in the subscription task that produced it. The data lane is unbounded, so a tick can wait in the queue while the update loop is behind; a production stamp would make an interval close once the *stamps* spanned a second, and the counter would read `--tick-rate` however far behind the loop had fallen. The number exists to fall in exactly that case.

## Tests

- Model: `Fps::update` reports `DisplayUpdated` only on the tick that recomputes, and `None` for every tick inside the interval. The existing interval tests now assert the outcome as well as the value.
- Runtime, through `TestStore::redraw_requested`: a tick produces no redraw and leaves the displayed rate unset. Inverting the two-line mapping in `record_tick` fails it.

The runtime test sends one tick, and deliberately: the first tick opens the measurement interval and returns before anything is measured, so its outcome cannot depend on the clock. Later ticks reach `record_tick` through the same `None` arm, so sending more would buy no wiring coverage and would make the test hold only while the sends land inside one real second. The tick that recomputes cannot be driven from a test at all — it is stamped as it is handled — so both of those directions are pinned at `Fps::update`, where the decision is actually made.

## Docs

The `Removed: --frame-rate` note said idle nostui redraws once per tick, that `--tick-rate` therefore set the idle floor and lowering it was the nearest thing to the old throttle, and that `--tick-rate 200` would mean 200 renders per second on an idle screen. This is the change that removes that property, so the note now says `--tick-rate` sets how often the application wakes up, not how often it draws.

## Not in scope

- **(c)/(d)** — measuring `pulled` on `tears::runtime::load` under a real feed and deciding what to do about event-driven redraws. Untouched; this PR is the baseline that measurement should be taken against.
- **#525** (filed from this work) — the terminal subscription maps every event it ignores (mouse, focus, paste) to a tick, so those events inflate the "ticks per sec" reading. Pre-existing; this PR only leaves a comment pointing at it.
- **#527** (filed from this review) — the FPS counter is rendered unconditionally, so the once-a-second repaint this PR leaves is the floor: the loop never truly parks while a debug counter no one asked for is on screen. Making it optional is a separate decision, and (c)/(d) should measure against this floor rather than against zero.
- **`route_relay_event`'s unmatched-subscription branch** — noted on #510 while reviewing #524; still belongs with (b)/(d)'s per-message decisions, and is not a free `without_redraw` because the method writes to the status bar before the lookup during startup.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi

