### PR TITLE
fix: the Nostr status line said "disconntected"

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1895,9 +1895,9 @@ mod tests {
         assert!(message.starts_with("[ERR: Nostr]"));
     }
 
-    /// The word reaches the user, and `typos` does not read string literals like this
-    /// one — it does not flag `disconntected`, which is how that spelling survived. So
-    /// the spelling is asserted here instead of left to the linter.
+    /// The word reaches the user, and `typos` scans this file but does not know
+    /// `disconntected` — this very comment carries that spelling and still lints
+    /// clean. So the spelling is asserted here instead of left to the linter.
     #[test]
     fn test_notify_subscription_shutdown_says_disconnected() {
         let mut state = AppState::new(Keys::generate().public_key());

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -824,7 +824,7 @@ impl<'a> AppState<'a> {
     /// Show that the Nostr subscription was shut down.
     pub fn notify_subscription_shutdown(&mut self) -> Command<AppMsg> {
         log::info!("Nostr subscription shut down");
-        self.set_status("Nostr", "disconntected");
+        self.set_status("Nostr", "disconnected");
         Command::none()
     }
 
@@ -1893,5 +1893,17 @@ mod tests {
 
         let message = state.status_bar.message().expect("status set");
         assert!(message.starts_with("[ERR: Nostr]"));
+    }
+
+    /// The word reaches the user, and `typos` does not read string literals like this
+    /// one — it does not flag `disconntected`, which is how that spelling survived. So
+    /// the spelling is asserted here instead of left to the linter.
+    #[test]
+    fn test_notify_subscription_shutdown_says_disconnected() {
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        let _ = state.notify_subscription_shutdown();
+
+        assert_eq!(state.status_bar.message(), Some("[Nostr] disconnected"));
     }
 }


### PR DESCRIPTION
Closes #532.

`AppState::notify_subscription_shutdown` wrote `[Nostr] disconntected` to the status bar whenever the Nostr subscription shut down.

## Why the linter was never going to catch it

`just lint` runs `typos`. It does not flag this word — I ran it on the word alone and it exits 0 — so the only thing standing between that spelling and a release was somebody reading the line.

That is also why the fix comes with a test. `notify_subscription_shutdown` had none at all, so nothing pinned its text; the same gap that let `disconntected` through would let the next one through too. Reverting the spelling fails the new test.

## Not in scope

Teaching `typos` this particular word is not worth it once it is fixed, and the general problem — user-facing strings that no linter reads — is what the test addresses for this one line rather than for the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
