### PR TITLE
fix: a key release is not someone pressing a key

### DIFF
--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -43,9 +43,9 @@ pub enum SystemMsg {
     /// does not clear `ENABLE_MOUSE_INPUT`, which is on by default — so there they do
     /// arrive. Before #527 they became ticks, which the FPS display counted as such.
     ///
-    /// That is about the events routed *here*. A Windows console also reports key
-    /// releases, and the `Event::Key` arm in `TearsApp::subscriptions` turns those into
-    /// `KeyInput` like any press — #531.
+    /// A Windows console also reports key releases, and those come here too since #531:
+    /// a release is not someone pressing a key, and treating it as one ran every binding
+    /// twice on that platform. See `terminal_event_to_msg`.
     TerminalEventIgnored,
     /// Show an error message
     ShowError(String),

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -44,8 +44,10 @@ pub enum SystemMsg {
     /// arrive. Before #527 they became ticks, which the FPS display counted as such.
     ///
     /// A Windows console also reports key releases, and those come here too since #531:
-    /// a release is not someone pressing a key, and treating it as one ran every binding
-    /// twice on that platform. See `terminal_event_to_msg`.
+    /// a release is not someone pressing a key. Configured bindings never matched one —
+    /// their map compares the kind — but the paths that read the key's code alone did
+    /// act on it, so cancelling a draft with `Esc` also cleared the timeline selection.
+    /// See `terminal_event_to_msg`.
     TerminalEventIgnored,
     /// Show an error message
     ShowError(String),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -200,15 +200,19 @@ impl<'a> Application for TearsApp<'a> {
 /// rather than ends here.
 ///
 /// `Repeat` is treated as input for the same reason: it means the key is still down.
-/// What comes of that depends on the mode. Composing reads `(code, modifiers)` and never
-/// the kind, and `tui-textarea` drops only `Release`, so a held key types repeats the way
-/// it should. Normal mode looks the binding up in a map keyed by `KeyEvent`, whose `Eq`
-/// and `Hash` include the kind, against entries built by `KeyEvent::new` — `Press` — so
-/// there a repeat matches nothing (#536). Nothing produces one today in either mode:
-/// crossterm reports that kind only through the kitty keyboard protocol, which nostui
-/// never asks for. It is named rather than lumped in with `Release` because a repeat *is*
-/// someone pressing the key, and `KeyEventKind` is a closed enum, so saying which of the
-/// three is which costs nothing.
+/// What comes of that depends on which path takes it, and the three do not agree —
+/// which is #536, not something this function can settle. Configured bindings live in a
+/// map keyed by `KeyEvent`, whose `Eq` and `Hash` include the kind, against entries
+/// built by `KeyEvent::new` — `Press` — so a repeat matches nothing there. Composing
+/// never consults that map: its `Esc` and `Ctrl+P` arms read `(code, modifiers)` alone,
+/// so a repeat fires them again, and everything else reaches `tui-textarea`, which drops
+/// only `Release` and so types the repeat as it should. Nothing produces one today in
+/// any of them: crossterm reports that kind only through the kitty keyboard protocol,
+/// which nostui never asks for.
+///
+/// It is named rather than lumped in with `Release` because a repeat *is* someone
+/// pressing the key, and `KeyEventKind` is a closed enum, so saying which of the three
+/// is which costs nothing.
 ///
 /// A free function rather than the closure it replaces: the closure lives inside
 /// `subscriptions`, which no test drives, and the decision above is worth pinning.
@@ -972,9 +976,9 @@ mod tests {
     }
 
     /// The other two kinds are the key going down or staying down, and this pins where
-    /// the mapping sends them — not what happens next, which differs by mode: a repeat
-    /// types normally while composing, and resolves to no binding in normal mode (#536).
-    /// Both are moot until nostui asks for the kitty keyboard protocol.
+    /// the mapping sends them — not what happens next, which the three key paths answer
+    /// differently and inconsistently (#536). All of it is moot until nostui asks for the
+    /// kitty keyboard protocol, which is the only thing that reports a repeat.
     #[test]
     fn test_key_press_and_repeat_are_input() {
         for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use nostr_sdk::prelude::*;
 use nowhear::{MediaEvent, MediaSourceError};
 use ratatui::prelude::*;
@@ -123,16 +123,7 @@ impl<'a> Application for TearsApp<'a> {
             ))
             .map(|msg| AppMsg::Nostr(NostrMsg::SubscriptionMessage(msg))),
             Subscription::new(TerminalEvents::new()).map(|result| match result {
-                Ok(event) => {
-                    // Handle different terminal event types
-                    match event {
-                        Event::Key(key) => AppMsg::System(SystemMsg::KeyInput(key)),
-                        Event::Resize(width, height) => {
-                            AppMsg::System(SystemMsg::Resize(width, height))
-                        }
-                        _ => AppMsg::System(SystemMsg::TerminalEventIgnored),
-                    }
-                }
+                Ok(event) => terminal_event_to_msg(event),
                 Err(e) => AppMsg::System(SystemMsg::ShowError(e.to_string())),
             }),
         ];
@@ -179,6 +170,34 @@ impl<'a> Application for TearsApp<'a> {
         }
 
         subs
+    }
+}
+
+/// Map one terminal event to the message it should become.
+///
+/// A key event is input only when the key is going down. A Windows console reports
+/// releases too — crossterm's WinAPI source sets the kind from the record's `key_down`
+/// flag and passes both up — so without this every binding ran twice there: `j` scrolled
+/// two notes, `x` closed two tabs (#531). Unix reports presses only, so this changes
+/// nothing there.
+///
+/// `Repeat` counts as a press because it means the key is still down, which is what
+/// someone holding `j` to scroll is asking for. Nothing produces it today: crossterm
+/// reports that kind only through the kitty keyboard protocol, and nostui never pushes
+/// the enhancement flags that turn it on. Naming it is what keeps holding a key working
+/// if that ever changes, and `KeyEventKind` is a closed enum, so the match stays honest
+/// about all three.
+///
+/// A free function rather than the closure it replaces: the closure lives inside
+/// `subscriptions`, which no test drives, and the decision above is worth pinning.
+fn terminal_event_to_msg(event: Event) -> AppMsg {
+    match event {
+        Event::Key(key) => match key.kind {
+            KeyEventKind::Press | KeyEventKind::Repeat => AppMsg::System(SystemMsg::KeyInput(key)),
+            KeyEventKind::Release => AppMsg::System(SystemMsg::TerminalEventIgnored),
+        },
+        Event::Resize(width, height) => AppMsg::System(SystemMsg::Resize(width, height)),
+        _ => AppMsg::System(SystemMsg::TerminalEventIgnored),
     }
 }
 
@@ -909,6 +928,55 @@ mod tests {
         assert_eq!(store.state().state.timeline.len(), 1);
         assert!(store.redraw_requested());
         store.finish();
+    }
+
+    /// #531: a Windows console reports a release for every press. A release is not
+    /// someone pressing a key, so it must not reach `KeyInput` — before this it did,
+    /// and every binding ran twice there.
+    #[test]
+    fn test_key_release_is_not_input() {
+        let release = KeyEvent::new_with_kind(
+            KeyCode::Char('j'),
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        );
+
+        assert!(matches!(
+            terminal_event_to_msg(Event::Key(release)),
+            AppMsg::System(SystemMsg::TerminalEventIgnored)
+        ));
+    }
+
+    /// The other two kinds are the key going down or staying down, which is what a
+    /// binding is for. `Repeat` is unreachable until nostui asks for the kitty
+    /// keyboard protocol; naming it is what keeps holding a key working if it does.
+    #[test]
+    fn test_key_press_and_repeat_are_input() {
+        for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {
+            let key = KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, kind);
+
+            assert!(
+                matches!(
+                    terminal_event_to_msg(Event::Key(key)),
+                    AppMsg::System(SystemMsg::KeyInput(got)) if got == key
+                ),
+                "{kind:?} should reach the keybindings"
+            );
+        }
+    }
+
+    /// Resizes still route to their own message, and everything else nostui does not
+    /// act on to the one that does nothing.
+    #[test]
+    fn test_other_terminal_events_keep_their_routing() {
+        assert!(matches!(
+            terminal_event_to_msg(Event::Resize(80, 24)),
+            AppMsg::System(SystemMsg::Resize(80, 24))
+        ));
+        assert!(matches!(
+            terminal_event_to_msg(Event::FocusGained),
+            AppMsg::System(SystemMsg::TerminalEventIgnored)
+        ));
     }
 
     /// A terminal event nostui does not act on changes nothing, so it must not

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -187,11 +187,17 @@ impl<'a> Application for TearsApp<'a> {
 /// mode's fallback to `Deselect` — one keystroke also clearing a timeline selection
 /// nobody asked it to. Typing was safe: `tui-textarea` discards releases itself.
 ///
-/// "Going down" is the rule rather than the whole story. The same parser deliberately
-/// reports an Alt code — Alt held over a numpad sequence — as a `Release` carrying the
-/// composed character, so that it cannot be discarded as a release. nostui never
-/// received those anyway, since `tui-textarea` dropped them; supporting Alt codes on
-/// Windows means coming back here first.
+/// "Going down" is the rule rather than the whole story, and the exception is worth
+/// knowing before someone goes looking for it. The same parser reports an Alt code —
+/// Alt held over a numpad sequence — as a `KeyCode::Char` carrying the composed
+/// character, with the kind still taken from `key_down`, so it arrives here as a
+/// `Release`. crossterm's exception is only to its own discarding of releases; the arm
+/// below is a separate filter and does drop it.
+///
+/// Nothing changes today: before this, an Alt code reached `tui-textarea` and was
+/// discarded there for the same reason, so it never typed anything either way. What
+/// changes is where it stops. Adding Alt-code support on Windows (#537) starts here
+/// rather than ends here.
 ///
 /// `Repeat` is treated as input for the same reason: it means the key is still down.
 /// What comes of that depends on the mode. Composing reads `(code, modifiers)` and never

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -181,12 +181,15 @@ impl<'a> Application for TearsApp<'a> {
 /// two notes, `x` closed two tabs (#531). Unix reports presses only, so this changes
 /// nothing there.
 ///
-/// `Repeat` counts as a press because it means the key is still down, which is what
-/// someone holding `j` to scroll is asking for. Nothing produces it today: crossterm
-/// reports that kind only through the kitty keyboard protocol, and nostui never pushes
-/// the enhancement flags that turn it on. Naming it is what keeps holding a key working
-/// if that ever changes, and `KeyEventKind` is a closed enum, so the match stays honest
-/// about all three.
+/// `Repeat` is treated as input for the same reason: it means the key is still down.
+/// That is where the resemblance to a press ends today — the keybinding map is keyed by
+/// `KeyEvent`, whose `Eq` and `Hash` include the kind, and configured bindings are built
+/// with `KeyEvent::new`, which sets `Press`. So a repeat reaches `handle_key_input` and
+/// then matches nothing (#536). Nothing produces one either: crossterm reports that kind
+/// only through the kitty keyboard protocol, which nostui never asks for. It is named
+/// rather than lumped in with `Release` because a repeat *is* someone pressing the key,
+/// and `KeyEventKind` is a closed enum, so saying which of the three is which costs
+/// nothing.
 ///
 /// A free function rather than the closure it replaces: the closure lives inside
 /// `subscriptions`, which no test drives, and the decision above is worth pinning.
@@ -947,9 +950,10 @@ mod tests {
         ));
     }
 
-    /// The other two kinds are the key going down or staying down, which is what a
-    /// binding is for. `Repeat` is unreachable until nostui asks for the kitty
-    /// keyboard protocol; naming it is what keeps holding a key working if it does.
+    /// The other two kinds are the key going down or staying down, and this pins where
+    /// the mapping sends them — not what happens next. A repeat gets no further than
+    /// `handle_key_input` today, since the binding map compares the kind (#536), and is
+    /// unreachable anyway until nostui asks for the kitty keyboard protocol.
     #[test]
     fn test_key_press_and_repeat_are_input() {
         for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -176,46 +176,24 @@ impl<'a> Application for TearsApp<'a> {
 /// Map one terminal event to the message it should become.
 ///
 /// A key event is input when the key is going down. A Windows console reports releases
-/// too — crossterm's WinAPI source sets the kind from the record's `key_down` flag and
-/// passes both up — and nostui acted on some of them (#531). Unix reports presses only,
-/// so this changes nothing there.
+/// too — crossterm takes the kind from the record's `key_down` flag — and nostui acted
+/// on some of them. Not the configured bindings, whose map is keyed by `KeyEvent` and so
+/// compares the kind; the two paths that read the key's code alone. Cancelling a draft
+/// with `Esc` closed the composer on the press, and the release then landed in normal
+/// mode, whose fallback reads `code` and fires `Deselect` (#531).
 ///
-/// Not the configured bindings, though: those live in a map keyed by `KeyEvent`, whose
-/// `Eq` and `Hash` include the kind, so a release never matched one. What a release did
-/// reach were the two paths that read the key's code alone. Cancelling a draft with
-/// `Esc` closed the composer on the press, and the release then fell through normal
-/// mode's fallback to `Deselect` — one keystroke also clearing a timeline selection
-/// nobody asked it to. Typing was safe: `tui-textarea` discards releases itself.
+/// `Repeat` counts as input, because a repeat is the key still being down. What each
+/// path does with one after that differs, and inconsistently — that is #536, which this
+/// function cannot settle. Nothing reports a repeat today in any case: only the kitty
+/// keyboard protocol does, and nostui never asks for it.
 ///
-/// "Going down" is the rule rather than the whole story, and the exception is worth
-/// knowing before someone goes looking for it. The same parser reports an Alt code —
-/// Alt held over a numpad sequence — as a `KeyCode::Char` carrying the composed
-/// character, with the kind still taken from `key_down`, so it arrives here as a
-/// `Release`. crossterm's exception is only to its own discarding of releases; the arm
-/// below is a separate filter and does drop it.
+/// Not every release is a key coming up. crossterm reports a Windows Alt code as a
+/// `Release` carrying the composed character, so the arm below drops it; it never typed
+/// anything before either, since `tui-textarea` discarded it further down. Making it
+/// work is #537, and it starts here.
 ///
-/// Nothing changes today: before this, an Alt code reached `tui-textarea` and was
-/// discarded there for the same reason, so it never typed anything either way. What
-/// changes is where it stops. Adding Alt-code support on Windows (#537) starts here
-/// rather than ends here.
-///
-/// `Repeat` is treated as input for the same reason: it means the key is still down.
-/// What comes of that depends on which path takes it, and the three do not agree —
-/// which is #536, not something this function can settle. Configured bindings live in a
-/// map keyed by `KeyEvent`, whose `Eq` and `Hash` include the kind, against entries
-/// built by `KeyEvent::new` — `Press` — so a repeat matches nothing there. Composing
-/// never consults that map: its `Esc` and `Ctrl+P` arms read `(code, modifiers)` alone,
-/// so a repeat fires them again, and everything else reaches `tui-textarea`, which drops
-/// only `Release` and so types the repeat as it should. Nothing produces one today in
-/// any of them: crossterm reports that kind only through the kitty keyboard protocol,
-/// which nostui never asks for.
-///
-/// It is named rather than lumped in with `Release` because a repeat *is* someone
-/// pressing the key, and `KeyEventKind` is a closed enum, so saying which of the three
-/// is which costs nothing.
-///
-/// A free function rather than the closure it replaces: the closure lives inside
-/// `subscriptions`, which no test drives, and the decision above is worth pinning.
+/// A free function rather than the closure it replaces: the closure lived inside
+/// `subscriptions`, which no test drives.
 fn terminal_event_to_msg(event: Event) -> AppMsg {
     match event {
         Event::Key(key) => match key.kind {
@@ -989,7 +967,7 @@ mod tests {
                     terminal_event_to_msg(Event::Key(key)),
                     AppMsg::System(SystemMsg::KeyInput(got)) if got == key
                 ),
-                "{kind:?} should reach the keybindings"
+                "{kind:?} should reach `KeyInput`"
             );
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -175,11 +175,23 @@ impl<'a> Application for TearsApp<'a> {
 
 /// Map one terminal event to the message it should become.
 ///
-/// A key event is input only when the key is going down. A Windows console reports
-/// releases too — crossterm's WinAPI source sets the kind from the record's `key_down`
-/// flag and passes both up — so without this every binding ran twice there: `j` scrolled
-/// two notes, `x` closed two tabs (#531). Unix reports presses only, so this changes
-/// nothing there.
+/// A key event is input when the key is going down. A Windows console reports releases
+/// too — crossterm's WinAPI source sets the kind from the record's `key_down` flag and
+/// passes both up — and nostui acted on some of them (#531). Unix reports presses only,
+/// so this changes nothing there.
+///
+/// Not the configured bindings, though: those live in a map keyed by `KeyEvent`, whose
+/// `Eq` and `Hash` include the kind, so a release never matched one. What a release did
+/// reach were the two paths that read the key's code alone. Cancelling a draft with
+/// `Esc` closed the composer on the press, and the release then fell through normal
+/// mode's fallback to `Deselect` — one keystroke also clearing a timeline selection
+/// nobody asked it to. Typing was safe: `tui-textarea` discards releases itself.
+///
+/// "Going down" is the rule rather than the whole story. The same parser deliberately
+/// reports an Alt code — Alt held over a numpad sequence — as a `Release` carrying the
+/// composed character, so that it cannot be discarded as a release. nostui never
+/// received those anyway, since `tui-textarea` dropped them; supporting Alt codes on
+/// Windows means coming back here first.
 ///
 /// `Repeat` is treated as input for the same reason: it means the key is still down.
 /// What comes of that depends on the mode. Composing reads `(code, modifiers)` and never
@@ -934,9 +946,11 @@ mod tests {
         store.finish();
     }
 
-    /// #531: a Windows console reports a release for every press. A release is not
-    /// someone pressing a key, so it must not reach `KeyInput` — before this it did,
-    /// and every binding ran twice there.
+    /// #531: a Windows console reports a release for every press, and a release is not
+    /// someone pressing a key. Configured bindings were safe — the map they live in
+    /// compares the kind — but the paths matching on the key's code alone were not:
+    /// a release of `Esc` reached normal mode's fallback and deselected the timeline
+    /// behind a draft the press had just cancelled.
     #[test]
     fn test_key_release_is_not_input() {
         let release = KeyEvent::new_with_kind(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -182,14 +182,15 @@ impl<'a> Application for TearsApp<'a> {
 /// nothing there.
 ///
 /// `Repeat` is treated as input for the same reason: it means the key is still down.
-/// That is where the resemblance to a press ends today — the keybinding map is keyed by
-/// `KeyEvent`, whose `Eq` and `Hash` include the kind, and configured bindings are built
-/// with `KeyEvent::new`, which sets `Press`. So a repeat reaches `handle_key_input` and
-/// then matches nothing (#536). Nothing produces one either: crossterm reports that kind
-/// only through the kitty keyboard protocol, which nostui never asks for. It is named
-/// rather than lumped in with `Release` because a repeat *is* someone pressing the key,
-/// and `KeyEventKind` is a closed enum, so saying which of the three is which costs
-/// nothing.
+/// What comes of that depends on the mode. Composing reads `(code, modifiers)` and never
+/// the kind, and `tui-textarea` drops only `Release`, so a held key types repeats the way
+/// it should. Normal mode looks the binding up in a map keyed by `KeyEvent`, whose `Eq`
+/// and `Hash` include the kind, against entries built by `KeyEvent::new` — `Press` — so
+/// there a repeat matches nothing (#536). Nothing produces one today in either mode:
+/// crossterm reports that kind only through the kitty keyboard protocol, which nostui
+/// never asks for. It is named rather than lumped in with `Release` because a repeat *is*
+/// someone pressing the key, and `KeyEventKind` is a closed enum, so saying which of the
+/// three is which costs nothing.
 ///
 /// A free function rather than the closure it replaces: the closure lives inside
 /// `subscriptions`, which no test drives, and the decision above is worth pinning.
@@ -951,9 +952,9 @@ mod tests {
     }
 
     /// The other two kinds are the key going down or staying down, and this pins where
-    /// the mapping sends them — not what happens next. A repeat gets no further than
-    /// `handle_key_input` today, since the binding map compares the kind (#536), and is
-    /// unreachable anyway until nostui asks for the kitty keyboard protocol.
+    /// the mapping sends them — not what happens next, which differs by mode: a repeat
+    /// types normally while composing, and resolves to no binding in normal mode (#536).
+    /// Both are moot until nostui asks for the kitty keyboard protocol.
     #[test]
     fn test_key_press_and_repeat_are_input() {
         for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {


### PR DESCRIPTION
Closes #531.

## What was wrong

`Event::Key` became `SystemMsg::KeyInput` regardless of `KeyEventKind`, and nostui never looked at that field anywhere.

Unix reports presses only, so nothing showed. A Windows console reports a release for every press — crossterm's WinAPI source sets the kind from the record's `key_down` flag and hands both up (`crossterm-0.29.0/src/event/sys/windows/parse.rs:285`).

**Not** every binding fired twice, which is what this PR claimed until `62ddb8e`. Configured bindings live in a `HashMap` keyed by `KeyEvent`, and crossterm's `Eq`/`Hash` include the kind while `parse_key_event` builds its entries through `KeyEvent::new` (`Press`) — so a release of `j` hashed to nothing. What a release reached are the two paths that read the key's code alone:

- `handle_composing_mode_key` matches `(code, modifiers)`;
- normal mode's fallback matches `code`.

**`Esc` is the one that reproduces.** Pressing it while composing cancels the draft and closes the composer; the release then arrives in normal mode, hits the `Esc` fallback, and fires `Deselect` — one keystroke cancelling a draft and clearing the timeline selection with it.

**`Ctrl+P` is the one that could.** The composer's arm matches `(Char('p'), CONTROL)` without looking at the kind, so the release matched it too. An earlier revision of this PR called that a duplicate publish and said so as a certainty; it is not one. The press's `SubmitNote` is enqueued microseconds after the press is reduced, while the release is tens of milliseconds behind a human finger, so ordinarily the submit lands first, closes the editor, and the release falls to normal mode and matches nothing.

The two cannot both be certain, which is what gave the overstatement away: `Esc` misfiring *requires* the press's message to be applied before the release arrives, and that is exactly the ordering under which `Ctrl+P` is harmless. A second submit needs press and release to reach one input batch together — the kernel stalled long enough for both to be queued before either is reduced — since a command's message re-enters through the lane rather than being applied inside the batch that produced it. Possible under load; not the deterministic behaviour, and not something I can observe on the platform it concerns.

Ignoring the release closes both regardless of which ordering a given run takes.Every release also cost a redraw for nothing. Typing was safe throughout: `tui-textarea` discards releases itself.

## The change

A release routes to `SystemMsg::TerminalEventIgnored`, which already exists for terminal events nostui does not act on and does nothing with them.

## The `Repeat` decision

The issue asked for one, so: **`Repeat` counts as a press.** It means the key is still down, which is what someone holding `j` to scroll is asking for.

Nothing produces it today. crossterm reports that kind only through the kitty keyboard protocol, and nostui never pushes the enhancement flags that enable it — Windows auto-repeat arrives as repeated `Press` events instead, so holding a key there already works and is unaffected. `KeyEventKind` is a closed three-variant enum, so naming all three makes the match exhaustive without a wildcard and says which of them is which.

What it does **not** do is make holding a key work everywhere, which an earlier revision of this PR claimed. Composing is fine — `handle_composing_mode_key` reads `(code, modifiers)` and `tui-textarea` drops only `Release`, so a held key types repeats. Normal mode is not: the binding map is keyed by `KeyEvent`, crossterm's `Eq`/`Hash` include the kind, and configured bindings are built with `KeyEvent::new` (`kind: Press`), so a repeat matches nothing there. That is **#536**, filed from this review; the mapping is not where it can be fixed.

## Structure

The mapping moves out of the `.map()` closure inside `subscriptions()` and into a free `terminal_event_to_msg`. The closure was untestable — `TestStore` never polls subscription streams — and this decision is worth pinning rather than describing.

## Tests

- a release does not reach `KeyInput`
- a press and a repeat both do, carrying the same `KeyEvent`
- a resize still routes to `Resize`, and an event nostui ignores still routes to `TerminalEventIgnored`

Routing all three kinds to `KeyInput` again fails the first, and only the first.

`just fmt`, `just lint`, `just test` (401 + 1 doc) all clean.

## Not in scope

- **#537** (filed from this review) — a Windows Alt code (`Alt+0233` → `é`) is reported by crossterm as a `Release` carrying the composed character, so nostui's new filter drops it. It never typed anything before either — `tui-textarea` discarded it for the same reason — so this moves where it stops, not whether it works.

- **#536** — the three key paths each treat `KeyEventKind` differently: the binding map compares it, composing ignores it, normal mode's fallback ignores it. A repeat resolves to nothing in normal mode and re-fires `Ctrl+P` in the composer. Latent until nostui asks for the kitty protocol; the fix is one normalisation, not three patches.
- **#538** — `submit_note` publishes whatever the buffer holds without checking the editor is open. That is what would turn a second submission into a duplicate note rather than a no-op, whichever way one arrives.

The fix cannot be verified on the platform it is for from here — no Windows console — so it rests on crossterm's parser, which the tests exercise directly by constructing the kinds it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
