### PR TITLE
fix: a submission for a closed composer publishes the note again

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -370,6 +370,19 @@ impl<'a> AppState<'a> {
     /// Publish the editor's current content as a text note, or as a NIP-10 reply
     /// when a reply target is set, then reset the editor.
     pub fn submit_note(&mut self) -> Command<AppMsg> {
+        // A composer that is not open has nothing to submit, and trying costs more than
+        // nothing: `ComposingCanceled` leaves the buffer alone — the next
+        // `ComposingStarted` is what clears it — so a second submission arriving after
+        // the first succeeded would read the same draft and publish the same note again.
+        //
+        // Guarded here rather than where the extra submission comes from, because that
+        // is not one place: a key path can queue two before either is applied, and the
+        // next way to do it need not be a key path at all (#538).
+        if !self.editor.is_active() {
+            log::warn!("Ignoring a note submission: the composer is not open");
+            return Command::none().without_redraw();
+        }
+
         let content = self.editor.get_content();
 
         let event_builder = if let Some(reply_to_event) = self.editor.reply_target() {
@@ -1294,6 +1307,34 @@ mod tests {
         assert_eq!(state.status_bar.message(), Some("[Posted] hi"));
     }
 
+    /// #538: the buffer outlives the composer, so a submission that arrives after the
+    /// editor closed would publish the same note a second time.
+    #[test]
+    fn test_submit_note_publishes_once_when_submitted_twice() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+        let id = only_pending(&state);
+
+        // The composer is closed now, and the draft is still in the buffer.
+        assert!(!state.editor.is_active());
+        assert_eq!(state.editor.get_content(), "h");
+
+        let _ = state.submit_note();
+
+        assert_eq!(
+            only_pending(&state),
+            id,
+            "the second submission published nothing"
+        );
+        assert_eq!(state.status_bar.message(), Some("[Sending] h"));
+    }
+
     #[test]
     fn test_submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
         let (mut state, _rx) = connected_state();
@@ -1566,6 +1607,32 @@ mod tests {
         // the buffer, so there is no way back to it.
         assert!(state.editor.is_active());
         assert_eq!(state.editor.get_content(), "h");
+    }
+
+    /// The other side of #538's guard: it must not block the retry the kept draft
+    /// exists for. A submission that failed before it was sent leaves the composer
+    /// open, so the next one is a first attempt, not a duplicate.
+    #[test]
+    fn a_kept_draft_can_still_be_submitted_again() {
+        let mut state = AppState::new(Keys::generate().public_key());
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        // Not connected: the failure is known before the command is queued.
+        let _ = state.submit_note();
+        assert!(state.editor.is_active());
+        assert!(state.pending_publishes.is_empty());
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let _ = state.on_connection_ready(tx);
+        let _ = state.submit_note();
+
+        let _ = only_pending(&state);
+        assert_eq!(state.status_bar.message(), Some("[Sending] h"));
+        assert!(!state.editor.is_active());
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -369,6 +369,7 @@ impl<'a> AppState<'a> {
 
     /// Publish the editor's current content as a text note, or as a NIP-10 reply
     /// when a reply target is set, then reset the editor.
+    /// No-op when the composer is closed.
     pub fn submit_note(&mut self) -> Command<AppMsg> {
         // A composer that is not open has nothing to submit, and trying costs more than
         // nothing: `ComposingCanceled` leaves the buffer alone — the next


### PR DESCRIPTION
Closes #538.

## What was wrong

`AppState::submit_note` read the draft and published it without checking that the composer was open:

```rust
let content = self.editor.get_content();
…
if self.publish(PublishKind::Note, &content, event_builder) {
    self.editor.update(EditorMessage::ComposingCanceled);
}
```

`ComposingCanceled` only clears `is_active`. The buffer survives on purpose — the next `ComposingStarted` is what empties it, which is what lets a send that fails before it leaves keep its draft (#513). So a second submission arriving after the first one succeeded read the *same* text and published the *same* note again.

## How two of them arrive

Both messages have to be reduced before either is applied, since a command's message re-enters through the runtime's data lane rather than landing inside the batch that produced it. Two routes are known, both in key handling:

- **Windows, before #535** — the composer's arm matches `(Char('p'), CONTROL)` without looking at the kind, so `Ctrl+P`'s release matched it as well as its press. Closed there.
- **Holding `Ctrl+P`** — a repeat matches the same arm. Latent: crossterm reports `Repeat` only under the kitty keyboard protocol, which nostui never enables. #536's.

Neither is common — it takes both events landing in one input batch — and neither is where the fix belongs. `submit_note` is a public method that publishes a note and can check the state it already holds; the next way to queue two need not be a key path at all, and what it produces is a duplicate note rather than an error.

## The change

An early return when the composer is not open, declining the redraw since nothing changed. `handle_editor_msg` does not clear the status bar on the way in, unlike the timeline's dispatch, so that declaration is true here.

## Tests

- **Submitting twice publishes once.** Removing the guard fails it with "expected exactly one pending publish".
- **A kept draft can still be submitted again.** The risk this change introduces is blocking the retry that #513's kept draft exists for: a send that fails before it leaves keeps the composer open, so the next submission is a first attempt rather than a duplicate. Not connected → fails, draft kept → connect → publishes.

`just fmt`, `just lint`, `just test` (403 + 1 doc) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
