### PR TITLE
fix: a held key resolves to the binding it is configured for

### DIFF
--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -51,14 +51,10 @@ pub enum SystemMsg {
     TerminalEventIgnored,
     /// Show an error message
     ShowError(String),
-    /// Key input event
+    /// Key input event, as the terminal reported it
     ///
-    /// The key arrives normalised to what `KeyEvent::new` would build: `kind` is always
-    /// `Press` and `state` is always `NONE`, whatever the terminal reported. Three
-    /// consumers rely on that — the binding map compares both fields, and the composer
-    /// and normal mode's fallback compare neither — so a handler that reads `kind` here
-    /// to tell a held key from a fresh one will see `Press` every time and never fire.
-    /// `terminal_event_to_msg` is where the normalisation happens and why (#536).
+    /// `handle_key_input` reduces it to what `KeyEvent::new` would build before anything
+    /// resolves it, so a decorated key does not have to be one here (#536).
     KeyInput(KeyEvent),
 }
 

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -52,6 +52,13 @@ pub enum SystemMsg {
     /// Show an error message
     ShowError(String),
     /// Key input event
+    ///
+    /// The key arrives normalised to what `KeyEvent::new` would build: `kind` is always
+    /// `Press` and `state` is always `NONE`, whatever the terminal reported. Three
+    /// consumers rely on that — the binding map compares both fields, and the composer
+    /// and normal mode's fallback compare neither — so a handler that reads `kind` here
+    /// to tell a held key from a fresh one will see `Press` every time and never fire.
+    /// `terminal_event_to_msg` is where the normalisation happens and why (#536).
     KeyInput(KeyEvent),
 }
 

--- a/src/application/message.rs
+++ b/src/application/message.rs
@@ -53,8 +53,9 @@ pub enum SystemMsg {
     ShowError(String),
     /// Key input event, as the terminal reported it
     ///
-    /// `handle_key_input` reduces it to what `KeyEvent::new` would build before anything
-    /// resolves it, so a decorated key does not have to be one here (#536).
+    /// `handle_key_input` refuses a release and reduces everything else to what
+    /// `KeyEvent::new` would build, before anything resolves it — so a producer may send
+    /// the key exactly as it arrived (#531, #536).
     KeyInput(KeyEvent),
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -182,9 +182,17 @@ impl<'a> Application for TearsApp<'a> {
 /// with `Esc` closed the composer on the press, and the release then landed in normal
 /// mode, whose fallback reads `code` and fires `Deselect` (#531).
 ///
-/// `Repeat` counts as input, because a repeat is the key still being down. What each
-/// path does with one after that differs, and inconsistently — that is #536, which this
-/// function cannot settle. Nothing reports a repeat today in any case: only the kitty
+/// A repeat is the key still being down, so it becomes input too — and becomes a press
+/// on the way, because none of the three paths downstream has any use for the
+/// difference and each of them handled it differently before (#536). The binding map
+/// compares the kind and its entries are all `Press`, so a repeat used to match nothing
+/// and holding a key did nothing; the composer and normal mode's fallback read the code
+/// alone and so were already treating the two alike. Normalising here is what makes all
+/// three agree, rather than three separate opinions about a distinction nobody wants.
+///
+/// It does mean nothing downstream can tell a held key from a fresh press. That is the
+/// point, and it is where to come back if anything ever needs to — refusing to repeat a
+/// destructive action, say. Nothing reports a repeat today in any case: only the kitty
 /// keyboard protocol does, and nostui never asks for it.
 ///
 /// Not every release is a key coming up. crossterm reports a Windows Alt code as a
@@ -197,7 +205,12 @@ impl<'a> Application for TearsApp<'a> {
 fn terminal_event_to_msg(event: Event) -> AppMsg {
     match event {
         Event::Key(key) => match key.kind {
-            KeyEventKind::Press | KeyEventKind::Repeat => AppMsg::System(SystemMsg::KeyInput(key)),
+            KeyEventKind::Press | KeyEventKind::Repeat => {
+                AppMsg::System(SystemMsg::KeyInput(KeyEvent {
+                    kind: KeyEventKind::Press,
+                    ..key
+                }))
+            }
             KeyEventKind::Release => AppMsg::System(SystemMsg::TerminalEventIgnored),
         },
         Event::Resize(width, height) => AppMsg::System(SystemMsg::Resize(width, height)),
@@ -271,7 +284,10 @@ impl<'a> TearsApp<'a> {
         match key.code {
             // Escape key - unselect/cancel (delegates to TimelineMsg::Deselect)
             KeyCode::Esc => Command::message(AppMsg::Timeline(TimelineMsg::Deselect)).into(),
-            _ => Command::none(),
+            // A key bound to nothing changes nothing, so it should not cost a render —
+            // and with no tick left to repaint anyway, holding one would otherwise be a
+            // render per repeat for no reason (#536).
+            _ => Command::none().without_redraw(),
         }
     }
 
@@ -953,23 +969,67 @@ mod tests {
         ));
     }
 
-    /// The other two kinds are the key going down or staying down, and this pins where
-    /// the mapping sends them — not what happens next, which the three key paths answer
-    /// differently and inconsistently (#536). All of it is moot until nostui asks for the
-    /// kitty keyboard protocol, which is the only thing that reports a repeat.
+    /// The other two kinds are the key going down or staying down, and both arrive as a
+    /// press. Nothing downstream wants the difference, and #536 is what came of three
+    /// paths each deciding that for themselves — so this pins that a repeat is
+    /// indistinguishable from a press by the time anything acts on it.
     #[test]
-    fn test_key_press_and_repeat_are_input() {
-        for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {
-            let key = KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, kind);
+    fn test_press_and_repeat_both_arrive_as_a_press() {
+        let press =
+            KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, KeyEventKind::Press);
+        let repeat =
+            KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, KeyEventKind::Repeat);
 
+        for key in [press, repeat] {
             assert!(
                 matches!(
                     terminal_event_to_msg(Event::Key(key)),
-                    AppMsg::System(SystemMsg::KeyInput(got)) if got == key
+                    AppMsg::System(SystemMsg::KeyInput(got)) if got == press
                 ),
-                "{kind:?} should reach `KeyInput`"
+                "{:?} should arrive as the press",
+                key.kind
             );
         }
+    }
+
+    /// What that buys: holding a key reaches the binding it is configured for. Before
+    /// #536 a repeat hashed differently from the `Press` the config was parsed into, so
+    /// it matched nothing and holding `j` did not scroll.
+    ///
+    /// The binding is put there rather than taken from the shipped defaults, so the test
+    /// pins the lookup rather than what `.config/config.json5` happens to say.
+    #[test]
+    fn test_a_held_key_reaches_its_binding() {
+        let mut flags = test_flags();
+        flags.config.keybindings.home.insert(
+            vec![KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)],
+            KeyAction::ScrollDown,
+        );
+        let mut store = TestStore::<TearsApp<'static>>::new(flags);
+
+        store.send(terminal_event_to_msg(Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Char('j'),
+            KeyModifiers::NONE,
+            KeyEventKind::Repeat,
+        ))));
+
+        store.receive_matching(|msg| matches!(msg, AppMsg::Timeline(TimelineMsg::ScrollDown)));
+        store.finish();
+    }
+
+    /// A key bound to nothing changes nothing, so it must not repaint — which matters
+    /// now that a held key produces one of these per repeat rather than none (#536).
+    #[test]
+    fn test_a_key_bound_to_nothing_does_not_redraw() {
+        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+
+        store.send(AppMsg::System(SystemMsg::KeyInput(KeyEvent::new(
+            KeyCode::F(12),
+            KeyModifiers::NONE,
+        ))));
+
+        assert!(!store.redraw_requested());
+        store.finish();
     }
 
     /// Resizes still route to their own message, and everything else nostui does not

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use nostr_sdk::prelude::*;
 use nowhear::{MediaEvent, MediaSourceError};
 use ratatui::prelude::*;
@@ -182,18 +182,25 @@ impl<'a> Application for TearsApp<'a> {
 /// with `Esc` closed the composer on the press, and the release then landed in normal
 /// mode, whose fallback reads `code` and fires `Deselect` (#531).
 ///
-/// A repeat is the key still being down, so it becomes input too — and becomes a press
-/// on the way, because none of the three paths downstream has any use for the
-/// difference and each of them handled it differently before (#536). The binding map
-/// compares the kind and its entries are all `Press`, so a repeat used to match nothing
-/// and holding a key did nothing; the composer and normal mode's fallback read the code
-/// alone and so were already treating the two alike. Normalising here is what makes all
-/// three agree, rather than three separate opinions about a distinction nobody wants.
+/// A repeat is the key still being down, so it becomes input too — and arrives as a
+/// plain press, because none of the three paths downstream has any use for the
+/// difference and each of them handled it differently (#536). The binding map compares
+/// the whole `KeyEvent`, and every entry in it comes from `KeyEvent::new`; the composer
+/// and normal mode's fallback read the code alone. So a key the map should have matched
+/// would miss it and fall through to a fallback that does nothing, while the other two
+/// paths carried on as if it were a press.
 ///
-/// It does mean nothing downstream can tell a held key from a fresh press. That is the
-/// point, and it is where to come back if anything ever needs to — refusing to repeat a
-/// destructive action, say. Nothing reports a repeat today in any case: only the kitty
-/// keyboard protocol does, and nostui never asks for it.
+/// Both of the fields `KeyEvent::new` fixes are reset here, not just the kind. The
+/// kitty keyboard protocol is what reports a repeat, and the same parser fills `state`
+/// from the same modifier mask — `NUM_LOCK` is on by default on most keyboards with a
+/// numpad — so leaving `state` alone would reproduce the miss on the very day repeats
+/// start arriving. Normalising both is what lets the three paths agree by construction.
+///
+/// It does mean nothing downstream can tell a held key from a fresh one, or a numpad key
+/// from its counterpart on the main row. That is the point, and this is where to come
+/// back if anything ever needs to — refusing to repeat a destructive action, say.
+/// Nothing reports a repeat today in any case: nostui never asks for the protocol, so
+/// none of this has bitten anyone yet.
 ///
 /// Not every release is a key coming up. crossterm reports a Windows Alt code as a
 /// `Release` carrying the composed character, so the arm below drops it; it never typed
@@ -208,6 +215,7 @@ fn terminal_event_to_msg(event: Event) -> AppMsg {
             KeyEventKind::Press | KeyEventKind::Repeat => {
                 AppMsg::System(SystemMsg::KeyInput(KeyEvent {
                     kind: KeyEventKind::Press,
+                    state: KeyEventState::NONE,
                     ..key
                 }))
             }
@@ -361,8 +369,10 @@ impl<'a> TearsApp<'a> {
             // System
             KeyAction::Quit => Command::message(AppMsg::System(SystemMsg::Quit)).into(),
             KeyAction::SubmitTextNote => {
-                // Only valid in composing mode, handled separately
-                Command::none()
+                // Only valid in composing mode, handled separately. Declining the redraw
+                // for the same reason the unbound fallback does: this changes nothing,
+                // and the key it is bound to is one somebody can hold down (#536).
+                Command::none().without_redraw()
             }
         }
     }
@@ -992,9 +1002,11 @@ mod tests {
         }
     }
 
-    /// What that buys: holding a key reaches the binding it is configured for. Before
-    /// #536 a repeat hashed differently from the `Press` the config was parsed into, so
-    /// it matched nothing and holding `j` did not scroll.
+    /// What that buys: a key the enhanced protocol decorates still reaches the binding
+    /// it is configured for. Without the normalisation a repeat, or a press carrying
+    /// `NUM_LOCK`, would hash differently from the plain `Press` the config is parsed
+    /// into, match nothing, and fall through to a fallback that does nothing — holding
+    /// `j` would not scroll.
     ///
     /// The binding is put there rather than taken from the shipped defaults, so the test
     /// pins the lookup rather than what `.config/config.json5` happens to say.
@@ -1007,13 +1019,40 @@ mod tests {
         );
         let mut store = TestStore::<TearsApp<'static>>::new(flags);
 
-        store.send(terminal_event_to_msg(Event::Key(KeyEvent::new_with_kind(
-            KeyCode::Char('j'),
-            KeyModifiers::NONE,
-            KeyEventKind::Repeat,
-        ))));
+        // A held key on a keyboard with the numpad lit: both of the fields the map
+        // compares are decorated, and both have to be normalised for this to resolve.
+        store.send(terminal_event_to_msg(Event::Key(
+            KeyEvent::new_with_kind_and_state(
+                KeyCode::Char('j'),
+                KeyModifiers::NONE,
+                KeyEventKind::Repeat,
+                KeyEventState::NUM_LOCK,
+            ),
+        )));
 
         store.receive_matching(|msg| matches!(msg, AppMsg::Timeline(TimelineMsg::ScrollDown)));
+        store.finish();
+    }
+
+    /// `SubmitTextNote` is a no-op outside the composer, and `Ctrl+P` is bound to it in
+    /// normal mode too — so holding it there would repaint per repeat for nothing. Same
+    /// reasoning as the unbound fallback; the fallback's test cannot reach it, because
+    /// this key *is* bound.
+    #[test]
+    fn test_a_bound_key_that_does_nothing_does_not_redraw() {
+        let mut flags = test_flags();
+        flags.config.keybindings.home.insert(
+            vec![KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL)],
+            KeyAction::SubmitTextNote,
+        );
+        let mut store = TestStore::<TearsApp<'static>>::new(flags);
+
+        store.send(AppMsg::System(SystemMsg::KeyInput(KeyEvent::new(
+            KeyCode::Char('p'),
+            KeyModifiers::CONTROL,
+        ))));
+
+        assert!(!store.redraw_requested());
         store.finish();
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -176,55 +176,21 @@ impl<'a> Application for TearsApp<'a> {
 /// Map one terminal event to the message it should become.
 ///
 /// A key event is input when the key is going down. A Windows console reports releases
-/// too — crossterm takes the kind from the record's `key_down` flag — and nostui acted
-/// on some of them. Not the configured bindings, whose map is keyed by `KeyEvent` and so
-/// compares the kind; the two paths that read the key's code alone. Cancelling a draft
-/// with `Esc` closed the composer on the press, and the release then landed in normal
-/// mode, whose fallback reads `code` and fires `Deselect` (#531).
+/// too, and nostui acted on them: not through the binding map, which compares the kind,
+/// but through the paths that read the key's code — so cancelling a draft with `Esc`
+/// closed the composer on the press and then deselected the timeline on the release
+/// (#531). A repeat is the key still down, so that is input.
 ///
-/// A repeat is the key still being down, so it becomes input too — and arrives as a
-/// plain press, because none of the three paths downstream has any use for the
-/// difference and each of them handled it differently (#536). The binding map compares
-/// the whole `KeyEvent`, and every entry in it comes from `KeyEvent::new`; the composer
-/// reads `(code, modifiers)`, and normal mode's fallback the code alone. So a key the
-/// map should have matched would miss it and fall through to a fallback that does
-/// nothing, while the other two paths carried on as if it were a press.
+/// One release is not a key coming up: crossterm reports a Windows Alt code as a
+/// `Release` carrying the composed character, so this drops it. It never typed anything
+/// before either — `tui-textarea` discarded it — and making it work is #537.
 ///
-/// Both of the fields `KeyEvent::new` fixes are reset here, not just the kind. The
-/// kitty keyboard protocol is what reports a repeat, and the same parser fills `state`
-/// from the same modifier mask — `NUM_LOCK` is on by default on most keyboards with a
-/// numpad — so leaving `state` alone would reproduce the miss on the very day repeats
-/// start arriving. Normalising both is what lets the three paths agree by construction.
-///
-/// It does mean nothing downstream can tell a held key from a fresh one, or a numpad key
-/// from its counterpart on the main row. That is the point, and this is where to come
-/// back if anything ever needs to. One thing already does — holding a key fires its
-/// binding once per repeat, and some of them publish or close things (#543) — though
-/// not because of anything here: ordinary auto-repeat has always arrived as a run of
-/// plain presses, and this only adds the protocol's repeats to what already resolves.
-/// Refusing them means the kind has to survive as far as whoever decides, so part of
-/// this would have to move rather than be added to.
-///
-/// The protocol's repeats do not arrive today in any case: nostui never asks for it, so
-/// this half of the normalisation is a correctness fix nobody has hit.
-///
-/// Not every release is a key coming up. crossterm reports a Windows Alt code as a
-/// `Release` carrying the composed character, so the arm below drops it; it never typed
-/// anything before either, since `tui-textarea` discarded it further down. Making it
-/// work is #537, and it starts here.
-///
-/// A free function rather than the closure it replaces: the closure lived inside
-/// `subscriptions`, which no test drives.
+/// A free function rather than the closure it replaces, which lived inside
+/// `subscriptions` where no test could drive it.
 fn terminal_event_to_msg(event: Event) -> AppMsg {
     match event {
         Event::Key(key) => match key.kind {
-            KeyEventKind::Press | KeyEventKind::Repeat => {
-                AppMsg::System(SystemMsg::KeyInput(KeyEvent {
-                    kind: KeyEventKind::Press,
-                    state: KeyEventState::NONE,
-                    ..key
-                }))
-            }
+            KeyEventKind::Press | KeyEventKind::Repeat => AppMsg::System(SystemMsg::KeyInput(key)),
             KeyEventKind::Release => AppMsg::System(SystemMsg::TerminalEventIgnored),
         },
         Event::Resize(width, height) => AppMsg::System(SystemMsg::Resize(width, height)),
@@ -278,6 +244,20 @@ impl<'a> TearsApp<'a> {
         // Note: Ctrl+C is now handled by signal subscription, not as keyboard input
         // This ensures it works reliably across different terminal emulators and
         // properly separates OS signals from application keybindings
+
+        // Reduce the key to what `KeyEvent::new` would have built, which is what the
+        // keybinding map was parsed from. It compares `kind` and `state` as well as the
+        // code and modifiers, and the two paths below compare various subsets, so a key
+        // the terminal decorated — a repeat, or anything with Num Lock lit — used to
+        // resolve differently in each of them (#536). Normalised here rather than where
+        // the event is mapped, so it holds for every producer of `KeyInput` rather than
+        // one of them.
+
+        let key = KeyEvent {
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+            ..key
+        };
 
         // Mode-specific keybindings
         if self.state.editor.is_active() {
@@ -995,47 +975,22 @@ mod tests {
         ));
     }
 
-    /// The other two kinds are the key going down or staying down, and both arrive as a
-    /// press. Nothing downstream wants the difference, and #536 is what came of three
-    /// paths each deciding that for themselves — so this pins that a repeat is
-    /// indistinguishable from a press by the time anything acts on it.
-    #[test]
-    fn test_press_and_repeat_both_arrive_as_a_press() {
-        let press =
-            KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, KeyEventKind::Press);
-        let repeat =
-            KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, KeyEventKind::Repeat);
-
-        for key in [press, repeat] {
-            assert!(
-                matches!(
-                    terminal_event_to_msg(Event::Key(key)),
-                    AppMsg::System(SystemMsg::KeyInput(got)) if got == press
-                ),
-                "{:?} should arrive as the press",
-                key.kind
-            );
-        }
-    }
-
-    /// What that buys: a key the enhanced protocol decorates still reaches the binding
-    /// it is configured for. Without the normalisation a repeat, or a press carrying
-    /// `NUM_LOCK`, would hash differently from the plain `Press` the config is parsed
-    /// into, match nothing, and fall through to a fallback that does nothing — holding
-    /// `j` would not scroll.
+    /// A key the terminal decorated still reaches the binding it is configured for. The
+    /// map compares `kind` and `state` as well as the code, and the config is parsed
+    /// into neither — so without the normalisation this misses and falls through to a
+    /// fallback that does nothing.
     ///
-    /// The binding is put there rather than taken from the shipped defaults, so the test
-    /// pins the lookup rather than what `.config/config.json5` happens to say.
+    /// Sent as a `KeyInput` rather than through `terminal_event_to_msg`, because the
+    /// guarantee is the handler's: it holds for whatever produces the message.
     #[test]
-    fn test_a_held_key_reaches_its_binding() {
+    fn test_a_decorated_key_reaches_its_binding() {
         let mut store = store_with_binding(
             KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
             KeyAction::ScrollDown,
         );
 
-        // A held key on a keyboard with the numpad lit: both of the fields the map
-        // compares are decorated, and both have to be normalised for this to resolve.
-        store.send(terminal_event_to_msg(Event::Key(
+        // A held key on a keyboard with the numpad lit: both decorated fields at once.
+        store.send(AppMsg::System(SystemMsg::KeyInput(
             KeyEvent::new_with_kind_and_state(
                 KeyCode::Char('j'),
                 KeyModifiers::NONE,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -603,6 +603,16 @@ mod tests {
         app
     }
 
+    /// A store whose only keybinding is `key` -> `action`.
+    ///
+    /// Put there rather than taken from `.config/config.json5`, so a test pins the
+    /// lookup and not what the shipped defaults happen to say.
+    fn store_with_binding(key: KeyEvent, action: KeyAction) -> TestStore<TearsApp<'static>> {
+        let mut flags = test_flags();
+        flags.config.keybindings.home.insert(vec![key], action);
+        TestStore::new(flags)
+    }
+
     /// Wrap a relay pool notification the way the subscription delivers it.
     fn notification(notif: ClientNotification) -> AppMsg {
         AppMsg::Nostr(NostrMsg::SubscriptionMessage(
@@ -1018,12 +1028,10 @@ mod tests {
     /// pins the lookup rather than what `.config/config.json5` happens to say.
     #[test]
     fn test_a_held_key_reaches_its_binding() {
-        let mut flags = test_flags();
-        flags.config.keybindings.home.insert(
-            vec![KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)],
+        let mut store = store_with_binding(
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
             KeyAction::ScrollDown,
         );
-        let mut store = TestStore::<TearsApp<'static>>::new(flags);
 
         // A held key on a keyboard with the numpad lit: both of the fields the map
         // compares are decorated, and both have to be normalised for this to resolve.
@@ -1044,19 +1052,22 @@ mod tests {
     /// normal mode too — so holding it there would repaint per repeat for nothing. Same
     /// reasoning as the unbound fallback; the fallback's test cannot reach it, because
     /// this key *is* bound.
+    ///
+    /// Which is why the control comes first. Both paths return the same command, and a
+    /// store built from `Config::default()` has no bindings at all, so without proving
+    /// this key resolves, the assertion would hold just as well if the lookup missed and
+    /// the fallback answered — and would keep holding if resolution broke later.
     #[test]
     fn test_a_bound_key_that_does_nothing_does_not_redraw() {
-        let mut flags = test_flags();
-        flags.config.keybindings.home.insert(
-            vec![KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL)],
-            KeyAction::SubmitTextNote,
-        );
-        let mut store = TestStore::<TearsApp<'static>>::new(flags);
+        let ctrl_p = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
 
-        store.send(AppMsg::System(SystemMsg::KeyInput(KeyEvent::new(
-            KeyCode::Char('p'),
-            KeyModifiers::CONTROL,
-        ))));
+        let mut resolves = store_with_binding(ctrl_p, KeyAction::ScrollDown);
+        resolves.send(AppMsg::System(SystemMsg::KeyInput(ctrl_p)));
+        resolves.receive_matching(|msg| matches!(msg, AppMsg::Timeline(TimelineMsg::ScrollDown)));
+        resolves.finish();
+
+        let mut store = store_with_binding(ctrl_p, KeyAction::SubmitTextNote);
+        store.send(AppMsg::System(SystemMsg::KeyInput(ctrl_p)));
 
         assert!(!store.redraw_requested());
         store.finish();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -186,9 +186,9 @@ impl<'a> Application for TearsApp<'a> {
 /// plain press, because none of the three paths downstream has any use for the
 /// difference and each of them handled it differently (#536). The binding map compares
 /// the whole `KeyEvent`, and every entry in it comes from `KeyEvent::new`; the composer
-/// and normal mode's fallback read the code alone. So a key the map should have matched
-/// would miss it and fall through to a fallback that does nothing, while the other two
-/// paths carried on as if it were a press.
+/// reads `(code, modifiers)`, and normal mode's fallback the code alone. So a key the
+/// map should have matched would miss it and fall through to a fallback that does
+/// nothing, while the other two paths carried on as if it were a press.
 ///
 /// Both of the fields `KeyEvent::new` fixes are reset here, not just the kind. The
 /// kitty keyboard protocol is what reports a repeat, and the same parser fills `state`
@@ -198,7 +198,10 @@ impl<'a> Application for TearsApp<'a> {
 ///
 /// It does mean nothing downstream can tell a held key from a fresh one, or a numpad key
 /// from its counterpart on the main row. That is the point, and this is where to come
-/// back if anything ever needs to — refusing to repeat a destructive action, say.
+/// back if anything ever needs to. One thing already does: holding a key now fires its
+/// binding once per repeat, and some of them publish or close things (#543). Refusing
+/// that means the kind has to survive as far as whoever decides, so part of this has to
+/// move rather than be added to.
 /// Nothing reports a repeat today in any case: nostui never asks for the protocol, so
 /// none of this has bitten anyone yet.
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -181,9 +181,11 @@ impl<'a> Application for TearsApp<'a> {
 /// closed the composer on the press and then deselected the timeline on the release
 /// (#531). A repeat is the key still down, so that is input.
 ///
-/// One release is not a key coming up: crossterm reports a Windows Alt code as a
-/// `Release` carrying the composed character, so this drops it. It never typed anything
-/// before either — `tui-textarea` discarded it — and making it work is #537.
+/// Not every release is a key coming up: crossterm reports a Windows Alt code as a
+/// `Release` carrying the composed character, so this drops it — and so does
+/// `handle_key_input`, which refuses releases on its own account. Making it work is
+/// #537, and it has both of those to get past. It never typed anything before either;
+/// `tui-textarea` discarded it further down.
 ///
 /// A free function rather than the closure it replaces, which lived inside
 /// `subscriptions` where no test could drive it.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -198,12 +198,15 @@ impl<'a> Application for TearsApp<'a> {
 ///
 /// It does mean nothing downstream can tell a held key from a fresh one, or a numpad key
 /// from its counterpart on the main row. That is the point, and this is where to come
-/// back if anything ever needs to. One thing already does: holding a key now fires its
-/// binding once per repeat, and some of them publish or close things (#543). Refusing
-/// that means the kind has to survive as far as whoever decides, so part of this has to
-/// move rather than be added to.
-/// Nothing reports a repeat today in any case: nostui never asks for the protocol, so
-/// none of this has bitten anyone yet.
+/// back if anything ever needs to. One thing already does — holding a key fires its
+/// binding once per repeat, and some of them publish or close things (#543) — though
+/// not because of anything here: ordinary auto-repeat has always arrived as a run of
+/// plain presses, and this only adds the protocol's repeats to what already resolves.
+/// Refusing them means the kind has to survive as far as whoever decides, so part of
+/// this would have to move rather than be added to.
+///
+/// The protocol's repeats do not arrive today in any case: nostui never asks for it, so
+/// this half of the normalisation is a correctness fix nobody has hit.
 ///
 /// Not every release is a key coming up. crossterm reports a Windows Alt code as a
 /// `Release` carrying the composed character, so the arm below drops it; it never typed

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -245,14 +245,22 @@ impl<'a> TearsApp<'a> {
         // This ensures it works reliably across different terminal emulators and
         // properly separates OS signals from application keybindings
 
+        // A release is not someone pressing a key (#531). `terminal_event_to_msg` routes
+        // those away before they reach here, but refusing them here too is the
+        // difference between a guarantee and a habit — and the normalisation below would
+        // otherwise launder one into a press, which is worse than the bug #531 fixed:
+        // the binding map used to reject a release on its kind, so only the paths
+        // reading the code alone misfired.
+        if key.kind == KeyEventKind::Release {
+            return Command::none().without_redraw();
+        }
+
         // Reduce the key to what `KeyEvent::new` would have built, which is what the
         // keybinding map was parsed from. It compares `kind` and `state` as well as the
         // code and modifiers, and the two paths below compare various subsets, so a key
         // the terminal decorated — a repeat, or anything with Num Lock lit — used to
-        // resolve differently in each of them (#536). Normalised here rather than where
-        // the event is mapped, so it holds for every producer of `KeyInput` rather than
-        // one of them.
-
+        // resolve differently in each of them (#536). Here rather than where the event
+        // is mapped, so it holds for every producer of `KeyInput` rather than one.
         let key = KeyEvent {
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
@@ -953,6 +961,48 @@ mod tests {
 
         assert_eq!(store.state().state.timeline.len(), 1);
         assert!(store.redraw_requested());
+        store.finish();
+    }
+
+    /// The mapping's own half of #531: a press and a repeat both become `KeyInput`.
+    ///
+    /// One line, and load-bearing out of proportion to it — every other test here sends
+    /// a `KeyInput` directly, so without this the whole terminal-key route is unguarded
+    /// and routing every key to `TerminalEventIgnored` would leave the suite green. The
+    /// work this branch points at next edits exactly this match (#537, #543).
+    #[test]
+    fn test_a_key_going_down_is_input() {
+        for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {
+            let key = KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, kind);
+
+            assert!(
+                matches!(
+                    terminal_event_to_msg(Event::Key(key)),
+                    AppMsg::System(SystemMsg::KeyInput(got)) if got == key
+                ),
+                "{kind:?} should reach `KeyInput`"
+            );
+        }
+    }
+
+    /// The consumer refuses a release too, rather than trusting the mapping to have
+    /// dropped it. A producer that forwarded one raw would otherwise have it normalised
+    /// into a press before the lookup — `f`'s release publishing a reaction, which is
+    /// worse than what #531 fixed.
+    #[test]
+    fn test_the_handler_refuses_a_release_of_its_own_accord() {
+        let f = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE);
+        let mut store = store_with_binding(f, KeyAction::React);
+
+        store.send(AppMsg::System(SystemMsg::KeyInput(
+            KeyEvent::new_with_kind(
+                KeyCode::Char('f'),
+                KeyModifiers::NONE,
+                KeyEventKind::Release,
+            ),
+        )));
+
+        assert!(!store.redraw_requested());
         store.finish();
     }
 


### PR DESCRIPTION
Closes #536.

## What was wrong

Three paths handle a key, and each had its own idea of what `KeyEventKind` means:

- the **binding map** compares it — `KeyEvent`'s `Eq` and `Hash` include the kind, and `parse_key_event` builds every entry through `KeyEvent::new`, which sets `Press`;
- the **composer**'s `Esc`/`Ctrl+P` arms read `(code, modifiers)` alone;
- normal mode's **fallback** reads `code` alone.

So a `Repeat` hashes differently from the configured key, matches nothing, and falls through to a fallback that does nothing, while the other two paths treat it as a press.

Nobody has hit that: the kitty keyboard protocol is the only thing that reports a `Repeat`, and nostui never asks for it. Holding `j` scrolls today, because ordinary auto-repeat arrives as a run of plain presses. This is a correctness fix for the day the protocol is enabled — not a scrolling bug anyone has seen.

## The change

Settle it once, at `handle_key_input` — the single way into both key paths — by reducing the key to what `KeyEvent::new` would have built before anything resolves it. The three paths then agree by construction rather than by three opinions about a distinction nothing downstream wants.

Both fields the map compares and the config never sets, not only the kind. `state` is in `Eq` and `Hash` too, and the kitty protocol fills it from the same modifier mask that carries the kind — `NUM_LOCK` is raised on any keyboard with the numpad lit — so normalising the kind alone would have reproduced the miss it was fixing.

**At the consumer, not the producer.** An earlier revision normalised in `terminal_event_to_msg` and documented the resulting invariant on `SystemMsg::KeyInput`. That holds only as long as every producer of that message remembers: a replay path, a second event source or a test harness feeding real terminal events would have reintroduced #536 with a comment as the only guard. `handle_key_input` covers all of them, and the message goes back to carrying what the terminal actually said.

The cost either way is that nothing past that point can tell a held key from a fresh press, or a numpad key from its counterpart on the main row.

## Also: keys that resolve to nothing stop redrawing

#536 asked for this to be decided alongside. A key bound to nothing changes nothing by definition, so `Command::none().without_redraw()`. It matters more than it did: with the tick gone (#527) there is no periodic repaint for it to blend into, and after this change holding an unbound key produces one of these per repeat rather than none.

The same applies to a key that *is* bound to something that does nothing. `KeyAction::SubmitTextNote` is the one arm of `handle_action` that returns without producing a message — it is handled in the composer instead — and `Ctrl+P` is bound to it in normal mode too, so holding it there repainted per repeat for a documented no-op.

`handle_key_input` is reached from `handle_system_msg`, which does not clear the status bar on the way in — unlike the timeline's dispatch, where that assumption caused a real bug — so the declaration is true here.

## Tests

- a decorated key — a repeat carrying `NUM_LOCK`, both fields at once — reaches its binding, sent as a `KeyInput` directly, since the guarantee is the handler's and holds for whatever produced the message;
- an unbound key does not redraw;
- a bound key that resolves to nothing does not either, behind a control that proves the binding resolved — without it the assertion would pass just as well on a lookup that missed, since both paths return the same command.

Each fails without the change it covers: dropping either half of the normalisation fails the first, and either directive fails its own test. The bindings are inserted rather than taken from `.config/config.json5`, so the tests pin the lookup and not the shipped defaults.

## What this makes reachable

Resolving a repeat to its binding applies to every binding, including the ones that publish or close things — so under the protocol, holding `f` would react once per repeat, `t` repost, `Ctrl+W` close tabs in a row.

Chasing that turned up something worse, and not this PR's doing: **it already happens without the protocol.** Ordinary auto-repeat sends a held key's bytes again and again, crossterm parses each as a plain `Press`, and each resolves — so holding `f` publishes a burst of identical reactions on every build today. Filed as **#543**, reframed from latent to live once that was clear.

Not fixed here. "Repeat" in that sense is not a kind the event carries — an auto-repeat is indistinguishable from someone pressing the key quickly — so it wants a debounce on the action, which is a policy call about which actions may repeat rather than anything this function can filter.

## Not in scope

- Holding `Ctrl+P` in the composer submits once per repeat. It always did — that arm never read the kind — and since #539 the second and later submissions are no-ops against a closed editor, so nothing is published twice. Whether auto-repeat should drive a submission at all is a separate question about that binding, not about kinds.
- `Repeat` remains unreachable until nostui asks for the kitty keyboard protocol. This is what makes holding a key work when it does.

`just fmt`, `just lint`, `just test` (405 + 1 doc) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
