### PR TITLE
fix: an empty composer published an empty note

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -397,10 +397,11 @@ impl<'a> AppState<'a> {
         // and the user can carry on typing — and it says so rather than ignoring the key,
         // which would read as a broken binding (#540).
         if content.trim().is_empty() {
-            // Logged like the refusals around it, so "Ctrl+P did nothing" is answerable
-            // from the log rather than only from the bar, which the next status
-            // overwrites.
-            log::info!("Refusing to publish a blank note");
+            // At the level its neighbours use, not the one this deserves: "Ctrl+P did
+            // nothing" gets triaged by grepping the log at warn and above, and a refusal
+            // that only shows at info is missing from exactly that search. The bar is no
+            // help by then — the next status has overwritten it.
+            log::warn!("Refusing to publish a blank note");
             self.set_status_error(PublishKind::Note.subject(), "nothing to post");
             return Command::none();
         }
@@ -1350,9 +1351,12 @@ mod tests {
         let (mut state, _rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
-        for code in [' ', ' '] {
+        // A newline is not a line holding whitespace: Enter leaves the buffer as two
+        // empty lines, which `get_content` joins into `"\n"`. Different shape, same
+        // answer, and only one of the two was covered.
+        for code in [KeyCode::Char(' '), KeyCode::Enter, KeyCode::Char(' ')] {
             state.editor.update(EditorMessage::KeyEventReceived {
-                event: KeyEvent::new(KeyCode::Char(code), KeyModifiers::NONE),
+                event: KeyEvent::new(code, KeyModifiers::NONE),
             });
         }
 
@@ -1374,9 +1378,14 @@ mod tests {
     }
 
     /// The other side of it: trimming decides, and does not touch what is sent.
+    ///
+    /// Asserted on the event handed to the worker, not on the status line. Both are
+    /// built from the same `content`, so a bar reading `[Sending]  hi ` would go on
+    /// reading that if the builder started trimming — which is the one change this test
+    /// exists to catch.
     #[test]
     fn test_submit_note_posts_padded_content_as_typed() {
-        let (mut state, _rx) = connected_state();
+        let (mut state, mut rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
         for code in [' ', 'h', 'i', ' '] {
@@ -1387,7 +1396,14 @@ mod tests {
 
         let _ = state.submit_note();
 
-        let _ = only_pending(&state);
+        let Ok(NostrCommand::SendEventBuilder { event_builder, .. }) = rx.try_recv() else {
+            panic!("the note should have been handed to the worker");
+        };
+        let event = event_builder
+            .finalize(&Keys::generate())
+            .expect("the builder should sign");
+
+        assert_eq!(event.content, " hi ");
         assert_eq!(state.status_bar.message(), Some("[Sending]  hi "));
     }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -369,7 +369,7 @@ impl<'a> AppState<'a> {
 
     /// Publish the editor's current content as a text note, or as a NIP-10 reply
     /// when a reply target is set, then reset the editor.
-    /// No-op when the composer is closed.
+    /// No-op when the composer is closed, and refused when the draft is blank.
     pub fn submit_note(&mut self) -> Command<AppMsg> {
         // A composer that is not open has nothing to submit, and trying costs more than
         // nothing: `ComposingCanceled` leaves the buffer alone — the next
@@ -385,6 +385,21 @@ impl<'a> AppState<'a> {
         }
 
         let content = self.editor.get_content();
+
+        // Refused before it costs anything. An empty note is a real event on the relays
+        // that says nothing and cannot be recalled, and `Ctrl+P` on a composer nobody has
+        // typed into is far likelier to be a slip than a request.
+        //
+        // Trimmed only to decide: whitespace and a stray newline are as empty as nothing
+        // at all. What gets published is the content as typed.
+        //
+        // The composer stays open, like the pre-send refusals below, so nothing is lost
+        // and the user can carry on typing — and it says so rather than ignoring the key,
+        // which would read as a broken binding (#540).
+        if content.trim().is_empty() {
+            self.set_status_error(PublishKind::Note.subject(), "nothing to post");
+            return Command::none();
+        }
 
         let event_builder = if let Some(reply_to_event) = self.editor.reply_target() {
             log::info!("Publishing reply: {content}");
@@ -1306,6 +1321,59 @@ mod tests {
         let _ = state.resolve_publish(id, Ok(()));
 
         assert_eq!(state.status_bar.message(), Some("[Posted] hi"));
+    }
+
+    /// #540: an empty note is an event the relays keep and nobody can read.
+    #[test]
+    fn test_submit_note_refuses_an_empty_draft() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+
+        let _ = state.submit_note();
+
+        assert!(state.pending_publishes.is_empty(), "nothing was published");
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Note] nothing to post")
+        );
+        assert!(state.editor.is_active(), "the composer stays open");
+    }
+
+    /// Whitespace and a stray newline are as empty as nothing at all.
+    #[test]
+    fn test_submit_note_refuses_a_draft_of_only_whitespace() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        for code in [' ', '\t'] {
+            state.editor.update(EditorMessage::KeyEventReceived {
+                event: KeyEvent::new(KeyCode::Char(code), KeyModifiers::NONE),
+            });
+        }
+
+        let _ = state.submit_note();
+
+        assert!(state.pending_publishes.is_empty(), "nothing was published");
+        assert!(state.editor.is_active(), "the composer stays open");
+    }
+
+    /// The other side of it: trimming decides, and does not touch what is sent.
+    #[test]
+    fn test_submit_note_posts_padded_content_as_typed() {
+        let (mut state, _rx) = connected_state();
+
+        state.editor.update(EditorMessage::ComposingStarted);
+        for code in [' ', 'h', 'i', ' '] {
+            state.editor.update(EditorMessage::KeyEventReceived {
+                event: KeyEvent::new(KeyCode::Char(code), KeyModifiers::NONE),
+            });
+        }
+
+        let _ = state.submit_note();
+
+        let _ = only_pending(&state);
+        assert_eq!(state.status_bar.message(), Some("[Sending]  hi "));
     }
 
     /// #538: the buffer outlives the composer, so a submission that arrives after the

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -397,6 +397,10 @@ impl<'a> AppState<'a> {
         // and the user can carry on typing — and it says so rather than ignoring the key,
         // which would read as a broken binding (#540).
         if content.trim().is_empty() {
+            // Logged like the refusals around it, so "Ctrl+P did nothing" is answerable
+            // from the log rather than only from the bar, which the next status
+            // overwrites.
+            log::info!("Refusing to publish a blank note");
             self.set_status_error(PublishKind::Note.subject(), "nothing to post");
             return Command::none();
         }
@@ -1346,15 +1350,26 @@ mod tests {
         let (mut state, _rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
-        for code in [' ', '\t'] {
+        for code in [' ', ' '] {
             state.editor.update(EditorMessage::KeyEventReceived {
                 event: KeyEvent::new(KeyCode::Char(code), KeyModifiers::NONE),
             });
         }
 
+        // Otherwise this would hold just as well if the keystrokes never landed, and
+        // would be saying "an empty buffer is empty" rather than what it claims.
+        assert!(
+            !state.editor.get_content().is_empty(),
+            "the whitespace reached the buffer"
+        );
+
         let _ = state.submit_note();
 
         assert!(state.pending_publishes.is_empty(), "nothing was published");
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Note] nothing to post")
+        );
         assert!(state.editor.is_active(), "the composer stays open");
     }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1346,43 +1346,52 @@ mod tests {
     }
 
     /// Whitespace and a stray newline are as empty as nothing at all.
+    ///
+    /// Both shapes, because they are not the same one. Spaces leave a line holding
+    /// whitespace; pressing Enter on an untouched composer leaves two empty lines, which
+    /// `get_content` joins into a bare `"\n"`. Same answer, different buffer.
     #[test]
     fn test_submit_note_refuses_a_draft_of_only_whitespace() {
-        let (mut state, _rx) = connected_state();
+        for keys in [
+            vec![KeyCode::Char(' '), KeyCode::Char(' ')],
+            vec![KeyCode::Enter],
+        ] {
+            let (mut state, _rx) = connected_state();
 
-        state.editor.update(EditorMessage::ComposingStarted);
-        // A newline is not a line holding whitespace: Enter leaves the buffer as two
-        // empty lines, which `get_content` joins into `"\n"`. Different shape, same
-        // answer, and only one of the two was covered.
-        for code in [KeyCode::Char(' '), KeyCode::Enter, KeyCode::Char(' ')] {
-            state.editor.update(EditorMessage::KeyEventReceived {
-                event: KeyEvent::new(code, KeyModifiers::NONE),
-            });
+            state.editor.update(EditorMessage::ComposingStarted);
+            for code in &keys {
+                state.editor.update(EditorMessage::KeyEventReceived {
+                    event: KeyEvent::new(*code, KeyModifiers::NONE),
+                });
+            }
+
+            // Otherwise this would hold just as well if the keystrokes never landed, and
+            // would be saying "an empty buffer is empty" rather than what it claims.
+            assert!(
+                !state.editor.get_content().is_empty(),
+                "{keys:?} should have reached the buffer"
+            );
+
+            let _ = state.submit_note();
+
+            assert!(
+                state.pending_publishes.is_empty(),
+                "{keys:?} should have published nothing"
+            );
+            assert_eq!(
+                state.status_bar.message(),
+                Some("[ERR: Note] nothing to post")
+            );
+            assert!(state.editor.is_active(), "the composer stays open");
         }
-
-        // Otherwise this would hold just as well if the keystrokes never landed, and
-        // would be saying "an empty buffer is empty" rather than what it claims.
-        assert!(
-            !state.editor.get_content().is_empty(),
-            "the whitespace reached the buffer"
-        );
-
-        let _ = state.submit_note();
-
-        assert!(state.pending_publishes.is_empty(), "nothing was published");
-        assert_eq!(
-            state.status_bar.message(),
-            Some("[ERR: Note] nothing to post")
-        );
-        assert!(state.editor.is_active(), "the composer stays open");
     }
 
     /// The other side of it: trimming decides, and does not touch what is sent.
     ///
-    /// Asserted on the event handed to the worker, not on the status line. Both are
+    /// Asserted on the event handed to the worker, not only on the status line. Both are
     /// built from the same `content`, so a bar reading `[Sending]  hi ` would go on
     /// reading that if the builder started trimming — which is the one change this test
-    /// exists to catch.
+    /// exists to catch. The bar is checked too, since it is what the user sees.
     #[test]
     fn test_submit_note_posts_padded_content_as_typed() {
         let (mut state, mut rx) = connected_state();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1109,6 +1109,25 @@ mod tests {
         ));
     }
 
+    /// #540: refusing a blank draft writes to the status bar, so unlike its neighbours
+    /// in `submit_note` it has to redraw — otherwise the line saying why never appears,
+    /// which is the whole of what the refusal is for. Asserted here because this is
+    /// where the directive is observable.
+    #[test]
+    fn test_refusing_a_blank_draft_redraws() {
+        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+
+        store.send(AppMsg::Editor(EditorMsg::StartComposing));
+        store.send(AppMsg::Editor(EditorMsg::SubmitNote));
+
+        assert!(store.redraw_requested());
+        assert_eq!(
+            store.state().state.status_bar.message(),
+            Some("[ERR: Note] nothing to post")
+        );
+        store.finish();
+    }
+
     /// A terminal event nostui does not act on changes nothing, so it must not
     /// render. Before #527 this arm produced a tick, which the FPS display counted
     /// as one and redrew for.


### PR DESCRIPTION
Closes #540.

## What was wrong

`submit_note` published whatever the buffer held, and nothing checked that it held anything. `n` then `Ctrl+P` — open the composer, submit without typing — put a kind 1 event with empty content on every relay, and the status bar read `[Sending] ` with nothing after the label.

## The decisions #540 asked for

**Refuse, rather than allow.** An empty note says nothing to a reader and cannot be taken back off a relay that already has it. The other side of the trade — someone who genuinely wants to publish nothing — is not a real user.

**Where "empty" stops.** `content.trim().is_empty()`, so whitespace and a stray newline count too. An emoji-only note does not, which is the right side of the line to be on.

**Trimming decides; it does not rewrite.** The content is published exactly as typed, padding included. A test pins that, because a check like this is one refactor away from quietly becoming a normalisation.

**It says so.** `[ERR: Note] nothing to post`, in the same shape as the other pre-send refusals (`read-only mode`, `not connected`). A key that silently does nothing reads as a broken binding, which is worse than a line on the bar.

**The composer stays open**, like every other refusal that happens before the send, so nothing is lost and the user can carry on typing.

## Tests

- an empty draft publishes nothing, keeps the composer open, and says why;
- a draft of only whitespace does the same;
- a draft with padding around real text still publishes, with the padding intact.

The first two fail without the guard; the third is what stops the guard growing into a trim.

`just fmt`, `just lint`, `just test` (410 + 1 doc) all clean.

## Not in scope

Reactions and reposts cannot be empty — their content is built from the selected note, not typed — so this is a note-only concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
