### PR TITLE
test: drop the `test_` prefix

### DIFF
--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config_loads_relays_or_reports_why_it_cannot() {
+    fn config_new_either_loads_a_key_and_relays_or_says_what_is_missing() {
         // This test needs to be updated to work in an environment where config files exist
         // For now, let's test that Config::new() either succeeds or fails for expected reasons
         match Config::new() {

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config() {
+    fn config_loads_relays_or_reports_why_it_cannot() {
         // This test needs to be updated to work in an environment where config files exist
         // For now, let's test that Config::new() either succeeds or fails for expected reasons
         match Config::new() {

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_config() {
+    fn config() {
         // This test needs to be updated to work in an environment where config files exist
         // For now, let's test that Config::new() either succeeds or fails for expected reasons
         match Config::new() {

--- a/src/application/config/keybindings.rs
+++ b/src/application/config/keybindings.rs
@@ -248,7 +248,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_simple_keys() -> Result<()> {
+    fn simple_keys() -> Result<()> {
         assert_eq!(
             parse_key_event("a")?,
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty())
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_modifiers() -> Result<()> {
+    fn with_modifiers() -> Result<()> {
         assert_eq!(
             parse_key_event("ctrl-a")?,
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL)
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_modifiers() -> Result<()> {
+    fn multiple_modifiers() -> Result<()> {
         assert_eq!(
             parse_key_event("ctrl-alt-a")?,
             KeyEvent::new(
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reverse_multiple_modifiers() {
+    fn reverse_multiple_modifiers() {
         assert_eq!(
             key_event_to_string(&KeyEvent::new(
                 KeyCode::Char('a'),
@@ -317,13 +317,13 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_keys() {
+    fn invalid_keys() {
         assert!(parse_key_event("invalid-key").is_err());
         assert!(parse_key_event("ctrl-invalid-key").is_err());
     }
 
     #[test]
-    fn test_case_insensitivity() -> Result<()> {
+    fn case_insensitivity() -> Result<()> {
         assert_eq!(
             parse_key_event("CTRL-a")?,
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL)

--- a/src/application/config/styles.rs
+++ b/src/application/config/styles.rs
@@ -135,32 +135,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_style_default() {
+    fn parse_style_default() {
         let style = parse_style("");
         assert_eq!(style, Style::default());
     }
 
     #[test]
-    fn test_parse_style_foreground() {
+    fn parse_style_foreground() {
         let style = parse_style("red");
         assert_eq!(style.fg, Some(Color::Indexed(1)));
     }
 
     #[test]
-    fn test_parse_style_background() {
+    fn parse_style_background() {
         let style = parse_style("on blue");
         assert_eq!(style.bg, Some(Color::Indexed(4)));
     }
 
     #[test]
-    fn test_parse_style_modifiers() {
+    fn parse_style_modifiers() {
         let style = parse_style("underline red on blue");
         assert_eq!(style.fg, Some(Color::Indexed(1)));
         assert_eq!(style.bg, Some(Color::Indexed(4)));
     }
 
     #[test]
-    fn test_process_color_string_splits_the_colour_from_its_modifiers() {
+    fn process_color_string_splits_the_colour_from_its_modifiers() {
         let (color, modifiers) = process_color_string("underline bold inverse gray");
         assert_eq!(color, "gray");
         assert!(modifiers.contains(Modifier::UNDERLINED));
@@ -169,14 +169,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_color_rgb() {
+    fn parse_color_rgb() {
         let color = parse_color("rgb123");
         let expected = 16 + 36 + 2 * 6 + 3;
         assert_eq!(color, Some(Color::Indexed(expected)));
     }
 
     #[test]
-    fn test_parse_color_unknown() {
+    fn parse_color_unknown() {
         let color = parse_color("unknown");
         assert_eq!(color, None);
     }

--- a/src/application/config/styles.rs
+++ b/src/application/config/styles.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn process_color_string_splits_the_colour_from_its_modifiers() {
+    fn process_color_string_splits_the_color_from_its_modifiers() {
         let (color, modifiers) = process_color_string("underline bold inverse gray");
         assert_eq!(color, "gray");
         assert!(modifiers.contains(Modifier::UNDERLINED));

--- a/src/application/config/styles.rs
+++ b/src/application/config/styles.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_color_string() {
+    fn test_process_color_string_splits_the_colour_from_its_modifiers() {
         let (color, modifiers) = process_color_string("underline bold inverse gray");
         assert_eq!(color, "gray");
         assert!(modifiers.contains(Modifier::UNDERLINED));

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn test_app_state_default() {
+    fn app_state_default() {
         let state = AppState::default();
 
         assert_eq!(state.timeline.len(), 0);
@@ -905,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    fn test_startup_mark_completed() {
+    fn startup_mark_completed() {
         let mut startup = Startup::default();
         startup.mark_completed();
         assert!(!startup.is_in_progress());
@@ -916,7 +916,7 @@ mod tests {
     }
 
     #[test]
-    fn test_app_state_new_with_pubkey() {
+    fn app_state_new_with_pubkey() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let state = AppState::new(pubkey);
@@ -926,7 +926,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_text_note_routes_to_specified_tab() -> Result<()> {
+    fn process_nostr_event_for_tab_text_note_routes_to_specified_tab() -> Result<()> {
         let current_user_pubkey = Keys::generate().public_key();
         let mut state = AppState::new(current_user_pubkey);
 
@@ -960,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_propagates_timeline_command() -> Result<()> {
+    fn process_nostr_event_for_tab_propagates_timeline_command() -> Result<()> {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let event = create_text_note(&Keys::generate(), "hello", Timestamp::from(1000))?;
@@ -974,7 +974,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_text_note_sets_status_when_load_more_completed_home(
+    fn process_nostr_event_for_tab_text_note_sets_status_when_load_more_completed_home(
     ) -> Result<()> {
         let current_user_pubkey = Keys::generate().public_key();
         let mut state = AppState::new(current_user_pubkey);
@@ -1014,7 +1014,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_text_note_sets_status_when_load_more_completed_user_timeline(
+    fn process_nostr_event_for_tab_text_note_sets_status_when_load_more_completed_user_timeline(
     ) -> Result<()> {
         let current_user_pubkey = Keys::generate().public_key();
         let mut state = AppState::new(current_user_pubkey);
@@ -1058,7 +1058,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_metadata_inserts_profile_when_valid_json() -> Result<()> {
+    fn process_nostr_event_for_tab_metadata_inserts_profile_when_valid_json() -> Result<()> {
         let current_user_pubkey = Keys::generate().public_key();
         let mut state = AppState::new(current_user_pubkey);
 
@@ -1086,7 +1086,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_nostr_event_for_tab_metadata_ignores_invalid_json() -> Result<()> {
+    fn process_nostr_event_for_tab_metadata_ignores_invalid_json() -> Result<()> {
         let current_user_pubkey = Keys::generate().public_key();
         let mut state = AppState::new(current_user_pubkey);
 
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     #[test]
-    fn test_open_author_timeline_switches_to_existing_tab() {
+    fn open_author_timeline_switches_to_existing_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
         let feed = FeedKind::Author(author_pubkey);
@@ -1128,7 +1128,7 @@ mod tests {
     }
 
     #[test]
-    fn test_open_author_timeline_creates_new_tab_and_shows_loading() {
+    fn open_author_timeline_creates_new_tab_and_shows_loading() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
         let Ok(author_npub) = author_pubkey.to_bech32();
@@ -1146,7 +1146,7 @@ mod tests {
     }
 
     #[test]
-    fn test_open_mention_tab_switches_to_existing_tab() {
+    fn open_mention_tab_switches_to_existing_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let feed = FeedKind::Mention;
 
@@ -1167,7 +1167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_open_mention_tab_creates_new_tab_and_shows_loading() {
+    fn open_mention_tab_creates_new_tab_and_shows_loading() {
         let mut state = AppState::new(Keys::generate().public_key());
         let feed = FeedKind::Mention;
 
@@ -1180,7 +1180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_close_current_tab_removes_active_tab() {
+    fn close_current_tab_removes_active_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         let author_pubkey = Keys::generate().public_key();
         let feed = FeedKind::Author(author_pubkey);
@@ -1195,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_close_current_tab_keeps_home_tab() {
+    fn close_current_tab_keeps_home_tab() {
         let mut state = AppState::new(Keys::generate().public_key());
         assert_eq!(state.timeline.active_tab().feed(), &FeedKind::Home);
 
@@ -1207,7 +1207,7 @@ mod tests {
     }
 
     #[test]
-    fn test_react_to_selected_without_selection_is_noop() {
+    fn react_to_selected_without_selection_is_noop() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let command = state.react_to_selected();
@@ -1217,7 +1217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_react_to_selected_sets_status() -> Result<()> {
+    fn react_to_selected_sets_status() -> Result<()> {
         let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1246,7 +1246,7 @@ mod tests {
     }
 
     #[test]
-    fn test_repost_selected_sets_status() -> Result<()> {
+    fn repost_selected_sets_status() -> Result<()> {
         let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1275,7 +1275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_start_reply_without_selection_is_noop() {
+    fn start_reply_without_selection_is_noop() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let _ = state.start_reply();
@@ -1285,7 +1285,7 @@ mod tests {
     }
 
     #[test]
-    fn test_start_reply_sets_reply_context() -> Result<()> {
+    fn start_reply_sets_reply_context() -> Result<()> {
         let keys = Keys::generate();
         let mut state = AppState::new(keys.public_key());
 
@@ -1302,7 +1302,7 @@ mod tests {
     }
 
     #[test]
-    fn test_submit_note_posts_content_and_resets_editor() {
+    fn submit_note_posts_content_and_resets_editor() {
         let (mut state, _rx) = connected_state();
 
         // Compose "hi" in the editor.
@@ -1330,7 +1330,7 @@ mod tests {
 
     /// #540: an empty note is an event the relays keep and nobody can read.
     #[test]
-    fn test_submit_note_refuses_an_empty_draft() {
+    fn submit_note_refuses_an_empty_draft() {
         let (mut state, _rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
@@ -1351,7 +1351,7 @@ mod tests {
     /// whitespace; pressing Enter on an untouched composer leaves two empty lines, which
     /// `get_content` joins into a bare `"\n"`. Same answer, different buffer.
     #[test]
-    fn test_submit_note_refuses_a_draft_of_only_whitespace() {
+    fn submit_note_refuses_a_draft_of_only_whitespace() {
         for keys in [
             vec![KeyCode::Char(' '), KeyCode::Char(' ')],
             vec![KeyCode::Enter],
@@ -1393,7 +1393,7 @@ mod tests {
     /// reading that if the builder started trimming — which is the one change this test
     /// exists to catch. The bar is checked too, since it is what the user sees.
     #[test]
-    fn test_submit_note_posts_padded_content_as_typed() {
+    fn submit_note_posts_padded_content_as_typed() {
         let (mut state, mut rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
@@ -1419,7 +1419,7 @@ mod tests {
     /// #538: the buffer outlives the composer, so a submission that arrives after the
     /// editor closed would publish the same note a second time.
     #[test]
-    fn test_submit_note_publishes_once_when_submitted_twice() {
+    fn submit_note_publishes_once_when_submitted_twice() {
         let (mut state, _rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
@@ -1445,7 +1445,7 @@ mod tests {
     }
 
     #[test]
-    fn test_submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
+    fn submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
         let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1474,7 +1474,7 @@ mod tests {
     }
 
     #[test]
-    fn test_publish_music_status_sets_status() {
+    fn publish_music_status_sets_status() {
         let (mut state, _rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
@@ -1549,7 +1549,7 @@ mod tests {
     }
 
     #[test]
-    fn test_publish_music_status_ignores_invalid_track() {
+    fn publish_music_status_ignores_invalid_track() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         // A track with an empty title cannot form a status, so nothing happens.
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_connection_ready_marks_ready_and_shows_loading() {
+    fn on_connection_ready_marks_ready_and_shows_loading() {
         let mut state = AppState::new(Keys::generate().public_key());
         let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -1570,7 +1570,7 @@ mod tests {
     }
 
     #[test]
-    fn test_route_relay_event_routes_to_owning_tab() -> Result<()> {
+    fn route_relay_event_routes_to_owning_tab() -> Result<()> {
         let keys = Keys::generate();
         let mut state = AppState::new(keys.public_key());
 
@@ -1593,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_more_timeline_without_events_is_noop() {
+    fn load_more_timeline_without_events_is_noop() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         // No events => no oldest timestamp => nothing to paginate.
@@ -1603,7 +1603,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_more_timeline_sets_loading_status() -> Result<()> {
+    fn load_more_timeline_sets_loading_status() -> Result<()> {
         let keys = Keys::generate();
         let mut state = AppState::new(keys.public_key());
 
@@ -1618,7 +1618,7 @@ mod tests {
     }
 
     #[test]
-    fn test_route_relay_event_ignores_untracked_subscription() -> Result<()> {
+    fn route_relay_event_ignores_untracked_subscription() -> Result<()> {
         let keys = Keys::generate();
         let mut state = AppState::new(keys.public_key());
 
@@ -1905,7 +1905,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_connection_ready_dispatches_nothing() {
+    fn on_connection_ready_dispatches_nothing() {
         let (_state, mut rx) = connected_state();
 
         // Becoming ready must not, by itself, send any command.
@@ -1913,7 +1913,7 @@ mod tests {
     }
 
     #[test]
-    fn test_open_author_timeline_dispatches_subscribe() {
+    fn open_author_timeline_dispatches_subscribe() {
         let (mut state, mut rx) = connected_state();
         let author_pubkey = Keys::generate().public_key();
 
@@ -1928,7 +1928,7 @@ mod tests {
     }
 
     #[test]
-    fn test_close_current_tab_dispatches_unsubscribe() {
+    fn close_current_tab_dispatches_unsubscribe() {
         let (mut state, mut rx) = connected_state();
         let feed = FeedKind::Author(Keys::generate().public_key());
         let sub_id = SubscriptionId::new("author_sub");
@@ -1951,7 +1951,7 @@ mod tests {
     }
 
     #[test]
-    fn test_react_to_selected_dispatches_send_event() -> Result<()> {
+    fn react_to_selected_dispatches_send_event() -> Result<()> {
         let (mut state, mut rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1970,7 +1970,7 @@ mod tests {
     }
 
     #[test]
-    fn test_repost_selected_dispatches_send_event() -> Result<()> {
+    fn repost_selected_dispatches_send_event() -> Result<()> {
         let (mut state, mut rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1989,7 +1989,7 @@ mod tests {
     }
 
     #[test]
-    fn test_submit_note_dispatches_send_event() {
+    fn submit_note_dispatches_send_event() {
         let (mut state, mut rx) = connected_state();
 
         state.editor.update(EditorMessage::ComposingStarted);
@@ -2006,7 +2006,7 @@ mod tests {
     }
 
     #[test]
-    fn test_publish_music_status_dispatches_send_event() {
+    fn publish_music_status_dispatches_send_event() {
         let (mut state, mut rx) = connected_state();
 
         let _ = state.publish_music_status(create_track("Song"));
@@ -2018,7 +2018,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_more_timeline_dispatches_load_more() -> Result<()> {
+    fn load_more_timeline_dispatches_load_more() -> Result<()> {
         // Regression guard for #458: the status-only test passed while the
         // `LoadMore` dispatch was missing.
         let (mut state, mut rx) = connected_state();
@@ -2041,7 +2041,7 @@ mod tests {
     }
 
     #[test]
-    fn test_close_connection_dispatches_shutdown() {
+    fn close_connection_dispatches_shutdown() {
         let (mut state, mut rx) = connected_state();
 
         let _ = state.close_connection();
@@ -2050,7 +2050,7 @@ mod tests {
     }
 
     #[test]
-    fn test_show_error_sets_error_status() {
+    fn show_error_sets_error_status() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let _ = state.show_error("boom".to_owned());
@@ -2059,7 +2059,7 @@ mod tests {
     }
 
     #[test]
-    fn test_notify_subscription_error_sets_error_status() {
+    fn notify_subscription_error_sets_error_status() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let _ = state.notify_subscription_error(CommandError::AddRelayFailed {
@@ -2075,7 +2075,7 @@ mod tests {
     /// `disconntected` — this very comment carries that spelling and still lints
     /// clean. So the spelling is asserted here instead of left to the linter.
     #[test]
-    fn test_notify_subscription_shutdown_says_disconnected() {
+    fn notify_subscription_shutdown_says_disconnected() {
         let mut state = AppState::new(Keys::generate().public_key());
 
         let _ = state.notify_subscription_shutdown();

--- a/src/application/state/user.rs
+++ b/src/application/state/user.rs
@@ -220,10 +220,16 @@ mod tests {
     #[test]
     fn clear_profiles_drops_every_profile() {
         let mut state = UserState::new();
-        let keys = Keys::generate();
-        let profile = create_test_profile(keys.public_key(), Timestamp::now());
-        state.insert_newer_profile(profile);
-        assert_eq!(state.profile_count(), 1);
+
+        // More than one, since "every" is what the name claims: draining only the first
+        // entry, or removing a single key, would pass with one and leave stale profiles
+        // on screen after a reset.
+        for _ in 0..3 {
+            let keys = Keys::generate();
+            let profile = create_test_profile(keys.public_key(), Timestamp::now());
+            state.insert_newer_profile(profile);
+        }
+        assert_eq!(state.profile_count(), 3);
 
         state.clear_profiles();
         assert_eq!(state.profile_count(), 0);

--- a/src/application/state/user.rs
+++ b/src/application/state/user.rs
@@ -121,14 +121,6 @@ mod tests {
     }
 
     #[test]
-    fn current_user_pubkey_returns_the_configured_key() {
-        let keys = Keys::generate();
-        let pubkey = keys.public_key();
-        let state = UserState::new_with_pubkey(pubkey);
-        assert_eq!(state.current_user_pubkey(), pubkey);
-    }
-
-    #[test]
     fn insert_newer_profile_keeps_only_the_latest() {
         let mut state = UserState::new();
         let keys = Keys::generate();

--- a/src/application/state/user.rs
+++ b/src/application/state/user.rs
@@ -106,13 +106,13 @@ mod tests {
     }
 
     #[test]
-    fn test_new() {
+    fn test_new_holds_no_profiles() {
         let state = UserState::new();
         assert_eq!(state.profile_count(), 0);
     }
 
     #[test]
-    fn test_new_with_pubkey() {
+    fn test_new_with_pubkey_records_the_current_user() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let state = UserState::new_with_pubkey(pubkey);
@@ -121,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user_pubkey() {
+    fn test_current_user_pubkey_returns_the_configured_key() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let state = UserState::new_with_pubkey(pubkey);
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_newer_profile() {
+    fn test_insert_newer_profile_keeps_only_the_latest() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_profile() {
+    fn test_get_profile_returns_none_until_one_is_inserted() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user() {
+    fn test_current_user_is_none_until_their_profile_arrives() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let mut state = UserState::new_with_pubkey(pubkey);
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_has_profile() {
+    fn test_has_profile_follows_insertion() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_profile_count() {
+    fn test_profile_count_counts_distinct_pubkeys() {
         let mut state = UserState::new();
         assert_eq!(state.profile_count(), 0);
 
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn test_all_pubkeys() {
+    fn test_all_pubkeys_lists_every_profile() {
         let mut state = UserState::new();
         let keys1 = Keys::generate();
         let keys2 = Keys::generate();
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_profiles() {
+    fn test_clear_profiles_empties_the_state() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let profile = create_test_profile(keys.public_key(), Timestamp::now());
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_profile() {
+    fn test_remove_profile_returns_and_drops_it() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();

--- a/src/application/state/user.rs
+++ b/src/application/state/user.rs
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_count_counts_distinct_pubkeys() {
+    fn profile_count_counts_the_profiles_held() {
         let mut state = UserState::new();
         assert_eq!(state.profile_count(), 0);
 
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_profiles_empties_the_state() {
+    fn clear_profiles_drops_every_profile() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let profile = create_test_profile(keys.public_key(), Timestamp::now());

--- a/src/application/state/user.rs
+++ b/src/application/state/user.rs
@@ -106,13 +106,13 @@ mod tests {
     }
 
     #[test]
-    fn test_new_holds_no_profiles() {
+    fn new_holds_no_profiles() {
         let state = UserState::new();
         assert_eq!(state.profile_count(), 0);
     }
 
     #[test]
-    fn test_new_with_pubkey_records_the_current_user() {
+    fn new_with_pubkey_records_the_current_user() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let state = UserState::new_with_pubkey(pubkey);
@@ -121,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user_pubkey_returns_the_configured_key() {
+    fn current_user_pubkey_returns_the_configured_key() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let state = UserState::new_with_pubkey(pubkey);
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_newer_profile_keeps_only_the_latest() {
+    fn insert_newer_profile_keeps_only_the_latest() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_profile_returns_none_until_one_is_inserted() {
+    fn get_profile_returns_none_until_one_is_inserted() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user_is_none_until_their_profile_arrives() {
+    fn current_user_is_none_until_their_profile_arrives() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let mut state = UserState::new_with_pubkey(pubkey);
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_has_profile_follows_insertion() {
+    fn has_profile_follows_insertion() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_profile_count_counts_distinct_pubkeys() {
+    fn profile_count_counts_distinct_pubkeys() {
         let mut state = UserState::new();
         assert_eq!(state.profile_count(), 0);
 
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn test_all_pubkeys_lists_every_profile() {
+    fn all_pubkeys_lists_every_profile() {
         let mut state = UserState::new();
         let keys1 = Keys::generate();
         let keys2 = Keys::generate();
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_profiles_empties_the_state() {
+    fn clear_profiles_empties_the_state() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let profile = create_test_profile(keys.public_key(), Timestamp::now());
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_profile_returns_and_drops_it() {
+    fn remove_profile_returns_and_drops_it() {
         let mut state = UserState::new();
         let keys = Keys::generate();
         let pubkey = keys.public_key();
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_profiles() {
+    fn multiple_profiles() {
         let mut state = UserState::new();
         let keys1 = Keys::generate();
         let keys2 = Keys::generate();

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -323,17 +323,22 @@ mod tests {
             events_set.insert(event.clone());
         }
 
+        let mut expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
+        expected.sort();
+
         // Deref経由でスライスメソッドを使用
         assert_eq!(events_set.len(), 3);
         assert_eq!(events_set.first().unwrap().content, "first");
 
         // iter()でのイテレーション（Deref経由）
-        let collected: Vec<_> = events_set.iter().collect();
-        assert_eq!(collected.len(), 3);
+        let mut collected: Vec<_> = events_set.iter().map(|e| e.id).collect();
+        collected.sort();
+        assert_eq!(collected, expected);
 
         // into_iter()でのイテレーション
-        let ids: Vec<_> = events_set.into_iter().map(|e| e.id).collect();
-        assert_eq!(ids.len(), 3);
+        let mut ids: Vec<_> = events_set.clone().into_iter().map(|e| e.id).collect();
+        ids.sort();
+        assert_eq!(ids, expected);
 
         Ok(())
     }

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::unwrap_used)]
-    fn test_iteration() -> Result<()> {
+    fn iteration_yields_every_inserted_event() -> Result<()> {
         let mut events_set = EventSet::new();
         let test_events = [
             create_test_event(1, "first")?,

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -323,21 +323,21 @@ mod tests {
             events_set.insert(event.clone());
         }
 
-        let mut expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
-        expected.sort();
+        // Unsorted: `EventSet` documents that it preserves insertion order, and nothing
+        // else in the crate pins that. Sorting both sides would let a reimplementation
+        // over a `HashSet` — which would scramble the timeline — pass.
+        let expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
 
         // Deref経由でスライスメソッドを使用
         assert_eq!(events_set.len(), 3);
         assert_eq!(events_set.first().unwrap().content, "first");
 
         // iter()でのイテレーション（Deref経由）
-        let mut collected: Vec<_> = events_set.iter().map(|e| e.id).collect();
-        collected.sort();
+        let collected: Vec<_> = events_set.iter().map(|e| e.id).collect();
         assert_eq!(collected, expected);
 
         // into_iter()でのイテレーション
-        let mut ids: Vec<_> = events_set.clone().into_iter().map(|e| e.id).collect();
-        ids.sort();
+        let ids: Vec<_> = events_set.into_iter().map(|e| e.id).collect();
         assert_eq!(ids, expected);
 
         Ok(())

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -208,14 +208,14 @@ mod tests {
     }
 
     #[test]
-    fn test_new_collection_is_empty() {
+    fn new_collection_is_empty() {
         let events = EventSet::new();
         assert!(events.is_empty());
         assert_eq!(events.len(), 0);
     }
 
     #[test]
-    fn test_insert_new_event_returns_true() -> Result<()> {
+    fn insert_new_event_returns_true() -> Result<()> {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test content")?;
 
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_duplicate_event_returns_false() -> Result<()> {
+    fn insert_duplicate_event_returns_false() -> Result<()> {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test content")?;
 
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_different_events_both_added() -> Result<()> {
+    fn insert_different_events_both_added() -> Result<()> {
         let mut events = EventSet::new();
         let event1 = create_test_event(1, "first event")?;
         let event2 = create_test_event(2, "second event")?;
@@ -263,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_push_is_alias_for_insert() -> Result<()> {
+    fn push_is_alias_for_insert() -> Result<()> {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test content")?;
 
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_event_with_different_content() -> Result<()> {
+    fn duplicate_event_with_different_content() -> Result<()> {
         let mut events = EventSet::new();
 
         // 同じEventIdで異なるコンテンツのイベントを作成
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_empties_the_collection() -> Result<()> {
+    fn clear_empties_the_collection() -> Result<()> {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test")?;
 
@@ -355,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn test_standard_traits() -> Result<()> {
+    fn standard_traits() -> Result<()> {
         let mut events = EventSet::new();
         let event1 = create_test_event(1, "first")?;
         let event2 = create_test_event(2, "second")?;
@@ -383,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn test_internal_consistency() -> Result<()> {
+    fn internal_consistency() -> Result<()> {
         let mut events = EventSet::new();
 
         // 複数のイベントを追加 (1-10)
@@ -410,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_performance_and_capacity() -> Result<()> {
+    fn performance_and_capacity() -> Result<()> {
         let mut events = EventSet::with_capacity(256);
         assert_eq!(events.capacity(), 256);
 

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -313,10 +313,13 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn iteration_yields_every_inserted_event_in_insertion_order() -> Result<()> {
         let mut events_set = EventSet::new();
+        // Suffixes out of order on purpose: with ascending ids, insertion order and id
+        // order coincide and a `BTreeSet`-by-id reimplementation would pass while
+        // reordering the timeline.
         let test_events = [
-            create_test_event(1, "first")?,
-            create_test_event(2, "second")?,
-            create_test_event(3, "third")?,
+            create_test_event(3, "first")?,
+            create_test_event(1, "second")?,
+            create_test_event(2, "third")?,
         ];
 
         for event in test_events.iter() {

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::unwrap_used)]
-    fn iteration_yields_every_inserted_event() -> Result<()> {
+    fn iteration_yields_every_inserted_event_in_insertion_order() -> Result<()> {
         let mut events_set = EventSet::new();
         let test_events = [
             create_test_event(1, "first")?,

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -314,8 +314,8 @@ mod tests {
     fn iteration_yields_every_inserted_event_in_insertion_order() -> Result<()> {
         let mut events_set = EventSet::new();
         // Suffixes out of order on purpose: with ascending ids, insertion order and id
-        // order coincide and a `BTreeSet`-by-id reimplementation would pass while
-        // reordering the timeline.
+        // order coincide, so the assertions below could not tell the two apart and a
+        // reimplementation over any id-ordered container would pass.
         let test_events = [
             create_test_event(3, "first")?,
             create_test_event(1, "second")?,
@@ -326,9 +326,11 @@ mod tests {
             events_set.insert(event.clone());
         }
 
-        // Unsorted: `EventSet` documents that it preserves insertion order, and nothing
-        // else in the crate pins that. Sorting both sides would let a reimplementation
-        // over a `HashSet` — which would scramble the timeline — pass.
+        // Unsorted, because the type's doc promises insertion order and nothing else in
+        // the crate pins it. No caller observes the order today — `EventSet` holds a
+        // note's reactions, reposts and zap receipts, which are read by two `len()`s and
+        // an order-independent fold — so this guards the documented contract rather than
+        // any behaviour a user could see. Sorting both sides would guard neither.
         let expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
 
         // Deref経由でスライスメソッドを使用

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear() -> Result<()> {
+    fn test_clear_empties_the_collection() -> Result<()> {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test")?;
 

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn find_event_id_from_last_e_tag_reads_the_e_tag() {
+    fn find_event_id_from_last_e_tag_finds_the_only_one() {
         let keys = Keys::generate();
         let target_id = EventId::from_byte_array([0; EventId::LEN]);
 
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn find_event_id_from_last_e_tag_multiple_tags() {
+    fn find_event_id_from_last_e_tag_takes_the_last_of_several() {
         let keys = Keys::generate();
         let first_id = EventId::from_byte_array([0; EventId::LEN]);
         let last_id = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn find_event_id_from_last_e_tag_no_tags() {
+    fn find_event_id_from_last_e_tag_is_none_without_one() {
         let keys = Keys::generate();
 
         let event = EventBuilder::new(Kind::Reaction, "+")

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_event_id_from_last_e_tag() {
+    fn test_find_event_id_from_last_e_tag_reads_the_e_tag() {
         let keys = Keys::generate();
         let target_id = EventId::from_byte_array([0; EventId::LEN]);
 

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -62,7 +62,7 @@ mod tests {
     use color_eyre::eyre::Result;
 
     #[test]
-    fn test_sortable_event_id_creation() {
+    fn sortable_event_id_creation() {
         let event_id = EventId::from_byte_array([0; EventId::LEN]);
         let timestamp = Timestamp::from(1000);
 
@@ -73,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sortable_event_id_from_event() -> Result<()> {
+    fn sortable_event_id_from_event() -> Result<()> {
         let keys = Keys::generate();
         let timestamp = Timestamp::from(1234567890);
 
@@ -90,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sortable_event_id_ordering_by_timestamp() {
+    fn sortable_event_id_ordering_by_timestamp() {
         let event_id1 = EventId::from_byte_array([0; EventId::LEN]);
         let event_id2 = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
 
@@ -103,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sortable_event_id_ordering_by_id_when_same_timestamp() {
+    fn sortable_event_id_ordering_by_id_when_same_timestamp() {
         let timestamp = Timestamp::from(1000);
         let event_id1 = EventId::from_slice(&[0u8; 32]).expect("Valid event ID");
         let event_id2 = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
@@ -117,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sortable_event_id_equality() {
+    fn sortable_event_id_equality() {
         let event_id = EventId::from_byte_array([0; EventId::LEN]);
         let timestamp = Timestamp::from(1000);
 
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sortable_event_id_in_reverse_sorted_set() {
+    fn sortable_event_id_in_reverse_sorted_set() {
         use sorted_vec::ReverseSortedSet;
         use std::cmp::Reverse;
 
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_event_id_from_last_e_tag_reads_the_e_tag() {
+    fn find_event_id_from_last_e_tag_reads_the_e_tag() {
         let keys = Keys::generate();
         let target_id = EventId::from_byte_array([0; EventId::LEN]);
 
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_event_id_from_last_e_tag_multiple_tags() {
+    fn find_event_id_from_last_e_tag_multiple_tags() {
         let keys = Keys::generate();
         let first_id = EventId::from_byte_array([0; EventId::LEN]);
         let last_id = EventId::from_slice(&[1u8; 32]).expect("Valid event ID");
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_event_id_from_last_e_tag_no_tags() {
+    fn find_event_id_from_last_e_tag_no_tags() {
         let keys = Keys::generate();
 
         let event = EventBuilder::new(Kind::Reaction, "+")

--- a/src/domain/nostr/feed_filter.rs
+++ b/src/domain/nostr/feed_filter.rs
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    fn test_home_feed_filters() {
+    fn test_home_feed_filters_cover_backward_forward_and_profiles() {
         let authors = vec![pubkey(1), pubkey(2)];
         let now = Timestamp::from(1000);
 
@@ -192,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_feed_filters() {
+    fn test_user_feed_filters_cover_backward_and_forward() {
         let author = pubkey(7);
         let now = Timestamp::from(2000);
 
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn test_home_load_more_filter() {
+    fn test_home_load_more_filter_pages_before_its_timestamp() {
         let authors = vec![pubkey(1), pubkey(2)];
         let since = Timestamp::from(500);
 
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_load_more_filter() {
+    fn test_user_load_more_filter_pages_before_its_timestamp() {
         let author = pubkey(9);
         let since = Timestamp::from(500);
 
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_feed_filters() {
+    fn test_mention_feed_filters_match_on_the_p_tag() {
         let own = pubkey(3);
         let now = Timestamp::from(2000);
 
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_load_more_filter() {
+    fn test_mention_load_more_filter_pages_before_its_timestamp() {
         let own = pubkey(3);
         let since = Timestamp::from(500);
 

--- a/src/domain/nostr/feed_filter.rs
+++ b/src/domain/nostr/feed_filter.rs
@@ -135,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_own_pubkey_appends_when_absent() {
+    fn with_own_pubkey_appends_when_absent() {
         let own = pubkey(1);
         let authors = vec![pubkey(2), pubkey(3)];
 
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_own_pubkey_keeps_unchanged_when_present() {
+    fn with_own_pubkey_keeps_unchanged_when_present() {
         let own = pubkey(1);
         let authors = vec![pubkey(2), own, pubkey(3)];
 
@@ -157,14 +157,14 @@ mod tests {
     }
 
     #[test]
-    fn test_with_own_pubkey_on_empty_authors() {
+    fn with_own_pubkey_on_empty_authors() {
         let own = pubkey(1);
 
         assert_eq!(with_own_pubkey(Vec::new(), own), vec![own]);
     }
 
     #[test]
-    fn test_home_feed_filters_cover_backward_forward_and_profiles() {
+    fn home_feed_filters_cover_backward_forward_and_profiles() {
         let authors = vec![pubkey(1), pubkey(2)];
         let now = Timestamp::from(1000);
 
@@ -192,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_feed_filters_cover_backward_and_forward() {
+    fn user_feed_filters_cover_backward_and_forward() {
         let author = pubkey(7);
         let now = Timestamp::from(2000);
 
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn test_home_load_more_filter_pages_before_its_timestamp() {
+    fn home_load_more_filter_pages_before_its_timestamp() {
         let authors = vec![pubkey(1), pubkey(2)];
         let since = Timestamp::from(500);
 
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_load_more_filter_pages_before_its_timestamp() {
+    fn user_load_more_filter_pages_before_its_timestamp() {
         let author = pubkey(9);
         let since = Timestamp::from(500);
 
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_feed_filters_match_on_the_p_tag() {
+    fn mention_feed_filters_match_on_the_p_tag() {
         let own = pubkey(3);
         let now = Timestamp::from(2000);
 
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_load_more_filter_pages_before_its_timestamp() {
+    fn mention_load_more_filter_pages_before_its_timestamp() {
         let own = pubkey(3);
         let since = Timestamp::from(500);
 

--- a/src/domain/nostr/nip10.rs
+++ b/src/domain/nostr/nip10.rs
@@ -352,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_tags_builder_does_not_duplicate_author_ptag() -> Result<()> {
+    fn reply_tags_builder_does_not_duplicate_author_ptag() -> Result<()> {
         // Create an event that already has a p-tag for the author
         let event = Event::from_json(
             r#"{
@@ -393,7 +393,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_tags_builder_adds_missing_author_ptag() -> Result<()> {
+    fn reply_tags_builder_adds_missing_author_ptag() -> Result<()> {
         // Create an event without p-tag for the author
         let event = Event::from_json(
             r#"{
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_tags_builder_with_relay_url() -> Result<()> {
+    fn reply_tags_builder_with_relay_url() -> Result<()> {
         // Create an event with relay URLs in tags
         let event = Event::from_json(
             r#"{
@@ -479,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_tags_builder_preserves_non_reply_etags() -> Result<()> {
+    fn reply_tags_builder_preserves_non_reply_etags() -> Result<()> {
         // Create an event with various e-tags including non-reply markers
         let event = Event::from_json(
             r#"{
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_tags_builder_removes_reply_marker_from_previous_reply() -> Result<()> {
+    fn reply_tags_builder_removes_reply_marker_from_previous_reply() -> Result<()> {
         // This tests the key behavior: when replying to a reply,
         // the previous "reply" marker should be removed
         let event = Event::from_json(

--- a/src/domain/nostr/nip10.rs
+++ b/src/domain/nostr/nip10.rs
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_reply_tags_builder_build_root(root_event: Event) -> Result<()> {
+    fn reply_tags_builder_build_root(root_event: Event) -> Result<()> {
         let expected = vec![
             Tag::from(TagStandard::Event {
                 event_id: EventId::from_hex(
@@ -272,7 +272,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_reply_tags_builder_build_reply(reply_event: Event) -> Result<()> {
+    fn reply_tags_builder_build_reply(reply_event: Event) -> Result<()> {
         let expected = vec![
             Tag::from(TagStandard::Event {
                 event_id: EventId::from_hex(
@@ -307,7 +307,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_reply_tags_builder_build_tag(tag_event: Event) -> Result<()> {
+    fn reply_tags_builder_build_tag(tag_event: Event) -> Result<()> {
         let expected = vec![
             Tag::from(TagStandard::Event {
                 event_id: EventId::from_hex(

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -86,7 +86,7 @@ mod tests {
             )
         ])
     ]
-    fn find_matches_only_delimited_nostr_uris(
+    fn find_needs_a_nostr_scheme_not_glued_to_a_word(
         #[case] content: &str,
         #[case] expected: Vec<Reference>,
     ) {

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -86,7 +86,7 @@ mod tests {
             )
         ])
     ]
-    fn find_needs_a_nostr_scheme_not_glued_to_a_word(
+    fn find_extracts_recognised_references_in_order_and_rejects_the_rest(
         #[case] content: &str,
         #[case] expected: Vec<Reference>,
     ) {

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -86,7 +86,7 @@ mod tests {
             )
         ])
     ]
-    fn test_parse(#[case] content: &str, #[case] expected: Vec<Reference>) {
+    fn parse_finds_every_reference(#[case] content: &str, #[case] expected: Vec<Reference>) {
         assert_eq!(Reference::find(content), expected);
     }
 }

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -86,7 +86,10 @@ mod tests {
             )
         ])
     ]
-    fn parse_finds_every_reference(#[case] content: &str, #[case] expected: Vec<Reference>) {
+    fn find_matches_only_delimited_nostr_uris(
+        #[case] content: &str,
+        #[case] expected: Vec<Reference>,
+    ) {
         assert_eq!(Reference::find(content), expected);
     }
 }

--- a/src/domain/nostr/nip38.rs
+++ b/src/domain/nostr/nip38.rs
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_with_valid_track() {
+    fn new_with_valid_track() {
         let track = create_valid_track();
         let status = MusicStatus::new(track);
 
@@ -76,7 +76,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_with_empty_title() {
+    fn new_with_empty_title() {
         let track = Track {
             title: "".to_string(),
             artist: vec!["Test Artist".to_string()],
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_with_empty_artist() {
+    fn new_with_empty_artist() {
         let track = Track {
             title: "Test Song".to_string(),
             artist: vec![],
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_with_none_duration() {
+    fn new_with_none_duration() {
         let track = Track {
             title: "Test Song".to_string(),
             artist: vec!["Test Artist".to_string()],
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    fn test_content_single_artist() {
+    fn content_single_artist() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
 
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn test_content_multiple_artists() {
+    fn content_multiple_artists() {
         let track = Track {
             title: "Collaboration".to_string(),
             artist: vec![
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_encodes_special_characters() {
+    fn reference_encodes_special_characters() {
         let track = Track {
             title: "Song & Title".to_string(),
             artist: vec!["Artist/Name".to_string()],
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_encodes_spaces() {
+    fn reference_encodes_spaces() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let reference = status.reference();
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expiration_returns_some() {
+    fn expiration_returns_some() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let expiration = status.expiration();
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expiration_is_in_future() {
+    fn expiration_is_in_future() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let expiration = status.expiration().expect("Expiration should be Some");
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_music_status_to_live_status() {
+    fn from_music_status_to_live_status() {
         let track = create_valid_track();
         let music_status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let live_status: LiveStatus = music_status.into();
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_live_status_builder_builds_a_user_status_event() {
+    fn live_status_builder_builds_a_user_status_event() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let expected_content = status.content();
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_music_status_preserves_reference() {
+    fn from_music_status_preserves_reference() {
         let track = Track {
             title: "Test & Song".to_string(),
             artist: vec!["Test Artist".to_string()],

--- a/src/domain/nostr/nip38.rs
+++ b/src/domain/nostr/nip38.rs
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_live_status_builder() {
+    fn test_live_status_builder_builds_a_user_status_event() {
         let track = create_valid_track();
         let status = MusicStatus::new(track).expect("Failed to create MusicStatus");
         let expected_content = status.content();

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -58,7 +58,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn profile_new() {
+    fn profile_new_keeps_what_it_was_built_from() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -78,7 +78,7 @@ mod tests {
     #[case(Metadata::new().display_name(""), None)]
     #[case(Metadata::new().display_name("").name(""), None)]
     #[case(Metadata::new().display_name("").name("hoge"), None)]
-    fn test_display_name(
+    fn display_name_is_only_the_display_name_and_never_blank(
         #[case] metadata: Metadata,
         #[case] expected: Option<&String>,
     ) -> Result<()> {
@@ -98,7 +98,10 @@ mod tests {
     #[case(Metadata::new().display_name("foo"), None)]
     #[case(Metadata::new().name(""), None)]
     #[case(Metadata::new().name("foo").display_name("foo"), Some("@foo".to_owned()))]
-    fn test_name(#[case] metadata: Metadata, #[case] expected: Option<String>) -> Result<()> {
+    fn handle_prefixes_the_name_and_ignores_the_display_name(
+        #[case] metadata: Metadata,
+        #[case] expected: Option<String>,
+    ) -> Result<()> {
         let key = PublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -58,7 +58,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_profile_new() {
+    fn profile_new() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_returns_display_name_when_set() {
+    fn name_returns_display_name_when_set() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_returns_name_with_at_when_display_name_empty() {
+    fn name_returns_name_with_at_when_display_name_empty() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -138,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_returns_name_with_at_when_display_name_none() {
+    fn name_returns_name_with_at_when_display_name_none() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_returns_npub_when_both_names_empty() {
+    fn name_returns_npub_when_both_names_empty() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_returns_npub_when_both_names_none() {
+    fn name_returns_npub_when_both_names_none() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_empty_string_display_name_is_skipped() {
+    fn name_empty_string_display_name_is_skipped() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -202,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_profile_clone() {
+    fn profile_clone() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_profile_serialization() {
+    fn profile_serialization() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn name_empty_string_display_name_is_skipped() {
+    fn name_keeps_a_whitespace_only_display_name() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -78,7 +78,7 @@ mod tests {
     #[case(Metadata::new().display_name(""), None)]
     #[case(Metadata::new().display_name("").name(""), None)]
     #[case(Metadata::new().display_name("").name("hoge"), None)]
-    fn display_name_is_only_the_display_name_and_never_blank(
+    fn display_name_is_only_the_display_name_and_never_empty(
         #[case] metadata: Metadata,
         #[case] expected: Option<&String>,
     ) -> Result<()> {

--- a/src/domain/text.rs
+++ b/src/domain/text.rs
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shorten_npub() {
+    fn test_shorten_npub_shortens_an_npub_and_leaves_a_hex_key() {
         assert_eq!(
             shorten_npub("npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug"),
             "f5uuy:mjmug"

--- a/src/domain/text.rs
+++ b/src/domain/text.rs
@@ -68,84 +68,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_wrap_text_no_wrap_alnum() {
+    fn wrap_text_no_wrap_alnum() {
         let actual = wrap_text("hello, world!", 13);
         let expected = "hello, world!";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_wrap_alnum() {
+    fn wrap_text_wrap_alnum() {
         let actual = wrap_text("hello, world!", 4);
         let expected = "hell\no, w\norld\n!";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_no_wrap_double_width() {
+    fn wrap_text_no_wrap_double_width() {
         let actual = wrap_text("こんにちは、世界！", 18);
         let expected = "こんにちは、世界！";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_wrap_double_width() {
+    fn wrap_text_wrap_double_width() {
         let actual = wrap_text("こんにちは、世界！", 7);
         let expected = "こんに\nちは、\n世界！";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_no_wrap_emoji() {
+    fn wrap_text_no_wrap_emoji() {
         let actual = wrap_text("🫲🫱🫲🫱🫲🫱", 12);
         let expected = "🫲🫱🫲🫱🫲🫱";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_wrap_emoji() {
+    fn wrap_text_wrap_emoji() {
         let actual = wrap_text("🫲🫱🫲🫱🫲🫱", 5);
         let expected = "🫲🫱\n🫲🫱\n🫲🫱";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_wrap_text_zero_width() {
+    fn wrap_text_zero_width() {
         let actual = wrap_text("hello, world!", 0);
         let expected = "";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_truncate_text_no_truncate() {
+    fn truncate_text_no_truncate() {
         let actual = truncate_text("foo\nbar\nbaz", 3);
         let expected = "foo\nbar\nbaz";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_truncate_text_truncate() {
+    fn truncate_text_truncate() {
         let actual = truncate_text("foo\nbar\nbaz", 2);
         let expected = "foo\n...";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_truncate_text_single_line() {
+    fn truncate_text_single_line() {
         let actual = truncate_text("foo\nbar", 1);
         let expected = "...";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_truncate_text_zero_height() {
+    fn truncate_text_zero_height() {
         let actual = truncate_text("foo\nbar\nbaz", 0);
         let expected = "";
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_shorten_npub_shortens_an_npub_and_leaves_a_hex_key() {
+    fn shorten_npub_shortens_an_npub_and_leaves_a_hex_key() {
         assert_eq!(
             shorten_npub("npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug"),
             "f5uuy:mjmug"

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -747,7 +747,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_first_message_is_ready() {
+    async fn first_message_is_ready() {
         let client = Arc::new(Client::default());
         let nostr_events = NostrEvents::new(client, Keys::generate().public_key(), None);
 

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -763,7 +763,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_key_uses_arc_pointer() {
+    fn subscription_key_uses_arc_pointer() {
         use tears::SubscriptionSource;
 
         let client = Arc::new(Client::default());
@@ -798,7 +798,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_key_different_clients() {
+    fn subscription_key_different_clients() {
         use tears::SubscriptionSource;
 
         // Create two separate clients with different Arcs
@@ -827,7 +827,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_key_different_arc_instances() {
+    fn subscription_key_different_arc_instances() {
         use tears::SubscriptionSource;
 
         let client = Client::default();

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -135,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_editor_default_state() {
+    fn new_editor_default_state() {
         let editor = Editor::new();
         assert!(!editor.is_active());
         assert!(!editor.is_reply());
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn test_composing_started() {
+    fn composing_started() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_started_with_profile() {
+    fn reply_started_with_profile() {
         let mut editor = Editor::new();
         let event = create_test_event();
         let profile = create_test_profile();
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_started_without_profile() {
+    fn reply_started_without_profile() {
         let mut editor = Editor::new();
         let event = create_test_event();
 
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn test_composing_canceled() {
+    fn composing_canceled() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
         assert!(editor.is_active());
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_composing_started_clears_reply_state() {
+    fn composing_started_clears_reply_state() {
         let mut editor = Editor::new();
         let event = create_test_event();
 
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_key_event_received_when_active() {
+    fn key_event_received_when_active() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn test_key_event_received_when_inactive() {
+    fn key_event_received_when_inactive() {
         let mut editor = Editor::new();
         // Editor is inactive by default
 
@@ -237,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_key_events() {
+    fn multiple_key_events() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_content_empties_the_buffer() {
+    fn clear_content_empties_the_buffer() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -278,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn test_composing_started_clears_previous_content() {
+    fn composing_started_clears_previous_content() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -294,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_started_clears_previous_content() {
+    fn reply_started_clears_previous_content() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -314,14 +314,14 @@ mod tests {
     }
 
     #[test]
-    fn test_textarea_reference() {
+    fn textarea_reference() {
         let editor = Editor::new();
         let textarea = editor.textarea();
         assert_eq!(textarea.lines().len(), 1);
     }
 
     #[test]
-    fn test_cancel_preserves_content() {
+    fn cancel_preserves_content() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_target_after_multiple_replies() {
+    fn reply_target_after_multiple_replies() {
         let mut editor = Editor::new();
         let event1 = create_test_event();
         let event2 = create_test_event();
@@ -361,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_u_as_first_key_event_when_active() {
+    fn ctrl_u_as_first_key_event_when_active() {
         // NOTE: This is a regression test for a tui-textarea bug that occurred
         // when using select_all() + delete_str() to clear content.
         // Ctrl+U (undo) would panic with "cursor (1, 0) exceeds max lines 1".

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn textarea_exposes_the_buffer_it_holds() {
+    fn a_new_editor_has_one_empty_line() {
         let editor = Editor::new();
         let textarea = editor.textarea();
         assert_eq!(textarea.lines().len(), 1);

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -314,10 +314,21 @@ mod tests {
     }
 
     #[test]
-    fn textarea_of_a_new_editor_is_one_empty_line() {
-        let editor = Editor::new();
-        let textarea = editor.textarea();
-        assert_eq!(textarea.lines(), [""]);
+    fn textarea_holds_what_was_typed() {
+        let mut editor = Editor::new();
+        editor.update(Message::ComposingStarted);
+        for code in ['h', 'i'] {
+            editor.update(Message::KeyEventReceived {
+                event: create_key_event(KeyCode::Char(code)),
+            });
+        }
+
+        // The composer is rendered from this, and from nothing else, so a `textarea()`
+        // handing back a fresh or stale `TextArea` would draw an empty box while the
+        // user typed. Asserting a new editor's textarea is blank cannot catch that —
+        // every default `TextArea` is blank — and `new_editor_default_state` already
+        // covers the empty case through `get_content`.
+        assert_eq!(editor.textarea().lines(), ["hi"]);
     }
 
     #[test]

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -314,10 +314,10 @@ mod tests {
     }
 
     #[test]
-    fn a_new_editor_has_one_empty_line() {
+    fn textarea_of_a_new_editor_is_one_empty_line() {
         let editor = Editor::new();
         let textarea = editor.textarea();
-        assert_eq!(textarea.lines().len(), 1);
+        assert_eq!(textarea.lines(), [""]);
     }
 
     #[test]

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn textarea_reference() {
+    fn textarea_exposes_the_buffer_it_holds() {
         let editor = Editor::new();
         let textarea = editor.textarea();
         assert_eq!(textarea.lines().len(), 1);

--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_content() {
+    fn test_clear_content_empties_the_buffer() {
         let mut editor = Editor::new();
         editor.update(Message::ComposingStarted);
 

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_creates_default_instance() {
+    fn new_creates_default_instance() {
         let nostr = Nostr::new();
 
         assert!(!nostr.is_ready());
@@ -167,14 +167,14 @@ mod tests {
     }
 
     #[test]
-    fn test_is_ready_returns_false_when_not_connected() {
+    fn is_ready_returns_false_when_not_connected() {
         let nostr = Nostr::new();
 
         assert!(!nostr.is_ready());
     }
 
     #[test]
-    fn test_is_ready_returns_true_after_connection_ready() {
+    fn is_ready_returns_true_after_connection_ready() {
         let mut nostr = Nostr::new();
 
         assert_eq!(nostr.update(Message::ConnectionReady), None);
@@ -183,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_subscribed_returns_false_when_no_subscription() {
+    fn is_subscribed_returns_false_when_no_subscription() {
         let nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_subscribed_returns_false_when_subscription_list_is_empty() {
+    fn is_subscribed_returns_false_when_subscription_list_is_empty() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_subscribed_returns_true_when_subscription_exists() {
+    fn is_subscribed_returns_true_when_subscription_exists() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_tab_by_subscription_returns_none_when_not_found() {
+    fn find_tab_by_subscription_returns_none_when_not_found() {
         let nostr = Nostr::new();
         let sub_id = SubscriptionId::new("test_sub");
 
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_tab_by_subscription_returns_feed_when_found() {
+    fn find_tab_by_subscription_returns_feed_when_found() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
@@ -237,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_connection_ready_sets_connected() {
+    fn update_connection_ready_sets_connected() {
         let mut nostr = Nostr::new();
 
         let outcome = nostr.update(Message::ConnectionReady);
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_event_submitted_returns_send_when_ready() {
+    fn update_event_submitted_returns_send_when_ready() {
         let mut nostr = Nostr::new();
         let event_builder = EventBuilder::new(Kind::TextNote, "test");
 
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_event_submitted_returns_none_when_not_ready() {
+    fn update_event_submitted_returns_none_when_not_ready() {
         let mut nostr = Nostr::new();
         let event_builder = EventBuilder::new(Kind::TextNote, "test");
 
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_requested_ignores_home_tab() {
+    fn update_subscription_requested_ignores_home_tab() {
         let mut nostr = Nostr::new();
 
         let _ = nostr.update(Message::ConnectionReady);
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_requested_creates_subscription() {
+    fn update_subscription_requested_creates_subscription() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_requested_ignores_request_when_not_connected() {
+    fn update_subscription_requested_ignores_request_when_not_connected() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -333,7 +333,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_requested_ignores_duplicate_request() {
+    fn update_subscription_requested_ignores_duplicate_request() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_created_adds_subscription_id() {
+    fn update_subscription_created_adds_subscription_id() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_created_appends_to_existing_subscriptions() {
+    fn update_subscription_created_appends_to_existing_subscriptions() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id1 = SubscriptionId::new("test_sub1");
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_closed_removes_subscription_and_returns_unsubscribe() {
+    fn update_subscription_closed_removes_subscription_and_returns_unsubscribe() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
@@ -422,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_subscription_closed_handles_non_existent_subscription() {
+    fn update_subscription_closed_handles_non_existent_subscription() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
 
@@ -435,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_history_requested_returns_load_more_command() {
+    fn update_history_requested_returns_load_more_command() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let since = Timestamp::from(1234567890);
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_connection_closed_clears_state_and_returns_shutdown() {
+    fn update_connection_closed_clears_state_and_returns_shutdown() {
         let mut nostr = Nostr::new();
         let feed = create_test_feed();
         let sub_id = SubscriptionId::new("test_sub");
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_connection_closed_returns_none_when_not_connected() {
+    fn update_connection_closed_returns_none_when_not_connected() {
         let mut nostr = Nostr::new();
 
         let outcome = nostr.update(Message::ConnectionClosed);

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_message_getter() {
+    fn message_getter() {
         let status_bar = StatusBar {
             message: Some("test message".to_string()),
         };
@@ -46,13 +46,13 @@ mod tests {
     }
 
     #[test]
-    fn test_message_getter_none() {
+    fn message_getter_none() {
         let status_bar = StatusBar::default();
         assert_eq!(status_bar.message(), None);
     }
 
     #[test]
-    fn test_update_message_changed() {
+    fn update_message_changed() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {
             label: "Info".to_string(),
@@ -67,7 +67,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_error_message_changed() {
+    fn update_error_message_changed() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::ErrorMessageChanged {
             label: "Network".to_string(),
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_message_cleared() {
+    fn update_message_cleared() {
         let mut status_bar = StatusBar {
             message: Some("[Info] Test message".to_string()),
         };
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    fn test_newline_normalization() {
+    fn newline_normalization() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {
             label: "MultiLine".to_string(),
@@ -106,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn test_newline_normalization_in_error_message() {
+    fn newline_normalization_in_error_message() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::ErrorMessageChanged {
             label: "Error".to_string(),
@@ -121,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_message_overwrite() {
+    fn message_overwrite() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {
             label: "First".to_string(),
@@ -140,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_label_and_message() {
+    fn empty_label_and_message() {
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {
             label: "".to_string(),

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -46,7 +46,7 @@ mod tests {
     }
 
     #[test]
-    fn message_is_none_until_something_sets_it() {
+    fn message_defaults_to_none() {
         let status_bar = StatusBar::default();
         assert_eq!(status_bar.message(), None);
     }

--- a/src/model/status_bar.rs
+++ b/src/model/status_bar.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn message_getter() {
+    fn message_returns_what_was_set() {
         let status_bar = StatusBar {
             message: Some("test message".to_string()),
         };
@@ -46,7 +46,7 @@ mod tests {
     }
 
     #[test]
-    fn message_getter_none() {
+    fn message_is_none_until_something_sets_it() {
         let status_bar = StatusBar::default();
         assert_eq!(status_bar.message(), None);
     }

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_default() {
+    fn timeline_default() {
         let timeline = Timeline::default();
 
         assert_eq!(timeline.tabs().len(), 1);
@@ -344,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn test_active_tab_starts_as_an_empty_home_tab() {
+    fn active_tab_starts_as_an_empty_home_tab() {
         let timeline = Timeline::default();
         let active_tab = timeline.active_tab();
 
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_tab_by_feed_returns_the_index_or_none() {
+    fn find_tab_by_feed_returns_the_index_or_none() {
         let mut timeline = Timeline::default();
 
         // Home tab should be at index 0
@@ -375,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_to_home_tab() {
+    fn note_added_to_home_tab() {
         let mut timeline = Timeline::default();
         let event = create_test_event(1000, 1, "Hello, Nostr!");
         let event_id = event.id;
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_to_nonexistent_tab() {
+    fn note_added_to_nonexistent_tab() {
         let mut timeline = Timeline::default();
         let event = create_test_event(1000, 1, "Hello, Nostr!");
 
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_empty_reflects_active_tab() {
+    fn is_empty_reflects_active_tab() {
         let mut timeline = Timeline::default();
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
 
@@ -434,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_shared_storage() {
+    fn note_added_shared_storage() {
         let mut timeline = Timeline::default();
 
         // Add a user timeline tab
@@ -467,7 +467,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_notes_sorting() {
+    fn multiple_notes_sorting() {
         let mut timeline = Timeline::default();
 
         // Add notes in non-chronological order
@@ -495,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_added() {
+    fn reaction_added() {
         let mut timeline = Timeline::default();
 
         // Add a text note first
@@ -522,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_added_to_nonexistent_note() {
+    fn reaction_added_to_nonexistent_note() {
         let mut timeline = Timeline::default();
 
         // Add a reaction to a non-existent note
@@ -538,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn test_repost_added() {
+    fn repost_added() {
         let mut timeline = Timeline::default();
 
         // Add a text note first
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn test_zap_receipt_added() {
+    fn zap_receipt_added() {
         let mut timeline = Timeline::default();
 
         // Add a text note first
@@ -590,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn test_item_selection() {
+    fn item_selection() {
         let mut timeline = Timeline::default();
 
         // Add some notes
@@ -612,7 +612,7 @@ mod tests {
     }
 
     #[test]
-    fn test_navigation_through_items() {
+    fn navigation_through_items() {
         let mut timeline = Timeline::default();
 
         // Add some notes
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_note_follows_the_selection() {
+    fn selected_note_follows_the_selection() {
         let mut timeline = Timeline::default();
 
         let event = create_test_event(1000, 1, "Test note");
@@ -664,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_by_index_returns_none_out_of_range() {
+    fn note_by_index_returns_none_out_of_range() {
         let mut timeline = Timeline::default();
 
         let event = create_test_event(1000, 1, "Test note");
@@ -684,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more_started_when_scrolling_to_bottom() {
+    fn loading_more_started_when_scrolling_to_bottom() {
         let mut timeline = Timeline::default();
 
         // Add some notes
@@ -709,7 +709,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more_completes_when_older_event_arrives() {
+    fn loading_more_completes_when_older_event_arrives() {
         let mut timeline = Timeline::default();
 
         // Add initial note
@@ -742,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_at_bottom_only_on_the_last_note() {
+    fn is_at_bottom_only_on_the_last_note() {
         let mut timeline = Timeline::default();
 
         // Empty timeline is not at bottom
@@ -767,7 +767,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_added() {
+    fn tab_added() {
         let mut timeline = Timeline::default();
         assert_eq!(timeline.tabs().len(), 1);
 
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_added_duplicate() {
+    fn tab_added_duplicate() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -800,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_removed() {
+    fn tab_removed() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -819,7 +819,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_removed_cannot_remove_home() {
+    fn tab_removed_cannot_remove_home() {
         let mut timeline = Timeline::default();
 
         // Try to remove the Home tab
@@ -831,7 +831,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_removed_out_of_bounds() {
+    fn tab_removed_out_of_bounds() {
         let mut timeline = Timeline::default();
 
         // Try to remove a non-existent tab
@@ -842,7 +842,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_removed_adjusts_active_index() {
+    fn tab_removed_adjusts_active_index() {
         let mut timeline = Timeline::default();
 
         let pubkey1 = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -868,7 +868,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_removed_active_tab() {
+    fn tab_removed_active_tab() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -888,7 +888,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_selected() {
+    fn tab_selected() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -906,7 +906,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_selected_out_of_bounds() {
+    fn tab_selected_out_of_bounds() {
         let mut timeline = Timeline::default();
 
         let _ = timeline.update(Message::TabSelected { index: 10 });
@@ -916,7 +916,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_tab_selected() {
+    fn next_tab_selected() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -938,7 +938,7 @@ mod tests {
     }
 
     #[test]
-    fn test_previous_tab_selected() {
+    fn previous_tab_selected() {
         let mut timeline = Timeline::default();
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
@@ -959,7 +959,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_scenario_multiple_tabs_and_notes() {
+    fn complex_scenario_multiple_tabs_and_notes() {
         let mut timeline = Timeline::default();
 
         // Add a user timeline tab
@@ -1007,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn test_last_tab_index_follows_the_tab_count() {
+    fn last_tab_index_follows_the_tab_count() {
         let mut timeline = Timeline::default();
         assert_eq!(timeline.last_tab_index(), 0);
 

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -761,6 +761,14 @@ mod tests {
         let _ = timeline.update(Message::FirstItemSelected);
         assert!(!timeline.is_at_bottom());
 
+        // Nor anywhere in between: without this the name's "only" is unearned, and an
+        // `is_at_bottom` true from the second note onwards would pass.
+        let _ = timeline.update(Message::ItemSelected { index: 2 });
+        assert!(!timeline.is_at_bottom());
+
+        // Nor anywhere in between: without this the name's "only" is unearned, and an
+        // `is_at_bottom` true from the second note onwards would pass.
+
         // Select last item - at bottom
         let _ = timeline.update(Message::LastItemSelected);
         assert!(timeline.is_at_bottom());

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -771,8 +771,12 @@ mod tests {
         assert!(!timeline.is_at_bottom());
 
         // Nor anywhere in between: without this the name's "only" is unearned, and an
-        // `is_at_bottom` true from the second note onwards would pass.
-        let _ = timeline.update(Message::ItemSelected { index: 2 });
+        // `is_at_bottom` true from the second note onwards would pass. Derived from the
+        // notes actually present, so shrinking the loop cannot make it select the last
+        // one and pass vacuously.
+        let middle = timeline.len() / 2;
+        assert!(middle > 0 && middle < timeline.len() - 1, "a middle exists");
+        let _ = timeline.update(Message::ItemSelected { index: middle });
         assert!(!timeline.is_at_bottom());
 
         // Select last item - at bottom

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -645,22 +645,31 @@ mod tests {
     fn selected_note_follows_the_selection() {
         let mut timeline = Timeline::default();
 
-        let event = create_test_event(1000, 1, "Test note");
-        let event_id = event.id;
+        // Two notes, and both ends of the selection checked. With one note at index 0,
+        // a `selected_note` that ignored the selection and returned the tab's first
+        // note would pass, and the `None` branch would never run.
+        // Newest first, as the tab stores them, so this reads in index order.
+        let mut ids = Vec::new();
+        for (i, timestamp) in [2000, 1000].into_iter().enumerate() {
+            let event = create_test_event(timestamp, i as u8, "Test note");
+            ids.push(event.id);
+            let _ = timeline.update(Message::NoteAddedToTab {
+                event,
+                feed: FeedKind::Home,
+            });
+        }
 
-        let _ = timeline.update(Message::NoteAddedToTab {
-            event,
-            feed: FeedKind::Home,
-        });
-
-        let _ = timeline.update(Message::ItemSelected { index: 0 });
-
-        let selected = timeline.selected_note();
-        assert!(selected.is_some());
-        assert_eq!(
-            selected.expect("Should have selected note").as_event().id,
-            event_id
+        assert!(
+            timeline.selected_note().is_none(),
+            "nothing is selected yet"
         );
+
+        for (index, id) in ids.iter().enumerate() {
+            let _ = timeline.update(Message::ItemSelected { index });
+
+            let selected = timeline.selected_note().expect("a note is selected");
+            assert_eq!(selected.as_event().id, *id, "index {index}");
+        }
     }
 
     #[test]

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -768,21 +768,17 @@ mod tests {
             });
         }
 
-        // Select first item - not at bottom
-        let _ = timeline.update(Message::FirstItemSelected);
-        assert!(!timeline.is_at_bottom());
+        // Every index but the last, rather than a sample of them: "only" is not earned
+        // by checking the first and one in the middle, since `selected_index >= len - 2`
+        // would pass that and report the bottom a note early, firing the load-more path
+        // before the user reaches it.
+        let last = timeline.len() - 1;
+        for index in 0..last {
+            let _ = timeline.update(Message::ItemSelected { index });
+            assert!(!timeline.is_at_bottom(), "index {index} of {last}");
+        }
 
-        // Nor anywhere in between: without this the name's "only" is unearned, and an
-        // `is_at_bottom` true from the second note onwards would pass. Derived from the
-        // notes actually present, so shrinking the loop cannot make it select the last
-        // one and pass vacuously.
-        let middle = timeline.len() / 2;
-        assert!(middle > 0 && middle < timeline.len() - 1, "a middle exists");
-        let _ = timeline.update(Message::ItemSelected { index: middle });
-        assert!(!timeline.is_at_bottom());
-
-        // Select last item - at bottom
-        let _ = timeline.update(Message::LastItemSelected);
+        let _ = timeline.update(Message::ItemSelected { index: last });
         assert!(timeline.is_at_bottom());
     }
 

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn a_default_timeline_is_one_empty_tab() {
+    fn timeline_default_is_one_empty_tab() {
         let timeline = Timeline::default();
 
         assert_eq!(timeline.tabs().len(), 1);

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -344,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn test_active_tab() {
+    fn test_active_tab_starts_as_an_empty_home_tab() {
         let timeline = Timeline::default();
         let active_tab = timeline.active_tab();
 
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_tab_by_feed() {
+    fn test_find_tab_by_feed_returns_the_index_or_none() {
         let mut timeline = Timeline::default();
 
         // Home tab should be at index 0
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_note() {
+    fn test_selected_note_follows_the_selection() {
         let mut timeline = Timeline::default();
 
         let event = create_test_event(1000, 1, "Test note");
@@ -664,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_by_index() {
+    fn test_note_by_index_returns_none_out_of_range() {
         let mut timeline = Timeline::default();
 
         let event = create_test_event(1000, 1, "Test note");
@@ -742,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_at_bottom() {
+    fn test_is_at_bottom_only_on_the_last_note() {
         let mut timeline = Timeline::default();
 
         // Empty timeline is not at bottom
@@ -1007,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn test_last_tab_index() {
+    fn test_last_tab_index_follows_the_tab_count() {
         let mut timeline = Timeline::default();
         assert_eq!(timeline.last_tab_index(), 0);
 

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -648,7 +648,9 @@ mod tests {
         // Two notes, and both ends of the selection checked. With one note at index 0,
         // a `selected_note` that ignored the selection and returned the tab's first
         // note would pass, and the `None` branch would never run.
-        // Newest first, as the tab stores them, so this reads in index order.
+        // Newest first, as the tab stores them, so this reads in index order. The
+        // timestamps are what order these; `create_test_event`'s suffix argument looks
+        // like it distinguishes them and does not (#550).
         let mut ids = Vec::new();
         for (i, timestamp) in [2000, 1000].into_iter().enumerate() {
             let event = create_test_event(timestamp, i as u8, "Test note");

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -766,9 +766,6 @@ mod tests {
         let _ = timeline.update(Message::ItemSelected { index: 2 });
         assert!(!timeline.is_at_bottom());
 
-        // Nor anywhere in between: without this the name's "only" is unearned, and an
-        // `is_at_bottom` true from the second note onwards would pass.
-
         // Select last item - at bottom
         let _ = timeline.update(Message::LastItemSelected);
         assert!(timeline.is_at_bottom());

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -664,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    fn note_by_index_returns_none_out_of_range() {
+    fn note_by_index_finds_a_note_and_is_none_out_of_range() {
         let mut timeline = Timeline::default();
 
         let event = create_test_event(1000, 1, "Test note");

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -768,9 +768,9 @@ mod tests {
             });
         }
 
-        // Guards the subtraction below and pins what the loop above is assumed to have
-        // produced: `notes` is a set, so events colliding would silently leave it empty
-        // and `len() - 1` would panic about arithmetic rather than about the timeline.
+        // Pins what the loop above is assumed to have produced. `notes` is a set, so
+        // events that collided would leave fewer than five, and the loop below would
+        // quietly check fewer indices while still passing — the weakening this catches.
         assert_eq!(timeline.len(), 5);
 
         // Every index but the last, rather than a sample of them: "only" is not earned

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -768,6 +768,11 @@ mod tests {
             });
         }
 
+        // Guards the subtraction below and pins what the loop above is assumed to have
+        // produced: `notes` is a set, so events colliding would silently leave it empty
+        // and `len() - 1` would panic about arithmetic rather than about the timeline.
+        assert_eq!(timeline.len(), 5);
+
         // Every index but the last, rather than a sample of them: "only" is not earned
         // by checking the first and one in the middle, since `selected_index >= len - 2`
         // would pass that and report the bottom a note early, firing the load-more path

--- a/src/model/timeline.rs
+++ b/src/model/timeline.rs
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn timeline_default() {
+    fn a_default_timeline_is_one_empty_tab() {
         let timeline = Timeline::default();
 
         assert_eq!(timeline.tabs().len(), 1);

--- a/src/model/timeline/pagination.rs
+++ b/src/model/timeline/pagination.rs
@@ -85,14 +85,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pagination_state_default() {
+    fn pagination_state_default() {
         let state = Pagination::new();
         assert_eq!(state.oldest_timestamp(), None);
         assert!(!state.is_loading_more());
     }
 
     #[test]
-    fn test_update_oldest() {
+    fn update_oldest() {
         let mut state = Pagination::new();
 
         let ts1 = Timestamp::from(1000);
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more() {
+    fn loading_more() {
         let mut state = Pagination::new();
         let since = Timestamp::from(1000);
 

--- a/src/model/timeline/selection.rs
+++ b/src/model/timeline/selection.rs
@@ -93,14 +93,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_selection_state_default() {
+    fn selection_state_default() {
         let state = Selection::new();
         assert_eq!(state.selected_index(), None);
         assert!(!state.is_selected());
     }
 
     #[test]
-    fn test_select_and_deselect() {
+    fn select_and_deselect() {
         let mut state = Selection::new();
         state.update(Message::ItemSelected(5));
         assert_eq!(state.selected_index(), Some(5));
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_up() {
+    fn scroll_up() {
         let mut state = Selection::new();
         state.update(Message::ItemSelected(5));
 
@@ -126,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_down() {
+    fn scroll_down() {
         let mut state = Selection::new();
 
         // Initial scroll down selects first item
@@ -143,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_first_and_last() {
+    fn select_first_and_last() {
         let mut state = Selection::new();
 
         state.update(Message::FirstItemSelected);
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_previous_item_selected_when_nothing_selected() {
+    fn previous_item_selected_when_nothing_selected() {
         let mut state = Selection::new();
         assert_eq!(state.selected_index(), None);
 
@@ -163,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_item_selected_with_empty_list() {
+    fn next_item_selected_with_empty_list() {
         let mut state = Selection::new();
 
         // Should do nothing when max_index is 0 (empty list)
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_item_selected_boundary() {
+    fn next_item_selected_boundary() {
         let mut state = Selection::new();
 
         // With max_index = 0, only one item exists

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_tab_default() {
+    fn timeline_tab_default() {
         let tab = TimelineTab::new_home();
         assert_eq!(tab.len(), 0);
         assert!(tab.is_empty());
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_feed() {
+    fn timeline_feed() {
         let home_tab = TimelineTab::new_home();
         assert_eq!(home_tab.feed, FeedKind::Home);
 
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selection_message_delegation() {
+    fn selection_message_delegation() {
         let mut tab = TimelineTab::new_home();
 
         // Test ItemSelected - no command should be issued for selection changes
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more_triggered_at_bottom() {
+    fn loading_more_triggered_at_bottom() {
         let mut tab = TimelineTab::new_home();
 
         // Add notes
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more_not_retriggered_while_in_flight() {
+    fn loading_more_not_retriggered_while_in_flight() {
         let mut tab = TimelineTab::new_home();
 
         // Add notes and move to the bottom
@@ -384,7 +384,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_more_not_triggered_without_notes() {
+    fn loading_more_not_triggered_without_notes() {
         let mut tab = TimelineTab::new_home();
         assert_eq!(tab.oldest_timestamp(), None);
 
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_basic() {
+    fn note_added_basic() {
         let mut tab = TimelineTab::new_home();
 
         let event_id = create_test_event_id(1000, 1);
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_updates_oldest_timestamp() {
+    fn note_added_updates_oldest_timestamp() {
         let mut tab = TimelineTab::new_home();
 
         let event1 = create_test_event_id(1000, 1);
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_sorting() {
+    fn note_added_sorting() {
         let mut tab = TimelineTab::new_home();
 
         // Add notes in random order
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_duplicate() {
+    fn note_added_duplicate() {
         let mut tab = TimelineTab::new_home();
 
         let event_id = create_test_event_id(1000, 1);
@@ -459,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_adjusts_selection_when_inserted_before() {
+    fn note_added_adjusts_selection_when_inserted_before() {
         let mut tab = TimelineTab::new_home();
 
         // Add initial notes
@@ -483,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_does_not_adjust_selection_when_inserted_after() {
+    fn note_added_does_not_adjust_selection_when_inserted_after() {
         let mut tab = TimelineTab::new_home();
 
         // Add initial notes
@@ -507,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_does_not_adjust_when_nothing_selected() {
+    fn note_added_does_not_adjust_when_nothing_selected() {
         let mut tab = TimelineTab::new_home();
 
         let event1 = create_test_event_id(1000, 1);
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[test]
-    fn test_note_added_does_not_adjust_when_duplicate() {
+    fn note_added_does_not_adjust_when_duplicate() {
         let mut tab = TimelineTab::new_home();
 
         let event1 = create_test_event_id(1000, 1);
@@ -538,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_scenario() {
+    fn complex_scenario() {
         let mut tab = TimelineTab::new_home();
 
         // Add some initial notes
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_and_last_item_with_empty_timeline() {
+    fn next_and_last_item_with_empty_timeline() {
         let mut tab = TimelineTab::new_home();
         assert_eq!(tab.len(), 0);
 
@@ -604,7 +604,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_and_last_item_with_single_item() {
+    fn next_and_last_item_with_single_item() {
         let mut tab = TimelineTab::new_home();
         let event = create_test_event_id(1000, 1);
         let _ = tab.update(Message::NoteAdded(event));
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_title_home() {
+    fn tab_title_home() {
         let tab = TimelineTab::new_home();
         let profiles = HashMap::new();
 
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_title_mention() {
+    fn tab_title_mention() {
         let tab = TimelineTab::new(FeedKind::Mention);
         let profiles = HashMap::new();
 
@@ -650,7 +650,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_title_user_timeline_with_handle() {
+    fn tab_title_user_timeline_with_handle() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let tab = TimelineTab::new(FeedKind::Author(pubkey));
 
@@ -665,7 +665,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_title_user_timeline_with_empty_name() {
+    fn tab_title_user_timeline_with_empty_name() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let tab = TimelineTab::new(FeedKind::Author(pubkey));
 
@@ -682,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_title_user_timeline_without_profile() {
+    fn tab_title_user_timeline_without_profile() {
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let tab = TimelineTab::new(FeedKind::Author(pubkey));
 

--- a/src/model/timeline/text_note.rs
+++ b/src/model/timeline/text_note.rs
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bech32_id() -> Result<(), Box<dyn Error>> {
+    fn test_bech32_id_is_a_note1_identifier() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event);
 
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_builder() -> Result<(), Box<dyn Error>> {
+    fn test_reaction_builder_builds_a_plus_reaction() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let text_note = TextNote::new(event.clone());
 
@@ -269,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_repost_builder() -> Result<(), Box<dyn Error>> {
+    fn test_repost_builder_tags_the_reposted_event() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let text_note = TextNote::new(event.clone());
 
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_reply_event_id() -> Result<(), Box<dyn Error>> {
+    fn test_find_reply_event_id_finds_the_answered_event() -> Result<(), Box<dyn Error>> {
         let original_event = create_test_event("Original")?;
         let reply_event = create_test_event_with_tags(
             "Reply",
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_client_name() -> Result<(), Box<dyn Error>> {
+    fn test_find_client_name_reads_the_client_tag() -> Result<(), Box<dyn Error>> {
         let client_tag = Tag::from(Nip89Tag::Client {
             name: String::from("TestClient"),
             address: None,
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_pubkeys() -> Result<(), Box<dyn Error>> {
+    fn test_mentioned_pubkeys_lists_the_p_tags() -> Result<(), Box<dyn Error>> {
         let mentioned_keys = Keys::generate();
         let p_tag = Tag::public_key(mentioned_keys.public_key());
 
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_as_event() -> Result<(), Box<dyn Error>> {
+    fn test_as_event_returns_the_event_it_wraps() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event.clone());
 

--- a/src/model/timeline/text_note.rs
+++ b/src/model/timeline/text_note.rs
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_text_note() -> Result<(), Box<dyn Error>> {
+    fn new_text_note() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Hello, Nostr!")?;
         let text_note = TextNote::new(event.clone());
 
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bech32_id_is_a_note1_identifier() -> Result<(), Box<dyn Error>> {
+    fn bech32_id_is_a_note1_identifier() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event);
 
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_with_reaction() -> Result<(), Box<dyn Error>> {
+    fn update_with_reaction() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_with_multiple_reactions() -> Result<(), Box<dyn Error>> {
+    fn update_with_multiple_reactions() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_with_repost() -> Result<(), Box<dyn Error>> {
+    fn update_with_repost() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_with_zap_receipt() -> Result<(), Box<dyn Error>> {
+    fn update_with_zap_receipt() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_builder_builds_a_plus_reaction() -> Result<(), Box<dyn Error>> {
+    fn reaction_builder_builds_a_plus_reaction() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let text_note = TextNote::new(event.clone());
 
@@ -269,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_repost_builder_tags_the_reposted_event() -> Result<(), Box<dyn Error>> {
+    fn repost_builder_tags_the_reposted_event() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let text_note = TextNote::new(event.clone());
 
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn test_zap_amount_with_multiple_receipts() -> Result<(), Box<dyn Error>> {
+    fn zap_amount_with_multiple_receipts() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Original post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_reply_event_id_finds_the_answered_event() -> Result<(), Box<dyn Error>> {
+    fn find_reply_event_id_finds_the_answered_event() -> Result<(), Box<dyn Error>> {
         let original_event = create_test_event("Original")?;
         let reply_event = create_test_event_with_tags(
             "Reply",
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_reply_event_id_none() -> Result<(), Box<dyn Error>> {
+    fn find_reply_event_id_none() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Not a reply")?;
         let text_note = TextNote::new(event);
 
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_client_name_reads_the_client_tag() -> Result<(), Box<dyn Error>> {
+    fn find_client_name_reads_the_client_tag() -> Result<(), Box<dyn Error>> {
         let client_tag = Tag::from(Nip89Tag::Client {
             name: String::from("TestClient"),
             address: None,
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_pubkeys_lists_the_p_tags() -> Result<(), Box<dyn Error>> {
+    fn mentioned_pubkeys_lists_the_p_tags() -> Result<(), Box<dyn Error>> {
         let mentioned_keys = Keys::generate();
         let p_tag = Tag::public_key(mentioned_keys.public_key());
 
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn test_combined_updates() -> Result<(), Box<dyn Error>> {
+    fn combined_updates() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Popular post")?;
         let mut text_note = TextNote::new(event.clone());
 
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_as_event_returns_the_event_it_wraps() -> Result<(), Box<dyn Error>> {
+    fn as_event_returns_the_event_it_wraps() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event.clone());
 

--- a/src/presentation/components.rs
+++ b/src/presentation/components.rs
@@ -81,7 +81,7 @@ mod tests {
     /// bar as well, so a test that only looked at the top would not notice the
     /// bottom pane moving.
     #[test]
-    fn test_home_component_starts_at_the_top_row() {
+    fn home_component_starts_at_the_top_row() {
         let mut terminal = Terminal::new(TestBackend::new(40, 8)).expect("test terminal");
         let mut components = Components::new();
         let mut state = AppState::default();

--- a/src/presentation/components/home/list.rs
+++ b/src/presentation/components/home/list.rs
@@ -93,7 +93,7 @@ mod tests {
     use nostr_sdk::prelude::*;
 
     #[test]
-    fn test_multibyte_character_rendering() -> Result<()> {
+    fn multibyte_character_rendering() -> Result<()> {
         use ratatui::backend::TestBackend;
         use ratatui::Terminal;
 

--- a/src/presentation/widgets/name_with_handle.rs
+++ b/src/presentation/widgets/name_with_handle.rs
@@ -81,7 +81,7 @@ mod tests {
     use ratatui::prelude::{Color, Modifier, Rect};
 
     #[test]
-    fn test_from_no_profile() {
+    fn from_no_profile() {
         // Test From trait with no profile
         let keys = Keys::generate();
         let widget = NameWithHandle::new(keys.public_key(), None, false);
@@ -95,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_display_name_only() {
+    fn from_display_name_only() {
         // Test From trait with display_name only
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice");
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_display_name_and_handle() {
+    fn from_display_name_and_handle() {
         // Test From trait with both display_name and handle
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice Smith").name("alice");
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_preserves_styles() {
+    fn from_preserves_styles() {
         // Test that From preserves style information
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice");
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_profile_shows_hex() {
+    fn no_profile_shows_hex() {
         // No profile - should show shortened hex public key
         let keys = Keys::generate();
         let widget = NameWithHandle::new(keys.public_key(), None, false);
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn test_display_name_only() {
+    fn display_name_only() {
         // Profile with display_name but no name (no handle)
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice");
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_only() {
+    fn handle_only() {
         // Profile with name (handle) but no display_name
         let keys = Keys::generate();
         let metadata = Metadata::new().name("alice");
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_display_name_and_handle_different() {
+    fn display_name_and_handle_different() {
         // Profile with both display_name and handle, and they're different
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice Smith").name("alice");
@@ -263,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_display_name_and_handle_same() {
+    fn display_name_and_handle_same() {
         // Profile where display_name equals handle (without @)
         // Should only show display_name
         let keys = Keys::generate();
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_highlighted_with_profile() {
+    fn highlighted_with_profile() {
         // Test highlighting when profile exists
         let keys = Keys::generate();
         let metadata = Metadata::new().display_name("Alice");
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn test_highlighted_without_profile() {
+    fn highlighted_without_profile() {
         // Test highlighting when no profile (hex display)
         let keys = Keys::generate();
         let widget = NameWithHandle::new(keys.public_key(), None, true);
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_highlighted_handle_only() {
+    fn highlighted_handle_only() {
         // Test highlighting when only handle exists (no display_name)
         let keys = Keys::generate();
         let metadata = Metadata::new().name("alice");

--- a/src/presentation/widgets/public_key.rs
+++ b/src/presentation/widgets/public_key.rs
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    fn shortened_keeps_the_first_and_last_characters() -> Result<()> {
+    fn shortened_renders_the_npub_head_and_tail() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;

--- a/src/presentation/widgets/public_key.rs
+++ b/src/presentation/widgets/public_key.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new() -> Result<()> {
+    fn test_new_keeps_the_key() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shortened() -> Result<()> {
+    fn test_shortened_keeps_the_first_and_last_characters() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;

--- a/src/presentation/widgets/public_key.rs
+++ b/src/presentation/widgets/public_key.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new_keeps_the_key() -> Result<()> {
+    fn new_keeps_the_key() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shortened_keeps_the_first_and_last_characters() -> Result<()> {
+    fn shortened_keeps_the_first_and_last_characters() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;
@@ -59,7 +59,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_public_key_to_text() -> Result<()> {
+    fn from_public_key_to_text() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;
@@ -73,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_public_key_widget() -> Result<()> {
+    fn render_public_key_widget() -> Result<()> {
         let key = NostrPublicKey::from_str(
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",
         )?;
@@ -102,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shortened_format_consistency() -> Result<()> {
+    fn shortened_format_consistency() -> Result<()> {
         // Test multiple keys to ensure consistent formatting
         let keys = vec![
             "4d39c23b3b03bf99494df5f3a149c7908ae1bc7416807fdd6b34a31886eaae25",

--- a/src/presentation/widgets/status_bar.rs
+++ b/src/presentation/widgets/status_bar.rs
@@ -86,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn test_status_bar_widget_new() {
+    fn status_bar_widget_new() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_with_display_name() {
+    fn user_name_with_display_name() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, Some("Alice"), Some("alice"));
         let status_bar = StatusBar::default();
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_with_handle_only() {
+    fn user_name_with_handle_only() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, None, Some("alice"));
         let status_bar = StatusBar::default();
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_without_profile() {
+    fn user_name_without_profile() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {
@@ -140,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_with_empty_profile_metadata() {
+    fn user_name_with_empty_profile_metadata() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, None, None);
         let status_bar = StatusBar::default();
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_with_empty_string_display_name() {
+    fn user_name_with_empty_string_display_name() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, Some(""), Some("alice"));
         let status_bar = StatusBar::default();
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_with_empty_string_name() {
+    fn user_name_with_empty_string_name() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, Some("Alice"), Some(""));
         let status_bar = StatusBar::default();
@@ -183,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_name_priority() {
+    fn user_name_priority() {
         let pubkey = create_test_pubkey();
         // Test priority: display_name > handle > npub
         let profile = create_test_profile(pubkey, Some("Display Name"), Some("handle"));
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_does_not_panic() {
+    fn render_does_not_panic() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {
@@ -213,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_message() {
+    fn render_with_message() {
         let pubkey = create_test_pubkey();
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_error_message() {
+    fn render_with_error_message() {
         let pubkey = create_test_pubkey();
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::ErrorMessageChanged {
@@ -267,7 +267,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_profile() {
+    fn render_with_profile() {
         let pubkey = create_test_pubkey();
         let profile = create_test_profile(pubkey, Some("Alice"), Some("alice"));
         let status_bar = StatusBar::default();
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_empty_message() {
+    fn render_empty_message() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_small_area() {
+    fn render_small_area() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_large_area() {
+    fn render_large_area() {
         let pubkey = create_test_pubkey();
         let mut status_bar = StatusBar::default();
         status_bar.update(Message::MessageChanged {

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -74,7 +74,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_context_clone() {
+    fn view_context_clone() {
         let profiles = HashMap::new();
         let ctx = ViewContext {
             profiles: &profiles,
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_bar_widget_new() {
+    fn tab_bar_widget_new() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -95,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_single_home_tab() {
+    fn titles_single_home_tab() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_multiple_tabs() {
+    fn titles_multiple_tabs() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_with_profile_display_name() {
+    fn titles_with_profile_display_name() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_with_profile_handle_only() {
+    fn titles_with_profile_handle_only() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -181,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_with_empty_profile_metadata() {
+    fn titles_with_empty_profile_metadata() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn test_titles_multiple_user_tabs() {
+    fn titles_multiple_user_tabs() {
         let mut timeline = Timeline::default();
         let pubkey1 = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let pubkey2 = PublicKey::from_slice(&[2u8; 32]).expect("Valid pubkey");
@@ -242,7 +242,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_does_not_panic() {
+    fn render_does_not_panic() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_multiple_tabs() {
+    fn render_with_multiple_tabs() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -290,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_active_tab() {
+    fn render_with_active_tab() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 
@@ -315,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_small_area() {
+    fn render_small_area() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_large_area() {
+    fn render_large_area() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -345,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_zero_height() {
+    fn render_zero_height() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {
@@ -360,7 +360,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_switching_tabs() {
+    fn render_switching_tabs() {
         let mut timeline = Timeline::default();
         let pubkey = create_test_pubkey();
 

--- a/src/presentation/widgets/text_note.rs
+++ b/src/presentation/widgets/text_note.rs
@@ -513,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn widget_new() -> Result<(), Box<dyn Error>> {
+    fn widget_new_keeps_the_note_it_renders() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test content")?;
         let text_note = TextNote::new(event);
 

--- a/src/presentation/widgets/text_note.rs
+++ b/src/presentation/widgets/text_note.rs
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_formatted_created_at_produces_wall_clock() -> Result<(), Box<dyn Error>> {
+    fn formatted_created_at_produces_wall_clock() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event);
 
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_names_with_profiles() -> Result<(), Box<dyn Error>> {
+    fn mentioned_names_with_profiles() -> Result<(), Box<dyn Error>> {
         let mentioned_keys = Keys::generate();
         let p_tag = Tag::public_key(mentioned_keys.public_key());
         let event = create_test_event_with_tags("Mentioning someone", vec![p_tag])?;
@@ -255,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_names_without_profiles() -> Result<(), Box<dyn Error>> {
+    fn mentioned_names_without_profiles() -> Result<(), Box<dyn Error>> {
         let mentioned_keys = Keys::generate();
         let p_tag = Tag::public_key(mentioned_keys.public_key());
         let event = create_test_event_with_tags("Mentioning someone", vec![p_tag])?;
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_names_multiple_mentions() -> Result<(), Box<dyn Error>> {
+    fn mentioned_names_multiple_mentions() -> Result<(), Box<dyn Error>> {
         let keys1 = Keys::generate();
         let keys2 = Keys::generate();
         let keys3 = Keys::generate();
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mentioned_names_empty() -> Result<(), Box<dyn Error>> {
+    fn mentioned_names_empty() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("No mentions")?;
         let text_note = TextNote::new(event);
 
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_lines_without_reply() -> Result<(), Box<dyn Error>> {
+    fn fixed_lines_without_reply() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Not a reply")?;
         let text_note = TextNote::new(event);
 
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_lines_with_reply() -> Result<(), Box<dyn Error>> {
+    fn fixed_lines_with_reply() -> Result<(), Box<dyn Error>> {
         let original_event = create_test_event("Original")?;
         let reply_event =
             create_test_event_with_tags("Reply", vec![Tag::event(original_event.id)])?;
@@ -380,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_height_without_reply() -> Result<(), Box<dyn Error>> {
+    fn calculate_height_without_reply() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Short content")?;
         let text_note = TextNote::new(event);
 
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_height_with_reply() -> Result<(), Box<dyn Error>> {
+    fn calculate_height_with_reply() -> Result<(), Box<dyn Error>> {
         let original_event = create_test_event("Original")?;
         let reply_event =
             create_test_event_with_tags("Reply", vec![Tag::event(original_event.id)])?;
@@ -432,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_height_with_padding() -> Result<(), Box<dyn Error>> {
+    fn calculate_height_with_padding() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test")?;
         let text_note = TextNote::new(event);
 
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_height_long_content() -> Result<(), Box<dyn Error>> {
+    fn calculate_height_long_content() -> Result<(), Box<dyn Error>> {
         let long_content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(10);
         let event = create_test_event(&long_content)?;
         let text_note = TextNote::new(event);
@@ -486,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_truncates_content_taller_than_area() -> Result<(), Box<dyn Error>> {
+    fn render_truncates_content_taller_than_area() -> Result<(), Box<dyn Error>> {
         // Content that wraps to more lines than (area.height - fixed_lines)
         // should be truncated with "..." in the rendered output.
         let long_content = "x ".repeat(400); // many words that wrap to many lines
@@ -513,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn test_widget_new() -> Result<(), Box<dyn Error>> {
+    fn widget_new() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test content")?;
         let text_note = TextNote::new(event);
 
@@ -534,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_does_not_panic() -> Result<(), Box<dyn Error>> {
+    fn render_does_not_panic() -> Result<(), Box<dyn Error>> {
         let event = create_test_event("Test render")?;
         let text_note = TextNote::new(event);
 
@@ -556,7 +556,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_reply_tag() -> Result<(), Box<dyn Error>> {
+    fn render_with_reply_tag() -> Result<(), Box<dyn Error>> {
         let original_event = create_test_event("Original")?;
         let reply_event =
             create_test_event_with_tags("Reply content", vec![Tag::event(original_event.id)])?;
@@ -580,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_with_client_tag() -> Result<(), Box<dyn Error>> {
+    fn render_with_client_tag() -> Result<(), Box<dyn Error>> {
         let client_tag = Tag::from(Nip89Tag::Client {
             name: String::from("TestClient"),
             address: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -576,7 +576,7 @@ mod tests {
     use crate::model::timeline::Message as TimelineMessage;
 
     /// Create flags for a test app instance
-    fn test_flags() -> InitFlags {
+    fn create_test_flags() -> InitFlags {
         let keys = Keys::generate();
 
         InitFlags {
@@ -589,7 +589,7 @@ mod tests {
 
     /// Create a test app instance
     fn create_test_app() -> TearsApp<'static> {
-        let (app, _) = TearsApp::new(test_flags());
+        let (app, _) = TearsApp::new(create_test_flags());
         app
     }
 
@@ -598,7 +598,7 @@ mod tests {
     /// Put there rather than taken from `.config/config.json5`, so a test pins the
     /// lookup and not what the shipped defaults happen to say.
     fn store_with_binding(key: KeyEvent, action: KeyAction) -> TestStore<TearsApp<'static>> {
-        let mut flags = test_flags();
+        let mut flags = create_test_flags();
         flags.config.keybindings.home.insert(vec![key], action);
         TestStore::new(flags)
     }
@@ -610,11 +610,11 @@ mod tests {
         ))
     }
 
-    fn test_relay_url() -> RelayUrl {
+    fn create_test_relay_url() -> RelayUrl {
         RelayUrl::parse("wss://relay.example.com").expect("valid relay url")
     }
 
-    fn test_note() -> NostrEvent {
+    fn create_test_note() -> NostrEvent {
         EventBuilder::new(Kind::TextNote, "test note")
             .finalize(&Keys::generate())
             .expect("Failed to sign test event")
@@ -906,12 +906,12 @@ mod tests {
     /// ignores would spend a full render on nothing, so that arm declines it (#510).
     #[test]
     fn ignored_event_notification_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(notification(ClientNotification::Event {
-            relay_url: test_relay_url(),
+            relay_url: create_test_relay_url(),
             subscription_id: SubscriptionId::new("unknown"),
-            event: Box::new(test_note()),
+            event: Box::new(create_test_note()),
         }));
 
         assert!(!store.redraw_requested());
@@ -922,10 +922,10 @@ mod tests {
     /// so it changes nothing the view shows and declines the redraw too (#510).
     #[test]
     fn non_event_relay_message_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(notification(ClientNotification::Message {
-            relay_url: test_relay_url(),
+            relay_url: create_test_relay_url(),
             message: Box::new(RelayMessage::EndOfStoredEvents(Cow::Owned(
                 SubscriptionId::new("home"),
             ))),
@@ -944,7 +944,7 @@ mod tests {
     /// anyway, so asserting the directive alone would hold either way.
     #[test]
     fn routed_event_message_still_redraws() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
         let subscription_id = SubscriptionId::new("home");
 
         store.send(AppMsg::Nostr(NostrMsg::SubscriptionMessage(
@@ -954,10 +954,10 @@ mod tests {
             },
         )));
         store.send(notification(ClientNotification::Message {
-            relay_url: test_relay_url(),
+            relay_url: create_test_relay_url(),
             message: Box::new(RelayMessage::Event {
                 subscription_id: Cow::Owned(subscription_id),
-                event: Cow::Owned(test_note()),
+                event: Cow::Owned(create_test_note()),
             }),
         }));
 
@@ -1084,7 +1084,7 @@ mod tests {
     /// now that a held key produces one of these per repeat rather than none (#536).
     #[test]
     fn a_key_bound_to_nothing_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::System(SystemMsg::KeyInput(KeyEvent::new(
             KeyCode::F(12),
@@ -1115,7 +1115,7 @@ mod tests {
     /// where the directive is observable.
     #[test]
     fn refusing_a_blank_draft_redraws() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::Editor(EditorMsg::StartComposing));
         store.send(AppMsg::Editor(EditorMsg::SubmitNote));
@@ -1133,7 +1133,7 @@ mod tests {
     /// as one and redrew for.
     #[test]
     fn ignored_terminal_event_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::System(SystemMsg::TerminalEventIgnored));
 
@@ -1147,7 +1147,7 @@ mod tests {
     /// and the now-playing line invisible on a client with nothing else going on.
     #[test]
     fn track_the_status_line_shows_redraws() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::TrackChanged {
             // Not "Music": that is `NOW_PLAYING_LABEL`, and the assertion below could
@@ -1177,7 +1177,7 @@ mod tests {
     /// without the user touching nostui at all.
     #[test]
     fn undisplayed_media_event_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::VolumeChanged {
             player_name: "Music".to_owned(),
@@ -1194,7 +1194,7 @@ mod tests {
     /// hide within a second, and #527 removed the tick.
     #[test]
     fn timeline_message_that_does_nothing_still_clears_the_status_bar_on_screen() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
         let subscription_id = SubscriptionId::new("home");
 
         // Complete startup: until an event arrives, timeline messages are ignored.
@@ -1205,10 +1205,10 @@ mod tests {
             },
         )));
         store.send(notification(ClientNotification::Message {
-            relay_url: test_relay_url(),
+            relay_url: create_test_relay_url(),
             message: Box::new(RelayMessage::Event {
                 subscription_id: Cow::Owned(subscription_id),
-                event: Cow::Owned(test_note()),
+                event: Cow::Owned(create_test_note()),
             }),
         }));
         store.send(AppMsg::System(SystemMsg::ShowError("boom".to_owned())));
@@ -1228,7 +1228,7 @@ mod tests {
     /// radio and live streams report routinely while their metadata keeps changing.
     #[test]
     fn track_the_status_line_rejects_does_not_redraw() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::TrackChanged {
             player_name: "Radio".to_owned(),
@@ -1254,7 +1254,7 @@ mod tests {
     /// that loop until #529 bounds it. Pinned so the brake is not removed by tidying.
     #[test]
     fn media_source_error_keeps_its_redraw_as_a_brake() {
-        let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
+        let mut store = TestStore::<TearsApp<'static>>::new(create_test_flags());
 
         store.send(AppMsg::Media(Err(MediaSourceError::UnsupportedPlatform)));
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unselect_action_delegates_to_deselect() {
+    fn unselect_action_delegates_to_deselect() {
         let mut app = create_test_app();
 
         // Add a test note to allow selection
@@ -655,7 +655,7 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_key_triggers_deselect() {
+    fn escape_key_triggers_deselect() {
         let mut app = create_test_app();
 
         // Add a test note to allow selection
@@ -688,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn test_timeline_ops_ignored_during_startup() {
+    fn timeline_ops_ignored_during_startup() {
         let mut app = create_test_app();
         assert!(app.state.startup.is_in_progress());
 
@@ -713,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_first_with_notes() {
+    fn select_first_with_notes() {
         let mut app = create_test_app();
 
         // Add test notes to timeline
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_last_with_notes() {
+    fn select_last_with_notes() {
         let mut app = create_test_app();
 
         // Add test notes to timeline
@@ -778,7 +778,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_to_top_delegates() {
+    fn scroll_to_top_delegates() {
         let mut app = create_test_app();
 
         // Add a test note
@@ -798,7 +798,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_to_bottom_delegates() {
+    fn scroll_to_bottom_delegates() {
         let mut app = create_test_app();
 
         // Add test notes
@@ -825,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn test_quit_key_works_in_normal_mode() {
+    fn quit_key_works_in_normal_mode() {
         let mut app = create_test_app();
 
         // In normal mode, 'q' key should trigger quit via keybinding
@@ -845,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_q_key_does_not_quit_in_composing_mode() {
+    fn q_key_does_not_quit_in_composing_mode() {
         let mut app = create_test_app();
 
         // Start composing mode
@@ -865,7 +865,7 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_cancels_composing_mode() {
+    fn escape_cancels_composing_mode() {
         let mut app = create_test_app();
 
         // Start composing mode with some content
@@ -886,7 +886,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_tab() {
+    fn select_tab() {
         let mut app = create_test_app();
 
         // Default tab should be 0
@@ -905,7 +905,7 @@ mod tests {
     /// `Message` — and nostui reads only the `Message`. Redrawing for the arm it
     /// ignores would spend a full render on nothing, so that arm declines it (#510).
     #[test]
-    fn test_ignored_event_notification_does_not_redraw() {
+    fn ignored_event_notification_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(notification(ClientNotification::Event {
@@ -921,7 +921,7 @@ mod tests {
     /// A relay message that is not an `EVENT` — an `EOSE`, here — is only logged,
     /// so it changes nothing the view shows and declines the redraw too (#510).
     #[test]
-    fn test_non_event_relay_message_does_not_redraw() {
+    fn non_event_relay_message_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(notification(ClientNotification::Message {
@@ -943,7 +943,7 @@ mod tests {
     /// subscription matches no tab is dropped by `route_relay_event` and today redraws
     /// anyway, so asserting the directive alone would hold either way.
     #[test]
-    fn test_routed_event_message_still_redraws() {
+    fn routed_event_message_still_redraws() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
         let subscription_id = SubscriptionId::new("home");
 
@@ -973,7 +973,7 @@ mod tests {
     /// and routing every key to `TerminalEventIgnored` would leave the suite green. The
     /// work this branch points at next edits exactly this match (#537, #543).
     #[test]
-    fn test_a_key_going_down_is_input() {
+    fn a_key_going_down_is_input() {
         for kind in [KeyEventKind::Press, KeyEventKind::Repeat] {
             let key = KeyEvent::new_with_kind(KeyCode::Char('j'), KeyModifiers::NONE, kind);
 
@@ -992,7 +992,7 @@ mod tests {
     /// into a press before the lookup — `f`'s release publishing a reaction, which is
     /// worse than what #531 fixed.
     #[test]
-    fn test_the_handler_refuses_a_release_of_its_own_accord() {
+    fn the_handler_refuses_a_release_of_its_own_accord() {
         let f = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE);
         let mut store = store_with_binding(f, KeyAction::React);
 
@@ -1014,7 +1014,7 @@ mod tests {
     /// a release of `Esc` reached normal mode's fallback and deselected the timeline
     /// behind a draft the press had just cancelled.
     #[test]
-    fn test_key_release_is_not_input() {
+    fn key_release_is_not_input() {
         let release = KeyEvent::new_with_kind(
             KeyCode::Char('j'),
             KeyModifiers::NONE,
@@ -1035,7 +1035,7 @@ mod tests {
     /// Sent as a `KeyInput` rather than through `terminal_event_to_msg`, because the
     /// guarantee is the handler's: it holds for whatever produces the message.
     #[test]
-    fn test_a_decorated_key_reaches_its_binding() {
+    fn a_decorated_key_reaches_its_binding() {
         let mut store = store_with_binding(
             KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
             KeyAction::ScrollDown,
@@ -1065,7 +1065,7 @@ mod tests {
     /// this key resolves, the assertion would hold just as well if the lookup missed and
     /// the fallback answered — and would keep holding if resolution broke later.
     #[test]
-    fn test_a_bound_key_that_does_nothing_does_not_redraw() {
+    fn a_bound_key_that_does_nothing_does_not_redraw() {
         let ctrl_p = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
 
         let mut resolves = store_with_binding(ctrl_p, KeyAction::ScrollDown);
@@ -1083,7 +1083,7 @@ mod tests {
     /// A key bound to nothing changes nothing, so it must not repaint — which matters
     /// now that a held key produces one of these per repeat rather than none (#536).
     #[test]
-    fn test_a_key_bound_to_nothing_does_not_redraw() {
+    fn a_key_bound_to_nothing_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::System(SystemMsg::KeyInput(KeyEvent::new(
@@ -1098,7 +1098,7 @@ mod tests {
     /// Resizes still route to their own message, and everything else nostui does not
     /// act on to the one that does nothing.
     #[test]
-    fn test_other_terminal_events_keep_their_routing() {
+    fn other_terminal_events_keep_their_routing() {
         assert!(matches!(
             terminal_event_to_msg(Event::Resize(80, 24)),
             AppMsg::System(SystemMsg::Resize(80, 24))
@@ -1114,7 +1114,7 @@ mod tests {
     /// which is the whole of what the refusal is for. Asserted here because this is
     /// where the directive is observable.
     #[test]
-    fn test_refusing_a_blank_draft_redraws() {
+    fn refusing_a_blank_draft_redraws() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::Editor(EditorMsg::StartComposing));
@@ -1132,7 +1132,7 @@ mod tests {
     /// render. Before #527 this arm produced a tick, which the FPS display counted
     /// as one and redrew for.
     #[test]
-    fn test_ignored_terminal_event_does_not_redraw() {
+    fn ignored_terminal_event_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::System(SystemMsg::TerminalEventIgnored));
@@ -1146,7 +1146,7 @@ mod tests {
     /// swapping the arms in `publish_music_status` would leave both of them passing
     /// and the now-playing line invisible on a client with nothing else going on.
     #[test]
-    fn test_track_the_status_line_shows_redraws() {
+    fn track_the_status_line_shows_redraws() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::TrackChanged {
@@ -1176,7 +1176,7 @@ mod tests {
     /// repaint either. With the tick gone these are the remaining messages that arrive
     /// without the user touching nostui at all.
     #[test]
-    fn test_undisplayed_media_event_does_not_redraw() {
+    fn undisplayed_media_event_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::VolumeChanged {
@@ -1193,7 +1193,7 @@ mod tests {
     /// redraw. Declining it leaves the cleared line standing — which the tick used to
     /// hide within a second, and #527 removed the tick.
     #[test]
-    fn test_timeline_message_that_does_nothing_still_clears_the_status_bar_on_screen() {
+    fn timeline_message_that_does_nothing_still_clears_the_status_bar_on_screen() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
         let subscription_id = SubscriptionId::new("home");
 
@@ -1227,7 +1227,7 @@ mod tests {
     /// not repaint either. `MusicStatus::new` rejects a track with no duration, which
     /// radio and live streams report routinely while their metadata keeps changing.
     #[test]
-    fn test_track_the_status_line_rejects_does_not_redraw() {
+    fn track_the_status_line_rejects_does_not_redraw() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::Media(Ok(MediaEvent::TrackChanged {
@@ -1253,7 +1253,7 @@ mod tests {
     /// source that produced it, and the repaint is the only per-iteration cost left in
     /// that loop until #529 bounds it. Pinned so the brake is not removed by tidying.
     #[test]
-    fn test_media_source_error_keeps_its_redraw_as_a_brake() {
+    fn media_source_error_keeps_its_redraw_as_a_brake() {
         let mut store = TestStore::<TearsApp<'static>>::new(test_flags());
 
         store.send(AppMsg::Media(Err(MediaSourceError::UnsupportedPlatform)));


### PR DESCRIPTION
Closes #541. Two commits, and the order matters — read them separately.

## Why the prefix goes

`#[test]` already says it is a test. 361 of 382 tests carried the prefix and 21 did not, so neither was the rule: every new test was decided by whichever neighbour the author happened to read, which is how the split widened in the first place. `cargo test test_` also looked like "run everything" while silently skipping the 21.

## `f062c0c` — name the tests that were named after what they call

Thirty-eight tests took the name of the function they exercise — `test_new`, `test_clear`, `test_get_profile` — which says what is under test and nothing about what is asserted. They now say the claim, written from the assertions in the body rather than from the old name:

```
test_new                → new_holds_no_profiles
test_clear              → clear_empties_the_collection
test_get_profile        → get_profile_returns_none_until_one_is_inserted
test_is_at_bottom       → is_at_bottom_only_on_the_last_note
test_shorten_npub       → shorten_npub_shortens_an_npub_and_leaves_a_hex_key
```

This is worth doing on its own merits. It is also what makes the second commit possible: `mod tests` pulls the outer module in with `use super::*`, so a test left as bare `new` or `clear` **shadows the very function it calls**. Twenty stop compiling; the other eighteen shadow in silence, which is worse. I ran the strip first and the compiler said so — the "mechanical rename" this looked like from the issue is not one.

## `a6f9655` — the strip

361 renames, one line each. Before running it I checked that no stripped name shadows an outer item or a test helper, collapses onto a name already taken, or becomes a keyword; all three came back empty.

## `73bf264` — the ones the pattern could not see

The strip matched a literal `#[test]` on the line above the `fn`. Several tests are not written that way, and it stepped over all of them: every `#[rstest]` (`parse`, `display_name`, `name`), the one `#[tokio::test]`, and a `#[test]` separated from its signature by an `#[allow]`. Nine functions, twenty-seven cases — in files whose other tests were renamed around them, so the split survived exactly where nobody would look, and the next rstest would have been copied from a prefixed neighbour.

I had counted with the same pattern I edited with, which is why an earlier version of this description claimed none remained. `cargo test -- --list` is the authority: **411 test cases, 0 prefixed** — re-run after the last commit, which removes a duplicate test and so drops the total by one.

Some needed names rather than a strip. `test_name` asserts `profile.handle()`, so it was misnaming its subject before it ever lost the prefix. Six more that the first pass missed — `config`, `profile_new`, `widget_new`, `timeline_default`, `message_getter`, `textarea_reference` — were subject names of the same kind as the thirty-eight. And one of my own new names spelled it `colour` where the function and its module say `color`, so `cargo test color` skipped the test named after it.

**The subject-name class is not swept.** That is a different axis from the prefix, and this PR only touched it where it had to: the 38 would not compile otherwise, and the rest came up one at a time in review. At least eighteen remain — `profile_clone`, `standard_traits`, `scroll_up`, `app_state_default` and so on — and a broader sweep needs judgement per test rather than a pattern. **#549** carries them, with the argument for why an empty name is worse than uninformative: twice in this PR's review a name of that shape turned out to be describing the wrong function.

No documentation, CI job, or `justfile` recipe filters on test names, so nothing outside the source refers to them.

## What #541 also asked

**Whether to enforce it.** Nothing in `just lint` reads test names, so this convention has no check and can drift again — the same way it drifted into two. Mechanising it is not worth what it costs for a naming rule, so the answer is that the convention gets written down where someone would look before adding a test, which is **#548**. That it was never written down is what let the split happen at all.

`just fmt`, `just lint`, `just test` (410 + 1 doc) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi


