### PR TITLE
docs: write down the conventions that only exist in the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,11 +116,15 @@ $ RUSTDOCFLAGS='-D warnings' just doc
 ```
 
 `Code Coverage` is the other, and it is not a required check. When Codecov goes
-red, read the uncovered lines rather than the percentage:
+red, read the uncovered lines rather than the percentage — `just test-cov` gives
+the summary, and the lines take a flag it does not pass:
 
 ```console
 $ cargo llvm-cov --all-features --workspace --show-missing-lines
 ```
+
+Both need [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), which CI
+installs for itself and a checkout does not have.
 
 Testable logic left uncovered is worth covering; the entry-point glue that takes
 the terminal over or connects to relays has no unit test today, and a red mark

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ has the layers, the direction dependencies may point, and the contracts that
 connect them — what `domain` may not know, why `model` reports outcomes instead
 of issuing effects, why `model::editor` is a deliberate exception.
 
-What follows is the rest: the conventions nothing in `just lint` or CI checks.
+What follows is the rest: the conventions that hold by agreement rather than by
+a check, and the checks `just fmt`, `just lint` and `just test` leave out.
 
 ## Language
 
@@ -18,8 +19,9 @@ something will be read decides it, not what kind of thing it is.
 ## Commit messages and pull request titles
 
 [Conventional Commits][cc]: `type: summary`, with `feat`, `fix`, `docs`,
-`refactor`, `perf`, `test`, `build`, `chore` and `revert` as the types. Scopes
-are not used here; the only scoped commits are Dependabot's `build(deps)`.
+`refactor`, `perf`, `test`, `build`, `chore` and `revert` as the types. A scope
+is allowed and rarely taken — two commits in the history carry one, beside
+Dependabot's `build(deps)`.
 
 The summary states what the change claims, not which file it touched:
 
@@ -34,18 +36,23 @@ is no commit linter here, and no CI job reads a commit message.
 
 ## Tests
 
-Every test lives in a `mod tests` at the end of the file it exercises. There is
-no `tests/` directory today.
+Tests live in a `mod tests` at the end of the file they exercise — all of them
+but the doctest on `NostrEvents::new`. There is no `tests/` directory today.
 
 ### A name says what is asserted
 
 The name states the claim rather than the function under test —
 `new_holds_no_profiles`, not `new` — and carries no `test_` prefix, since
 `#[test]` already says that ([#541](https://github.com/akiomik/nostui/issues/541),
-[#547](https://github.com/akiomik/nostui/pull/547)). Dropping the prefix is what
-makes the first half load-bearing: `mod tests` pulls the outer module in with
-`use super::*`, so a test left named after the function it calls shadows that
-function.
+[#547](https://github.com/akiomik/nostui/pull/547)).
+
+Dropping the prefix is what makes the first half more than taste where the
+subject is a free function: `mod tests` pulls the outer module in with
+`use super::*`, so a test named `shorten_npub` shadows the function it means to
+call, and the call in its own body resolves to the test. An inherent method is
+not exposed to that — `use super::*` does not put `UserState::new` in scope as a
+bare `new` — so there the reason to name the assertion is just that the
+assertion is what a reader needs.
 
 A name that quantifies has to earn it. `every`, `only`, `in order` and `never`
 each need enough cases that a wrong implementation fails: one profile does not
@@ -74,8 +81,12 @@ uncommitted work with it.
   `assert_eq!(xs.len(), 0)`. Use plain `assert!` for a genuine `bool`.
 - Do not test what a `derive` provides (`Debug`, `Default`, `Clone`,
   `PartialEq`).
-- Return `Result` from the test instead of calling `unwrap`; use `expect` on an
-  `Option`.
+- Return `Result` and use `?` rather than calling `unwrap`; use `expect` on an
+  `Option`. This one is checked — `Cargo.toml` sets `unwrap_used = "warn"` and
+  `just lint` denies warnings — so an `unwrap` fails the lint rather than
+  review. Where `?` cannot reach, inside an `rstest` `#[case(...)]` argument for
+  instance, the tree opens the module with `#![allow(clippy::unwrap_used)]`
+  instead of contorting the case.
 
 ### Where the redraw directive is observable
 
@@ -83,13 +94,16 @@ Whether a `Command` was built `without_redraw` can only be read through
 `tears::testing::TestStore::redraw_requested`, `Command::requests_redraw` being
 crate-private to `tears`. So those tests live in `src/runtime.rs` even when the
 decision they pin is made in `application::state`: construct a
-`TestStore::<TearsApp<'static>>::new(flags)`, `send` the message, and read
-`redraw_requested()`. `TestStore::new` asserts that no Tokio runtime is entered,
-so the test must be a plain `#[test]` — `#[tokio::test]` panics.
+`TestStore::<TearsApp<'static>>::new(flags)`, `send` the message, read
+`redraw_requested()`, and end with `store.finish()`. `finish` is not bookkeeping:
+the store checks that every message it produced was received, on drop if the test
+did not ask, so skipping it fails the test somewhere other than its assertion.
+`TestStore::new` also asserts that no Tokio runtime is entered, so the test must
+be a plain `#[test]` — `#[tokio::test]` panics.
 
 ## Before you push
 
-[just](https://github.com/casey/just) runs what CI runs:
+[just](https://github.com/casey/just) runs most of what CI runs:
 
 ```console
 $ just fmt
@@ -99,28 +113,32 @@ $ just test
 
 CI runs these as separate jobs, so a formatting slip fails a run that clippy and
 the tests passed locally — hand-edited grouped `use` imports are the usual
-cause. `just lint` also needs [typos](https://github.com/crate-ci/typos) on
-PATH.
+cause. `just lint` also needs [typos](https://github.com/crate-ci/typos) on PATH,
+which is what covers the `Spelling` job. Both jobs that run tests set
+`TZ=Asia/Tokyo` and the justfile does not, so an assertion that reads local time
+can pass here and fail there — `TextNoteWidget::formatted_created_at` renders in
+the local zone, and its test pins the shape rather than a wall-clock value for
+that reason.
 
-One CI job is outside all three: `Docs` builds the documentation with warnings
-denied. Run it by hand when the change touched a doc comment, since `just doc`
+Two CI jobs are outside all three. `Docs` builds the documentation with warnings
+denied; run it by hand when the change touched a doc comment, since `just doc`
 alone does not deny them:
 
 ```console
 $ RUSTDOCFLAGS='-D warnings' just doc
 ```
 
-Codecov comments on the pull request and is not a required check. The repository
-has no `codecov.yml`, so the default `threshold: 0%` fails on any decrease at
-all. When it goes red, read the uncovered lines rather than the percentage:
+`Code Coverage` is the other, and it is not a required check. The repository has
+no `codecov.yml`, so the default `threshold: 0%` fails on any decrease at all.
+When Codecov goes red, read the uncovered lines rather than the percentage:
 
 ```console
 $ cargo llvm-cov --all-features --workspace --show-missing-lines
 ```
 
 Testable logic left uncovered is worth covering; the entry-point glue that takes
-the terminal over or connects to relays cannot be unit-tested, and a red mark is
-better than a contrivance that buys the percentage back. Say in the pull request
-which of the two it was.
+the terminal over or connects to relays has no unit test today, and a red mark
+there is better than a contrivance that buys the percentage back. Say in the
+pull request which of the two it was.
 
 [cc]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@ Issues and pull requests are welcome.
 
 Where code goes is written down already: [docs/architecture.md](docs/architecture.md)
 has the layers, the direction dependencies may point, and the contracts that
-connect them — what `domain` may not know, why `model` reports outcomes instead
-of issuing effects, why `model::editor` is a deliberate exception.
+connect them.
 
 What follows is the rest: the conventions that hold by agreement rather than by
 a check, and the checks `just fmt`, `just lint` and `just test` leave out.
@@ -16,18 +15,15 @@ Everything published is written in English — code, comments, documentation,
 commit messages, and the titles and bodies of pull requests and issues. Where
 something will be read decides it, not what kind of thing it is.
 
-That is about prose a contributor writes, not about text a test operates on.
-The CJK literals in `wrap_text`'s tests are the double-width columns those tests
-are for, and an ASCII replacement would keep passing while checking nothing;
-`domain::nostr::nip10`'s note fixtures are content in the same way.
+That is about prose somebody wrote to be read. Text a test operates on is data:
+`wrap_text`'s CJK literals are the double-width columns its tests are about, and
+replacing them with ASCII would leave the tests passing and checking nothing.
 
 ## Commit messages and pull request titles
 
 [Conventional Commits][cc]: `type: summary`, with `feat`, `fix`, `docs`,
-`refactor`, `perf`, `test`, `build`, `ci`, `chore` and `revert` as the types, and
-`!` before the `:` for a breaking change (`feat!`, `refactor!`). A scope is
-allowed and rarely taken — two commits in the history carry one, beside
-Dependabot's `build(deps)`.
+`refactor`, `perf`, `test`, `build`, `ci`, `chore` and `revert` as the types, an
+optional scope, and `!` before the `:` for a breaking change.
 
 The summary states what the change claims, not which file it touched:
 
@@ -37,33 +33,26 @@ test: "every profile" needs more than one profile
 docs: a stopped media source is restarted by the next message, not never
 ```
 
-Pull request titles take the same shape. Nothing verifies any of this — there
-is no commit linter here, and no CI job reads a commit message.
+Pull request titles take the same shape. Nothing verifies any of this.
 
 ## Tests
 
-Tests live in a `mod tests` at the end of the file they exercise — all of them
-but the doctest on `NostrEvents::new`. There is no `tests/` directory today.
+Tests live in a `mod tests` at the end of the file they exercise, the one
+doctest aside. There is no `tests/` directory.
 
 ### A name says what is asserted
 
 The name states the claim rather than the function under test —
 `new_holds_no_profiles`, not `new` — and carries no `test_` prefix, since
-`#[test]` already says that ([#541](https://github.com/akiomik/nostui/issues/541),
-[#547](https://github.com/akiomik/nostui/pull/547)).
-
-Dropping the prefix is what makes the first half more than taste where the
-subject is a free function: `mod tests` pulls the outer module in with
-`use super::*`, so a test named `shorten_npub` shadows the function it means to
-call, and the call in its own body resolves to the test. An inherent method is
-not exposed to that — `use super::*` does not put `UserState::new` in scope as a
-bare `new` — so there the reason to name the assertion is just that the
-assertion is what a reader needs.
+`#[test]` already says that
+([#541](https://github.com/akiomik/nostui/issues/541),
+[#547](https://github.com/akiomik/nostui/pull/547)). Where the subject is a free
+function the prefix was load-bearing as well: `mod tests` pulls the outer module
+in with `use super::*`, so a test named `shorten_npub` shadows the function it
+means to call.
 
 A name that quantifies has to earn it. `every`, `only`, `in order` and `never`
-each need enough cases that a wrong implementation fails: one profile does not
-establish `clear_profiles_drops_every_profile`, and three sampled indices do not
-establish `is_at_bottom_only_on_the_last_note`.
+each need enough cases in the body that a wrong implementation fails.
 
 ### A test nobody watched fail is not a test
 
@@ -78,38 +67,30 @@ uncommitted work with it.
 
 ### Assertions
 
-- Assert the whole value rather than a field at a time:
-  `assert_eq!(foo, Foo { field: "bar" })` over a run of
-  `assert_eq!(foo.field, "bar")`. A field-at-a-time test only fails on the
-  fields it happened to name.
+- Assert the whole value rather than a field at a time. A field-at-a-time test
+  only fails on the fields it happened to name.
 - Prefer the form that prints the value on failure: `assert_eq!(maybe, None)`
-  over `assert!(maybe.is_none())`, `assert_eq!(xs, Vec::<T>::new())` over
-  `assert_eq!(xs.len(), 0)`. Use plain `assert!` for a genuine `bool`.
-- Do not test what a `derive` provides (`Debug`, `Default`, `Clone`,
-  `PartialEq`).
-- Return `Result` and use `?` rather than calling `unwrap`; use `expect` on an
-  `Option`. This one is checked — `Cargo.toml` sets `unwrap_used = "warn"` and
-  `just lint` denies warnings — so an `unwrap` fails the lint rather than
-  review. Where `?` cannot reach, inside an `rstest` `#[case(...)]` argument for
-  instance, put `#[allow(clippy::unwrap_used)]` on the one test that needs it
-  rather than contorting the case. The inner `#![allow(…)]` at the top of
-  `domain::nostr::nip27`'s `mod tests` covers a module of them and is the
-  exception — it belongs inside the test module, since at the top of the file it
-  would cover the production code too, and taken by default it silences every
-  test added to the module afterwards.
+  over `assert!(maybe.is_none())`. Use plain `assert!` for a genuine `bool`.
+- Do not test what a `derive` provides.
+- Return `Result` and use `?` rather than calling `unwrap`. This one is checked:
+  `Cargo.toml` warns on `unwrap_used` and `just lint` denies warnings. Where `?`
+  cannot reach, put `#[allow(clippy::unwrap_used)]` on the item that needs it
+  rather than on the module, which would cover every test added later too.
 
 ### Where the redraw directive is observable
 
 Whether a `Command` was built `without_redraw` can only be read through
-`tears::testing::TestStore::redraw_requested`, `Command::requests_redraw` being
-crate-private to `tears`. So those tests live in `src/runtime.rs` even when the
-decision they pin is made in `application::state`: construct a
-`TestStore::<TearsApp<'static>>::new(flags)`, `send` the message, read
-`redraw_requested()`, and end with `store.finish()`. `finish` is not bookkeeping:
-the store checks that every message it produced was received, on drop if the test
-did not ask, so skipping it fails the test somewhere other than its assertion.
-`TestStore::new` also asserts that no Tokio runtime is entered, so the test must
-be a plain `#[test]` — `#[tokio::test]` panics.
+`tears::testing::TestStore::redraw_requested`, so those tests live in
+`src/runtime.rs` even when the decision they pin is made in `application::state`.
+Three things about the store decide whether such a test works:
+
+- `new` asserts that no Tokio runtime is entered, so the test is a plain
+  `#[test]`; `#[tokio::test]` panics.
+- The flag carries the most recent command's directive, so read it immediately
+  after the `send` under test. Anything dispatched afterwards overwrites it.
+- `finish()` ends the test. It checks that every message the store produced was
+  received — on drop if the test never called it, which fails somewhere other
+  than the assertion.
 
 ## Before you push
 
@@ -121,26 +102,21 @@ $ just lint
 $ just test
 ```
 
-CI runs these as separate jobs, so a formatting slip fails a run that clippy and
-the tests passed locally — hand-edited grouped `use` imports are the usual
-cause. `just lint` also needs [typos](https://github.com/crate-ci/typos) on PATH,
-which is what covers the `Spelling` job. Both jobs that run tests set
-`TZ=Asia/Tokyo` and the justfile does not, so an assertion that reads local time
-can pass here and fail there — `TextNoteWidget::formatted_created_at` renders in
-the local zone, and its test pins the shape rather than a wall-clock value for
-that reason.
+`just fmt` rewrites rather than reports, so commit what it changed: CI runs
+`cargo fmt --all --check`, where a reformat left uncommitted fails. `just lint`
+needs [typos](https://github.com/crate-ci/typos) on PATH. Both CI jobs that run
+tests set `TZ=Asia/Tokyo` and the justfile does not, so an assertion that reads
+local time can pass here and fail there.
 
 Two CI jobs are outside all three. `Docs` builds the documentation with warnings
-denied; run it by hand when the change touched a doc comment, since `just doc`
-alone does not deny them:
+denied, which `just doc` alone does not:
 
 ```console
 $ RUSTDOCFLAGS='-D warnings' just doc
 ```
 
-`Code Coverage` is the other, and it is not a required check. The repository has
-no `codecov.yml`, so the default `threshold: 0%` fails on any decrease at all.
-When Codecov goes red, read the uncovered lines rather than the percentage:
+`Code Coverage` is the other, and it is not a required check. When Codecov goes
+red, read the uncovered lines rather than the percentage:
 
 ```console
 $ cargo llvm-cov --all-features --workspace --show-missing-lines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ Everything published is written in English — code, comments, documentation,
 commit messages, and the titles and bodies of pull requests and issues. Where
 something will be read decides it, not what kind of thing it is.
 
-That is about prose somebody wrote to be read. Text a test operates on is data:
-`wrap_text`'s CJK literals are the double-width columns its tests are about, and
-replacing them with ASCII would leave the tests passing and checking nothing.
+That is about prose somebody wrote to be read. Text that a test or a benchmark
+operates on is data: `wrap_text`'s CJK literals are the double-width columns its
+tests and its bench are about, and replacing them with ASCII would leave the
+tests green and the benchmark measuring something else.
 
 ## Commit messages and pull request titles
 
@@ -86,11 +87,10 @@ Three things about the store decide whether such a test works:
 
 - `new` asserts that no Tokio runtime is entered, so the test is a plain
   `#[test]`; `#[tokio::test]` panics.
-- The flag carries the most recent command's directive, so read it immediately
-  after the `send` under test. Anything dispatched afterwards overwrites it.
-- `finish()` ends the test. It checks that every message the store produced was
-  received — on drop if the test never called it, which fails somewhere other
-  than the assertion.
+- Read the flag immediately after the `send` under test. It holds one command's
+  directive, so anything else dispatched is what you read instead.
+- End with `finish()`. Skipping it does not skip the check it makes: the same
+  one runs at drop, and fails there rather than at the assertion.
 
 ## Before you push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing
+
+Issues and pull requests are welcome.
+
+Where code goes is written down already: [docs/architecture.md](docs/architecture.md)
+has the layers, the direction dependencies may point, and the contracts that
+connect them — what `domain` may not know, why `model` reports outcomes instead
+of issuing effects, why `model::editor` is a deliberate exception.
+
+What follows is the rest: the conventions nothing in `just lint` or CI checks.
+
+## Language
+
+Everything published is written in English — code, comments, documentation,
+commit messages, and the titles and bodies of pull requests and issues. Where
+something will be read decides it, not what kind of thing it is.
+
+## Commit messages and pull request titles
+
+[Conventional Commits][cc]: `type: summary`, with `feat`, `fix`, `docs`,
+`refactor`, `perf`, `test`, `build`, `chore` and `revert` as the types. Scopes
+are not used here; the only scoped commits are Dependabot's `build(deps)`.
+
+The summary states what the change claims, not which file it touched:
+
+```
+fix: an empty composer published an empty note
+test: "every profile" needs more than one profile
+docs: a stopped media source is restarted by the next message, not never
+```
+
+Pull request titles take the same shape. Nothing verifies any of this — there
+is no commit linter here, and no CI job reads a commit message.
+
+## Tests
+
+Every test lives in a `mod tests` at the end of the file it exercises. There is
+no `tests/` directory today.
+
+### A name says what is asserted
+
+The name states the claim rather than the function under test —
+`new_holds_no_profiles`, not `new` — and carries no `test_` prefix, since
+`#[test]` already says that ([#541](https://github.com/akiomik/nostui/issues/541),
+[#547](https://github.com/akiomik/nostui/pull/547)). Dropping the prefix is what
+makes the first half load-bearing: `mod tests` pulls the outer module in with
+`use super::*`, so a test left named after the function it calls shadows that
+function.
+
+A name that quantifies has to earn it. `every`, `only`, `in order` and `never`
+each need enough cases that a wrong implementation fails: one profile does not
+establish `clear_profiles_drops_every_profile`, and three sampled indices do not
+establish `is_at_bottom_only_on_the_last_note`.
+
+### A test nobody watched fail is not a test
+
+The defect this repository keeps producing is not a wrong assertion but an inert
+one — a test that passes whether or not the change under it is present. Break
+the implementation, run `cargo test <filter>`, watch the failure, then put it
+back. Reasoning that an assertion must be load-bearing has been wrong often
+enough that review does not accept it.
+
+Undo the mutation by editing it back out. `git checkout -- <file>` takes the
+uncommitted work with it.
+
+### Assertions
+
+- Assert the whole value rather than a field at a time:
+  `assert_eq!(foo, Foo { field: "bar" })` over a run of
+  `assert_eq!(foo.field, "bar")`. A field-at-a-time test only fails on the
+  fields it happened to name.
+- Prefer the form that prints the value on failure: `assert_eq!(maybe, None)`
+  over `assert!(maybe.is_none())`, `assert_eq!(xs, Vec::<T>::new())` over
+  `assert_eq!(xs.len(), 0)`. Use plain `assert!` for a genuine `bool`.
+- Do not test what a `derive` provides (`Debug`, `Default`, `Clone`,
+  `PartialEq`).
+- Return `Result` from the test instead of calling `unwrap`; use `expect` on an
+  `Option`.
+
+### Where the redraw directive is observable
+
+Whether a `Command` was built `without_redraw` can only be read through
+`tears::testing::TestStore::redraw_requested`, `Command::requests_redraw` being
+crate-private to `tears`. So those tests live in `src/runtime.rs` even when the
+decision they pin is made in `application::state`: construct a
+`TestStore::<TearsApp<'static>>::new(flags)`, `send` the message, and read
+`redraw_requested()`. `TestStore::new` asserts that no Tokio runtime is entered,
+so the test must be a plain `#[test]` — `#[tokio::test]` panics.
+
+## Before you push
+
+[just](https://github.com/casey/just) runs what CI runs:
+
+```console
+$ just fmt
+$ just lint
+$ just test
+```
+
+CI runs these as separate jobs, so a formatting slip fails a run that clippy and
+the tests passed locally — hand-edited grouped `use` imports are the usual
+cause. `just lint` also needs [typos](https://github.com/crate-ci/typos) on
+PATH.
+
+One CI job is outside all three: `Docs` builds the documentation with warnings
+denied. Run it by hand when the change touched a doc comment, since `just doc`
+alone does not deny them:
+
+```console
+$ RUSTDOCFLAGS='-D warnings' just doc
+```
+
+Codecov comments on the pull request and is not a required check. The repository
+has no `codecov.yml`, so the default `threshold: 0%` fails on any decrease at
+all. When it goes red, read the uncovered lines rather than the percentage:
+
+```console
+$ cargo llvm-cov --all-features --workspace --show-missing-lines
+```
+
+Testable logic left uncovered is worth covering; the entry-point glue that takes
+the terminal over or connects to relays cannot be unit-tested, and a red mark is
+better than a contrivance that buys the percentage back. Say in the pull request
+which of the two it was.
+
+[cc]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,17 @@ Everything published is written in English — code, comments, documentation,
 commit messages, and the titles and bodies of pull requests and issues. Where
 something will be read decides it, not what kind of thing it is.
 
+That is about prose a contributor writes, not about text a test operates on.
+The CJK literals in `wrap_text`'s tests are the double-width columns those tests
+are for, and an ASCII replacement would keep passing while checking nothing;
+`domain::nostr::nip10`'s note fixtures are content in the same way.
+
 ## Commit messages and pull request titles
 
 [Conventional Commits][cc]: `type: summary`, with `feat`, `fix`, `docs`,
-`refactor`, `perf`, `test`, `build`, `ci`, `chore` and `revert` as the types. A scope
-is allowed and rarely taken — two commits in the history carry one, beside
+`refactor`, `perf`, `test`, `build`, `ci`, `chore` and `revert` as the types, and
+`!` before the `:` for a breaking change (`feat!`, `refactor!`). A scope is
+allowed and rarely taken — two commits in the history carry one, beside
 Dependabot's `build(deps)`.
 
 The summary states what the change claims, not which file it touched:
@@ -86,9 +92,11 @@ uncommitted work with it.
   `just lint` denies warnings — so an `unwrap` fails the lint rather than
   review. Where `?` cannot reach, inside an `rstest` `#[case(...)]` argument for
   instance, put `#[allow(clippy::unwrap_used)]` on the one test that needs it
-  rather than contorting the case. The module-wide `#![allow(…)]` in
-  `domain::nostr::nip27` covers a whole file of such cases and is the exception;
-  taken by default it also silences every test added to the module later.
+  rather than contorting the case. The inner `#![allow(…)]` at the top of
+  `domain::nostr::nip27`'s `mod tests` covers a module of them and is the
+  exception — it belongs inside the test module, since at the top of the file it
+  would cover the production code too, and taken by default it silences every
+  test added to the module afterwards.
 
 ### Where the redraw directive is observable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ something will be read decides it, not what kind of thing it is.
 ## Commit messages and pull request titles
 
 [Conventional Commits][cc]: `type: summary`, with `feat`, `fix`, `docs`,
-`refactor`, `perf`, `test`, `build`, `chore` and `revert` as the types. A scope
+`refactor`, `perf`, `test`, `build`, `ci`, `chore` and `revert` as the types. A scope
 is allowed and rarely taken — two commits in the history carry one, beside
 Dependabot's `build(deps)`.
 
@@ -85,8 +85,10 @@ uncommitted work with it.
   `Option`. This one is checked — `Cargo.toml` sets `unwrap_used = "warn"` and
   `just lint` denies warnings — so an `unwrap` fails the lint rather than
   review. Where `?` cannot reach, inside an `rstest` `#[case(...)]` argument for
-  instance, the tree opens the module with `#![allow(clippy::unwrap_used)]`
-  instead of contorting the case.
+  instance, put `#[allow(clippy::unwrap_used)]` on the one test that needs it
+  rather than contorting the case. The module-wide `#![allow(…)]` in
+  `domain::nostr::nip27` covers a whole file of such cases and is the exception;
+  taken by default it also silences every test added to the module later.
 
 ### Where the redraw directive is observable
 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,9 @@ The following actions are available:
 
 For how the codebase is organised — the layers, their dependency direction, and
 the contracts between them — see [docs/architecture.md](docs/architecture.md).
+
+## Contributing
+
+Conventions the tooling does not check — commit messages, how tests are named
+and what they have to prove, the local checks before pushing — are in
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -32,8 +32,6 @@ impl Reference {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
-
     use pretty_assertions::assert_eq;
     use rstest::*;
 
@@ -86,6 +84,7 @@ mod tests {
             )
         ])
     ]
+    #[allow(clippy::unwrap_used)]
     fn find_extracts_recognised_references_in_order_and_rejects_the_rest(
         #[case] content: &str,
         #[case] expected: Vec<Reference>,


### PR DESCRIPTION
Closes #548.

Adds `CONTRIBUTING.md`, and a four-line pointer to it from `README.md`.

## Where it went

#548 left the placement open — `CONTRIBUTING.md`, `docs/testing.md`, or a short
entry file pointing at `docs/`. One file, because what is being written down is
four test rules and three paragraphs around them; a split costs a decision per
rule about which half it belongs in, and buys nothing until there is more to
divide. `docs/architecture.md` stays where it is and the new file opens by
pointing at it, since where code goes was already answered there.

## What it says

Only what this repository has actually argued about:

- **Language.** English for everything that reaches GitHub, including issue and
  pull request titles and bodies.
- **Commit subjects.** Conventional Commits, and the summary states the claim
  rather than the file — which is what the last hundred commits do, with no
  linter to keep it that way. Scopes are recorded as unused, since the only
  scoped commits are Dependabot's.
- **Tests**, which is what #548 asked for:
  - A name says what is asserted, and carries no `test_` prefix (#541, #547).
    The reason the two halves are one rule is in there: `use super::*` means a
    test left named after the function it calls shadows that function.
  - `every`, `only`, `in order` and `never` in a name have to be earned by the
    cases in the body. Both examples are real ones from #547's review.
  - An assertion is not trusted until the implementation was broken and the test
    was watched failing. This is the one that has cost the most review time —
    across #545 and #547, every finding of the class was an inert test, and none
    was a wrong answer.
  - `without_redraw` is observable only through
    `tears::testing::TestStore::redraw_requested`, so those tests live in
    `src/runtime.rs` even when the decision is made in `application::state`
    (#510).
  - The assertion-style rules that had never been in the tree at all: assert the
    whole value, prefer the comparison that prints on failure, do not test what
    a `derive` provides, return `Result` instead of `unwrap`.
- **Before you push.** `just fmt`, `just lint`, `just test`; the two CI jobs
  none of them covers (`Docs` with warnings denied, and Codecov); and how a red
  Codecov mark is read here — the uncovered lines rather than the percentage,
  since it is not a required check and the default `threshold: 0%` fails on any
  decrease at all.

## What it does not say

Nothing about where an integration test goes, because there is no `tests/`
directory to send one to; the file states that instead. Nothing about injecting
a clock into a test either — the note was drafted, then dropped when a grep
found no `Instant` anywhere in `src/` since the tick was removed in #528. A rule
whose example does not exist is the kind that rots first.

One thing the file states is not yet true of the tree: `src/domain/collections.rs`
has 22 comment lines in Japanese, the only ones in the repository. Translating
them is a change to the source and does not belong beside a documentation file,
so it is #553. The rule is written as the rule, without a carve-out for the file
that does not meet it yet.

Nothing is mechanised. #547 already argued that a lint for a naming rule costs
more than it is worth, so the whole of the check is that the rule is now
somewhere to look.

`Cargo.toml`'s `include` does not ship `CONTRIBUTING.md`, so the README's link
to it dangles inside the packaged `.crate` — as the `docs/architecture.md` link
two lines above it already does. crates.io rewrites relative links against the
repository, so the rendered page is right either way, and this is left as it is
rather than changed by a documentation pull request.

## The one code change

`src/domain/nostr/nip27.rs` was the only place in the tree contradicting a rule
this pull request writes down: it opted the whole test module out of
`unwrap_used` rather than the one test that needs it. It looked unavoidable,
because the `unwrap`s are inside multi-line `#[case(...)]` arguments. It is not
— an `#[allow]` on the `#[rstest]` function reaches them, since that is where
rstest expands the cases. Removing the module attribute first made clippy report
all five; the function attribute silenced all five.

## What review cost, and what was done about it

Eight rounds, 23 findings, the last two rounds clean. Every finding was the same
shape — a sentence here claiming something about the tree that is wrong,
incomplete, or without an example — but it split in two:

| | | |
| --- | --- | --- |
| Rounds 1-4 | 18 findings | 12 of them corroboration, 6 rules |
| Rounds 5-8 | 5 findings | 0 corroboration, 5 rules, then dry |

Corroboration is the census that backs a rule without instructing anyone: how
many commits carry a scope, which file takes the module-wide allow, the count of
tests `use super::*` would shadow. Answering each finding added another sentence
of that kind, so the file grew 44% across four rounds while the finding count
stayed flat. `af36dd2` removes it and keeps the rules, which is what #548 asked
for: a few rules that have actually been argued about, not a style guide. The
finding rate fell to 4, then 1, then 0 and 0.

## Verification

Every claim in the file was checked against the tree rather than recalled:
`mod tests` is the last top-level item in all 31 files that have one, no test
name carries the prefix, `Command::requests_redraw` is `#[cfg(test)]
pub(crate)` in `tears`, and `TestStore::new` asserts no Tokio runtime is entered
— which is what makes `#[tokio::test]` panic.

`just fmt`, `just lint` and `just test` (410 + 1 doc) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi


