### PR TITLE
docs: the one file where the language rule had a counterexample

### DIFF
--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -332,7 +332,8 @@ mod tests {
         // any behaviour a user could see. Sorting both sides would guard neither.
         let expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
 
-        // len() reaches the slice through Deref; EventSet defines none of its own.
+        // len() reaches the slice through Deref, EventSet defining none of its own;
+        // first() on the line below is EventSet's own method, not the slice's.
         assert_eq!(events_set.len(), 3);
         assert_eq!(events_set.first().unwrap().content, "first");
 

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -193,7 +193,8 @@ mod tests {
 
     fn create_test_event(id_suffix: u8, content: &str) -> Result<Event> {
         let mut id_bytes = [0u8; 32];
-        id_bytes[31] = id_suffix; // 最後のバイトを変えて異なるIDを作成
+        // Only the last byte varies, so every suffix gives a distinct id.
+        id_bytes[31] = id_suffix;
 
         let keys = Keys::generate();
         Ok(Event::new(
@@ -233,15 +234,13 @@ mod tests {
         let mut events = EventSet::new();
         let event = create_test_event(1, "test content")?;
 
-        // 最初の挿入
         let first_add = events.insert(event.clone());
         assert!(first_add);
         assert_eq!(events.len(), 1);
 
-        // 重複挿入
         let second_add = events.insert(event);
         assert!(!second_add);
-        assert_eq!(events.len(), 1); // サイズは変わらない
+        assert_eq!(events.len(), 1);
 
         Ok(())
     }
@@ -268,7 +267,7 @@ mod tests {
         let event = create_test_event(1, "test content")?;
 
         assert!(events.push(event.clone()));
-        assert!(!events.push(event)); // 重複
+        assert!(!events.push(event));
         assert_eq!(events.len(), 1);
 
         Ok(())
@@ -278,7 +277,6 @@ mod tests {
     fn duplicate_event_with_different_content() -> Result<()> {
         let mut events = EventSet::new();
 
-        // 同じEventIdで異なるコンテンツのイベントを作成
         let id = EventId::from_byte_array([1u8; 32]);
         let keys = Keys::generate();
 
@@ -293,17 +291,18 @@ mod tests {
         );
 
         let event2 = Event::new(
-            id, // 同じID
+            id,
             keys.public_key(),
             Timestamp::now(),
             Kind::TextNote,
             vec![],
-            "second content".to_string(), // 異なるコンテンツ
+            "second content".to_string(),
             Signature::from_slice(&[0u8; 64])?,
         );
 
         assert!(events.insert(event1));
-        assert!(!events.insert(event2)); // IDが同じなので拒否される
+        // Rejected on the id alone; the differing content does not make it a new event.
+        assert!(!events.insert(event2));
         assert_eq!(events.len(), 1);
 
         Ok(())
@@ -333,15 +332,14 @@ mod tests {
         // any behaviour a user could see. Sorting both sides would guard neither.
         let expected: Vec<_> = test_events.iter().map(|e| e.id).collect();
 
-        // Deref経由でスライスメソッドを使用
+        // len() reaches the slice through Deref; EventSet defines none of its own.
         assert_eq!(events_set.len(), 3);
         assert_eq!(events_set.first().unwrap().content, "first");
 
-        // iter()でのイテレーション（Deref経由）
+        // iter() the same way, rather than the IntoIterator impl on &EventSet.
         let collected: Vec<_> = events_set.iter().map(|e| e.id).collect();
         assert_eq!(collected, expected);
 
-        // into_iter()でのイテレーション
         let ids: Vec<_> = events_set.into_iter().map(|e| e.id).collect();
         assert_eq!(ids, expected);
 
@@ -396,22 +394,19 @@ mod tests {
     fn internal_consistency() -> Result<()> {
         let mut events = EventSet::new();
 
-        // 複数のイベントを追加 (1-10)
         for i in 1..=10 {
             events.insert(create_test_event(i, &format!("event {i}"))?);
         }
 
-        // いくつか重複を試行 (5-15で5-10は重複)
+        // 5-15, so 5-10 repeat what is already there and 11-15 are new.
         for i in 5..=15 {
             events.insert(create_test_event(i, &format!("duplicate attempt {i}"))?);
         }
 
-        // 内部の一貫性をチェック
         assert_eq!(events.events.len(), events.event_ids.len());
-        // 1-10の最初の追加 + 11-15の新規追加 = 15個のユニークなイベント
+        // 1-10 from the first loop plus 11-15 from the second.
         assert_eq!(events.len(), 15);
 
-        // 全てのイベントIDがHashSetに存在することを確認
         for event in events.iter() {
             assert!(events.event_ids.contains(&event.id));
         }
@@ -424,22 +419,21 @@ mod tests {
         let mut events = EventSet::with_capacity(256);
         assert_eq!(events.capacity(), 256);
 
-        // 大量のイベントを追加（パフォーマンステスト）
         for i in 0..1000 {
             let event = create_test_event((i % 256) as u8, &format!("event {i}"))?;
             events.insert(event);
         }
 
-        // 256個のユニークなイベントのみが保存されるはず
+        // 1000 inserts drawn from 256 distinct suffixes leave 256 unique events.
         assert_eq!(events.len(), 256);
 
-        // contains()の動作確認
+        // A fresh event carrying an id already present: contains() reads the id, not
+        // the content, so the differing content does not matter.
         let test_event = create_test_event(100, "test")?;
         assert!(events.contains(&test_event.id));
 
-        // retain機能のテスト
         events.retain(|e| e.content.starts_with("event 1"));
-        assert!(events.len() < 256); // いくつかのイベントが削除される
+        assert!(events.len() < 256);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #553.

`src/domain/collections.rs` was the only file under `src/` with Japanese comments — 22 lines, all inside `EventSet` and its tests — which left [#552](https://github.com/akiomik/nostui/pull/552)'s language rule with a counterexample in a file contributors open.

## What each comment became

Kept, in English, because it records something the code does not say:

| Where | What it records |
| --- | --- |
| `create_test_event` | only the last id byte varies, so each suffix is a distinct id |
| `duplicate_event_with_different_content` | the insert is rejected on the id alone, whatever the content says |
| `iteration_yields_..._in_insertion_order` | `len()` and `iter()` reach the slice through `Deref`, not through an inherent method or the `IntoIterator` impl on `&EventSet` |
| `internal_consistency` | the 5-15 loop repeats 5-10 and adds 11-15, which is where 15 comes from |
| `performance_and_capacity` | 1000 inserts over 256 distinct suffixes leave 256 events; `contains()` matches the fresh event because it reads the id, not the content |

Deleted, because each restated the line under it: "first insertion" above an `insert`, "duplicate insertion" above the second one, "the size does not change" after an `assert_eq!` on the length, "duplicate" beside a `push` of the same event, "iteration with into_iter()" above an `into_iter()`, "add several events (1-10)" above `for i in 1..=10`, "check internal consistency" above the consistency assertion, "confirm every event id is in the HashSet" above the loop that does, "add many events (performance test)" above the 1000-insert loop, "test the retain feature" above `retain`, and "some events are removed" after the assertion that says so. The setup comment in `duplicate_event_with_different_content` and the two `// same id` / `// different content` markers went the same way — the test name already states both.

No code or assertion changed, so there is no behaviour to break and no test to watch fail; the tests are the same 410 before and after.

## Acceptance

```console
$ grep -rn '//.*[ぁ-んァ-ヶ一-龠]' src/
$ echo $?
1
```

`just fmt`, `just lint` and `just test` pass; `just fmt` left nothing to commit.

The CJK test data the issue names is untouched: `wrap_text`'s double-width literals and `nip10`'s signed-event fixtures are data the tests operate on, and the grep above does not reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi