### PR TITLE
test: eighteen names that said what they call, not what they check

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn app_state_default() {
+    fn default_has_no_notes_no_editor_and_startup_in_progress() {
         let state = AppState::default();
 
         assert_eq!(state.timeline.len(), 0);

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn default_has_no_notes_no_active_editor_and_startup_in_progress() {
+    fn default_has_an_empty_active_tab_no_active_editor_and_startup_in_progress() {
         let state = AppState::default();
 
         assert_eq!(state.timeline.len(), 0);

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn default_has_no_notes_no_editor_and_startup_in_progress() {
+    fn default_has_no_notes_no_active_editor_and_startup_in_progress() {
         let state = AppState::default();
 
         assert_eq!(state.timeline.len(), 0);

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn standard_traits() -> Result<()> {
+    fn trait_impls_reflect_the_set_contents() -> Result<()> {
         let mut events = EventSet::new();
         let event1 = create_test_event(1, "first")?;
         let event2 = create_test_event(2, "second")?;
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn internal_consistency() -> Result<()> {
+    fn duplicate_inserts_keep_the_id_index_and_the_events_in_step() -> Result<()> {
         let mut events = EventSet::new();
 
         for i in 1..=10 {
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[test]
-    fn performance_and_capacity() -> Result<()> {
+    fn with_capacity_reserves_and_still_dedupes_by_id() -> Result<()> {
         let mut events = EventSet::with_capacity(256);
         assert_eq!(events.capacity(), 256);
 

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -62,7 +62,7 @@ mod tests {
     use color_eyre::eyre::Result;
 
     #[test]
-    fn sortable_event_id_creation() {
+    fn new_keeps_the_id_and_timestamp_given() {
         let event_id = EventId::from_byte_array([0; EventId::LEN]);
         let timestamp = Timestamp::from(1000);
 

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_clone() {
+    fn clone_equals_the_original() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_serialization() {
+    fn json_round_trip_preserves_the_profile() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         let created_at = Timestamp::now();

--- a/src/model/nostr.rs
+++ b/src/model/nostr.rs
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn new_creates_default_instance() {
+    fn new_is_not_ready_and_has_no_subscriptions() {
         let nostr = Nostr::new();
 
         assert!(!nostr.is_ready());

--- a/src/model/timeline/pagination.rs
+++ b/src/model/timeline/pagination.rs
@@ -85,14 +85,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pagination_state_default() {
+    fn new_has_no_oldest_timestamp_and_is_not_loading() {
         let state = Pagination::new();
         assert_eq!(state.oldest_timestamp(), None);
         assert!(!state.is_loading_more());
     }
 
     #[test]
-    fn update_oldest() {
+    fn oldest_timestamp_moves_older_and_never_newer() {
         let mut state = Pagination::new();
 
         let ts1 = Timestamp::from(1000);
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn loading_more() {
+    fn loading_more_starts_with_a_since_and_finishes_clearing_it() {
         let mut state = Pagination::new();
         let since = Timestamp::from(1000);
 

--- a/src/model/timeline/selection.rs
+++ b/src/model/timeline/selection.rs
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn scroll_up() {
+    fn previous_item_steps_back_and_stops_at_the_first() {
         let mut state = Selection::new();
         state.update(Message::ItemSelected(5));
 
@@ -126,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn scroll_down() {
+    fn next_item_starts_at_zero_and_stops_at_max_index() {
         let mut state = Selection::new();
 
         // Initial scroll down selects first item

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -290,8 +290,12 @@ mod tests {
 
     #[test]
     fn each_tab_keeps_the_feed_it_was_made_for() {
+        // Every `FeedKind`, so a `new` that coerced one of them fails here.
         let home_tab = TimelineTab::new_home();
         assert_eq!(home_tab.feed, FeedKind::Home);
+
+        let mention_tab = TimelineTab::new(FeedKind::Mention);
+        assert_eq!(mention_tab.feed, FeedKind::Mention);
 
         let pubkey = PublicKey::from_slice(&[1u8; 32]).expect("Valid pubkey");
         let user_tab = TimelineTab::new(FeedKind::Author(pubkey));

--- a/src/model/timeline/tab.rs
+++ b/src/model/timeline/tab.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn timeline_tab_default() {
+    fn new_home_starts_empty_unselected_and_not_loading() {
         let tab = TimelineTab::new_home();
         assert_eq!(tab.len(), 0);
         assert!(tab.is_empty());
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn timeline_feed() {
+    fn each_tab_keeps_the_feed_it_was_made_for() {
         let home_tab = TimelineTab::new_home();
         assert_eq!(home_tab.feed, FeedKind::Home);
 

--- a/src/presentation/widgets/status_bar.rs
+++ b/src/presentation/widgets/status_bar.rs
@@ -86,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn status_bar_widget_new() {
+    fn new_keeps_the_status_bar_and_context_given() {
         let pubkey = create_test_pubkey();
         let status_bar = StatusBar::default();
         let ctx = ViewContext {

--- a/src/presentation/widgets/status_bar.rs
+++ b/src/presentation/widgets/status_bar.rs
@@ -88,7 +88,12 @@ mod tests {
     #[test]
     fn new_keeps_the_status_bar_and_context_given() {
         let pubkey = create_test_pubkey();
-        let status_bar = StatusBar::default();
+        // Carrying a message, so a `new` that stored `StatusBar::default()` fails here.
+        let mut status_bar = StatusBar::default();
+        status_bar.update(Message::MessageChanged {
+            label: String::from("Info"),
+            message: String::from("Connected"),
+        });
         let ctx = ViewContext {
             user_pubkey: pubkey,
             user_profile: None,

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -74,7 +74,7 @@ mod tests {
     }
 
     #[test]
-    fn view_context_clone() {
+    fn clone_sees_the_same_number_of_profiles() {
         let profiles = HashMap::new();
         let ctx = ViewContext {
             profiles: &profiles,
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    fn tab_bar_widget_new() {
+    fn new_reads_through_to_the_timeline_given() {
         let timeline = Timeline::default();
         let profiles = HashMap::new();
         let ctx = ViewContext {

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -85,13 +85,19 @@ mod tests {
 
     #[test]
     fn new_reads_through_to_the_timeline_given() {
-        let timeline = Timeline::default();
+        // A second tab, so the assertion tells this timeline from the default one a
+        // `new` that ignored its argument would have to invent.
+        let mut timeline = Timeline::default();
+        let _ = timeline.update(Message::TabAdded {
+            feed: FeedKind::Author(create_test_pubkey()),
+        });
+
         let profiles = HashMap::new();
         let ctx = ViewContext {
             profiles: &profiles,
         };
         let widget = TabBarWidget::new(&timeline, ctx.clone());
-        assert_eq!(widget.timeline.tabs().len(), 1);
+        assert_eq!(widget.timeline.tabs().len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #549.

#548 wrote the convention down; this renames the eighteen tests #549 lists as
unambiguous, and — after the first review of this branch — fixes three bodies
that turned out not to check what their new names claim.

| file | was | is |
|---|---|---|
| `domain::nostr::profile` | `profile_clone` | `clone_equals_the_original` |
| | `profile_serialization` | `json_round_trip_preserves_the_profile` |
| `domain::collections` | `standard_traits` | `trait_impls_reflect_the_set_contents` |
| | `internal_consistency` | `duplicate_inserts_keep_the_id_index_and_the_events_in_step` |
| | `performance_and_capacity` | `with_capacity_reserves_and_still_dedupes_by_id` |
| `model::timeline::pagination` | `pagination_state_default` | `new_has_no_oldest_timestamp_and_is_not_loading` |
| | `update_oldest` | `oldest_timestamp_moves_older_and_never_newer` |
| | `loading_more` | `loading_more_starts_with_a_since_and_finishes_clearing_it` |
| `model::timeline::selection` | `scroll_up` | `previous_item_steps_back_and_stops_at_the_first` |
| | `scroll_down` | `next_item_starts_at_zero_and_stops_at_max_index` |
| `model::timeline::tab` | `timeline_tab_default` | `new_home_starts_empty_unselected_and_not_loading` |
| | `timeline_feed` | `each_tab_keeps_the_feed_it_was_made_for` |
| `presentation::widgets::status_bar` | `status_bar_widget_new` | `new_keeps_the_status_bar_and_context_given` |
| `presentation::widgets::tab_bar` | `view_context_clone` | `clone_sees_the_same_number_of_profiles` |
| | `tab_bar_widget_new` | `new_reads_through_to_the_timeline_given` |
| `domain::nostr::event` | `sortable_event_id_creation` | `new_keeps_the_id_and_timestamp_given` |
| `application::state` | `app_state_default` | `default_has_an_empty_active_tab_no_active_editor_and_startup_in_progress` |
| `model::nostr` | `new_creates_default_instance` | `new_is_not_ready_and_has_no_subscriptions` |

## The names that did not survive their own review

Writing the claim down is what exposed the bodies that do not check it. Three
arrangements changed so the name is true:

- **`each_tab_keeps_the_feed_it_was_made_for`** quantified over three
  `FeedKind`s and built two. `Mention` is a real tab (`application::state`), so
  a `TimelineTab::new` that coerced it stayed green under a name promising
  otherwise. The `Mention` case is there now.
- **`new_reads_through_to_the_timeline_given`** asserted one tab on a
  `Timeline::default()`, which *is* one tab — satisfied by any default the
  widget might be holding instead. The timeline gets a second tab, so the
  assertion is about this one.
- **`new_keeps_the_status_bar_and_context_given`** compared a default
  `StatusBar` against a default. It carries a message now; the `ctx` half was
  already load-bearing.

Two rounds of review went into `app_state_default`'s replacement, and both were
the name claiming an absence the body does not check. It said "no editor", but
`AppState::editor` is a plain `Editor<'a>`, not an `Option` — the default state
has an editor and it is inactive. It then said "no notes", but `Timeline::len()`
is `self.active_tab().len()`; the central `notes` map is private to
`model::timeline` and this test cannot see it. The name is now
`default_has_an_empty_active_tab_no_active_editor_and_startup_in_progress`,
which is what the three assertions check.

## Two names that report a weakness

Where the body is thin and fixing it is a different change, the name says so
rather than covering for it:

- `clone_sees_the_same_number_of_profiles` (was `view_context_clone`) compares
  `len()` on two empty `HashMap`s. It would pass on a `clone` that returned an
  empty map.
- `clone_equals_the_original` (was `profile_clone`) asserts what
  `derive(Clone, PartialEq)` provides, which CONTRIBUTING says not to test.

Both are filed as #557, together with the `domain::collections` grab-bags. The
worst of those, `with_capacity_reserves_and_still_dedupes_by_id`, ends on a
`retain` assertion its name never reaches; #557 now names that assertion rather
than calling the test a grab-bag.

## Checks

`just fmt`, `just lint`, `just test` — 410 passed, 0 failed. Coverage is
unchanged: no production line moved.

Every claim a strengthened assertion makes was watched failing, then put back.
None of these mutations is in the diff:

| test | mutation | result |
|---|---|---|
| `oldest_timestamp_moves_older_and_never_newer` | `Pagination::update` assigns unconditionally | fails on the newer-timestamp case |
| `each_tab_keeps_the_feed_it_was_made_for` | `TimelineTab::new` coerces `Mention` to `Home` | fails on the mention tab |
| `new_reads_through_to_the_timeline_given` | `TabBarWidget::new` stores a leaked `Timeline::default()` | fails on the tab count |
| `new_keeps_the_status_bar_and_context_given` | `StatusBarWidget::new` stores `StatusBar::default()` | fails on the status bar |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi
