### PR TITLE
test: three tests asserted a derive, and two asserted four things each

### DIFF
--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -429,29 +429,23 @@ mod tests {
     fn a_duplicate_insert_leaves_the_event_already_stored() -> Result<()> {
         let events = overlapping_inserts()?;
 
-        // Ids 5-10 were offered twice. `insert` ignores the second offer, so the
-        // contents are the first loop's; an `insert` that replaced on a duplicate id
-        // would leave "duplicate attempt 5" here and still hold fifteen events.
-        let contents: Vec<&str> = events.iter().map(|event| event.content.as_str()).collect();
+        // Only the ids offered twice carry this claim, so only those are read. `insert`
+        // ignores the second offer, so the contents are the first loop's; an `insert`
+        // that replaced on a duplicate id would leave "duplicate attempt 5" here and
+        // still hold fifteen events under the same fifteen ids.
+        let contents: Vec<&str> = (5..=10)
+            .map(|i| {
+                let id = id_of(i);
+                events
+                    .iter()
+                    .find(|event| event.id == id)
+                    .map(|event| event.content.as_str())
+                    .expect("offered in the first loop")
+            })
+            .collect();
         assert_eq!(
             contents,
-            vec![
-                "event 1",
-                "event 2",
-                "event 3",
-                "event 4",
-                "event 5",
-                "event 6",
-                "event 7",
-                "event 8",
-                "event 9",
-                "event 10",
-                "duplicate attempt 11",
-                "duplicate attempt 12",
-                "duplicate attempt 13",
-                "duplicate attempt 14",
-                "duplicate attempt 15",
-            ]
+            vec!["event 5", "event 6", "event 7", "event 8", "event 9", "event 10"]
         );
 
         Ok(())
@@ -461,13 +455,17 @@ mod tests {
     fn the_id_index_and_the_events_stay_in_step() -> Result<()> {
         let events = overlapping_inserts()?;
 
-        assert_eq!(events.events.len(), events.event_ids.len());
-
+        // Fifteen written out rather than read back off `events`: a length taken from
+        // the same Vec being iterated compares `[]` against `[]` on a set that stored
+        // nothing, and an `insert` that stored nothing would pass.
         let indexed: Vec<bool> = events
             .iter()
             .map(|event| events.event_ids.contains(&event.id))
             .collect();
-        assert_eq!(indexed, vec![true; events.len()]);
+        assert_eq!(indexed, vec![true; 15]);
+
+        // And no id in the index without an event of its own.
+        assert_eq!(events.event_ids.len(), 15);
 
         Ok(())
     }
@@ -497,17 +495,25 @@ mod tests {
     }
 
     #[test]
-    fn contains_reads_the_id_and_not_the_content() -> Result<()> {
+    fn contains_finds_an_id_even_on_an_event_it_never_saw() -> Result<()> {
         let mut events = EventSet::new();
         events.insert(create_test_event(1, "the content that was inserted")?);
 
-        // Same id, different content: found anyway.
+        // A freshly built event carrying the same id: different content, different
+        // author, never offered to the set. The id is what is looked up.
         let same_id = create_test_event(1, "nothing like it")?;
         assert!(events.contains(&same_id.id));
 
-        // Same content, different id: not found.
-        let same_content = create_test_event(2, "the content that was inserted")?;
-        assert!(!events.contains(&same_content.id));
+        Ok(())
+    }
+
+    #[test]
+    fn contains_is_false_for_an_id_never_inserted() -> Result<()> {
+        let mut events = EventSet::new();
+        events.insert(create_test_event(1, "the content that was inserted")?);
+
+        let never_inserted = create_test_event(2, "the content that was inserted")?;
+        assert!(!events.contains(&never_inserted.id));
 
         Ok(())
     }

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -191,14 +191,17 @@ mod tests {
     use nostr_sdk::prelude::Signature;
     use nostr_sdk::prelude::{Kind, Timestamp};
 
-    fn create_test_event(id_suffix: u8, content: &str) -> Result<Event> {
+    /// Only the last byte varies, so every suffix gives a distinct id.
+    fn id_of(id_suffix: u8) -> EventId {
         let mut id_bytes = [0u8; 32];
-        // Only the last byte varies, so every suffix gives a distinct id.
         id_bytes[31] = id_suffix;
+        EventId::from_byte_array(id_bytes)
+    }
 
+    fn create_test_event(id_suffix: u8, content: &str) -> Result<Event> {
         let keys = Keys::generate();
         Ok(Event::new(
-            EventId::from_byte_array(id_bytes),
+            id_of(id_suffix),
             keys.public_key(),
             Timestamp::now(),
             Kind::TextNote,
@@ -412,9 +415,44 @@ mod tests {
     fn duplicate_inserts_leave_one_event_per_id() -> Result<()> {
         let events = overlapping_inserts()?;
 
-        // 1-10 from the first loop plus 11-15 from the second, and nothing for the six
-        // repeats.
-        assert_eq!(events.len(), 15);
+        // The ids themselves rather than a count: 1-10 from the first loop and 11-15
+        // from the second, each exactly once. A count alone would also hold for a set
+        // that stored two events under one id and dropped another id entirely.
+        let ids: Vec<EventId> = events.iter().map(|event| event.id).collect();
+        let expected: Vec<EventId> = (1..=15).map(id_of).collect();
+        assert_eq!(ids, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_duplicate_insert_leaves_the_event_already_stored() -> Result<()> {
+        let events = overlapping_inserts()?;
+
+        // Ids 5-10 were offered twice. `insert` ignores the second offer, so the
+        // contents are the first loop's; an `insert` that replaced on a duplicate id
+        // would leave "duplicate attempt 5" here and still hold fifteen events.
+        let contents: Vec<&str> = events.iter().map(|event| event.content.as_str()).collect();
+        assert_eq!(
+            contents,
+            vec![
+                "event 1",
+                "event 2",
+                "event 3",
+                "event 4",
+                "event 5",
+                "event 6",
+                "event 7",
+                "event 8",
+                "event 9",
+                "event 10",
+                "duplicate attempt 11",
+                "duplicate attempt 12",
+                "duplicate attempt 13",
+                "duplicate attempt 14",
+                "duplicate attempt 15",
+            ]
+        );
 
         Ok(())
     }
@@ -438,7 +476,11 @@ mod tests {
     fn with_capacity_reserves_the_capacity_asked_for() {
         let events = EventSet::with_capacity(256);
 
-        assert_eq!(events.capacity(), 256);
+        // Both halves: `capacity()` reads the events, and an `event_ids` left
+        // unreserved would make the set grow its index on the first inserts anyway.
+        // `at least`, because that is all `Vec` and `HashSet` promise.
+        assert!(events.capacity() >= 256);
+        assert!(events.event_ids.capacity() >= 256);
     }
 
     #[test]

--- a/src/domain/collections.rs
+++ b/src/domain/collections.rs
@@ -391,8 +391,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn duplicate_inserts_keep_the_id_index_and_the_events_in_step() -> Result<()> {
+    /// Ten ids, then eleven inserts of which six repeat, so the set has seen both a
+    /// duplicate and a new id by the time it is read.
+    fn overlapping_inserts() -> Result<EventSet> {
         let mut events = EventSet::new();
 
         for i in 1..=10 {
@@ -404,37 +405,85 @@ mod tests {
             events.insert(create_test_event(i, &format!("duplicate attempt {i}"))?);
         }
 
-        assert_eq!(events.events.len(), events.event_ids.len());
-        // 1-10 from the first loop plus 11-15 from the second.
-        assert_eq!(events.len(), 15);
+        Ok(events)
+    }
 
-        for event in events.iter() {
-            assert!(events.event_ids.contains(&event.id));
-        }
+    #[test]
+    fn duplicate_inserts_leave_one_event_per_id() -> Result<()> {
+        let events = overlapping_inserts()?;
+
+        // 1-10 from the first loop plus 11-15 from the second, and nothing for the six
+        // repeats.
+        assert_eq!(events.len(), 15);
 
         Ok(())
     }
 
     #[test]
-    fn with_capacity_reserves_and_still_dedupes_by_id() -> Result<()> {
-        let mut events = EventSet::with_capacity(256);
+    fn the_id_index_and_the_events_stay_in_step() -> Result<()> {
+        let events = overlapping_inserts()?;
+
+        assert_eq!(events.events.len(), events.event_ids.len());
+
+        let indexed: Vec<bool> = events
+            .iter()
+            .map(|event| events.event_ids.contains(&event.id))
+            .collect();
+        assert_eq!(indexed, vec![true; events.len()]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn with_capacity_reserves_the_capacity_asked_for() {
+        let events = EventSet::with_capacity(256);
+
         assert_eq!(events.capacity(), 256);
+    }
+
+    #[test]
+    fn a_thousand_inserts_drawn_from_256_ids_leave_256_events() -> Result<()> {
+        let mut events = EventSet::new();
 
         for i in 0..1000 {
-            let event = create_test_event((i % 256) as u8, &format!("event {i}"))?;
-            events.insert(event);
+            events.insert(create_test_event((i % 256) as u8, &format!("event {i}"))?);
         }
 
-        // 1000 inserts drawn from 256 distinct suffixes leave 256 unique events.
         assert_eq!(events.len(), 256);
 
-        // A fresh event carrying an id already present: contains() reads the id, not
-        // the content, so the differing content does not matter.
-        let test_event = create_test_event(100, "test")?;
-        assert!(events.contains(&test_event.id));
+        Ok(())
+    }
 
-        events.retain(|e| e.content.starts_with("event 1"));
-        assert!(events.len() < 256);
+    #[test]
+    fn contains_reads_the_id_and_not_the_content() -> Result<()> {
+        let mut events = EventSet::new();
+        events.insert(create_test_event(1, "the content that was inserted")?);
+
+        // Same id, different content: found anyway.
+        let same_id = create_test_event(1, "nothing like it")?;
+        assert!(events.contains(&same_id.id));
+
+        // Same content, different id: not found.
+        let same_content = create_test_event(2, "the content that was inserted")?;
+        assert!(!events.contains(&same_content.id));
+
+        Ok(())
+    }
+
+    #[test]
+    fn retain_keeps_only_the_events_its_predicate_accepts() -> Result<()> {
+        let mut events = EventSet::new();
+        for i in 1..=6 {
+            let label = if i % 2 == 0 { "drop" } else { "keep" };
+            events.insert(create_test_event(i, &format!("{label} {i}"))?);
+        }
+
+        events.retain(|event| event.content.starts_with("keep"));
+
+        // The exact survivors, not merely fewer than before: a `retain` that dropped
+        // everything, or kept the wrong half, would pass a count-only assertion.
+        let contents: Vec<&str> = events.iter().map(|event| event.content.as_str()).collect();
+        assert_eq!(contents, vec!["keep 1", "keep 3", "keep 5"]);
 
         Ok(())
     }

--- a/src/domain/nostr/event.rs
+++ b/src/domain/nostr/event.rs
@@ -117,17 +117,6 @@ mod tests {
     }
 
     #[test]
-    fn sortable_event_id_equality() {
-        let event_id = EventId::from_byte_array([0; EventId::LEN]);
-        let timestamp = Timestamp::from(1000);
-
-        let sortable1 = SortableEventId::new(event_id, timestamp);
-        let sortable2 = SortableEventId::new(event_id, timestamp);
-
-        assert_eq!(sortable1, sortable2);
-    }
-
-    #[test]
     fn sortable_event_id_in_reverse_sorted_set() {
         use sorted_vec::ReverseSortedSet;
         use std::cmp::Reverse;

--- a/src/domain/nostr/profile.rs
+++ b/src/domain/nostr/profile.rs
@@ -205,21 +205,6 @@ mod tests {
     }
 
     #[test]
-    fn clone_equals_the_original() {
-        let keys = Keys::generate();
-        let pubkey = keys.public_key();
-        let created_at = Timestamp::now();
-        let mut metadata = Metadata::new();
-        metadata.display_name = Some(String::from("Test User"));
-
-        let profile = Profile::new(pubkey, created_at, metadata);
-        let cloned = profile.clone();
-
-        assert_eq!(profile, cloned);
-        assert_eq!(profile.name(), cloned.name());
-    }
-
-    #[test]
     fn json_round_trip_preserves_the_profile() {
         let keys = Keys::generate();
         let pubkey = keys.public_key();

--- a/src/presentation/widgets/tab_bar.rs
+++ b/src/presentation/widgets/tab_bar.rs
@@ -74,16 +74,6 @@ mod tests {
     }
 
     #[test]
-    fn clone_sees_the_same_number_of_profiles() {
-        let profiles = HashMap::new();
-        let ctx = ViewContext {
-            profiles: &profiles,
-        };
-        let cloned = ctx.clone();
-        assert_eq!(ctx.profiles.len(), cloned.profiles.len());
-    }
-
-    #[test]
     fn new_reads_through_to_the_timeline_given() {
         // A second tab, so the assertion tells this timeline from the default one a
         // `new` that ignored its argument would have to invent.


### PR DESCRIPTION
Closes #557. Follow-up to #556, which named these and left them.

## Deleted: three tests of a `derive`

CONTRIBUTING says not to test what a `derive` provides.

- **`clone_sees_the_same_number_of_profiles`** (`presentation::widgets::tab_bar`)
  compared `len()` on two empty `HashMap`s behind the same shared reference —
  `ViewContext` holds `&'a HashMap`, so both calls read the same map. Nothing
  short of not compiling could break it.
- **`clone_equals_the_original`** (`domain::nostr::profile`) asserted
  `profile == profile.clone()`. `Profile` derives both `Clone` and `PartialEq`.
- **`sortable_event_id_equality`** (`domain::nostr::event`) is the same defect
  one file over. It is not in #557's list because nobody had looked; the
  acceptance criterion is repo-wide ("no test asserts only what a `derive`
  provides"), so I swept for the shape rather than stopping at the two named.
  The derived `PartialEq` is still exercised —
  `sortable_event_id_in_reverse_sorted_set` compares two
  `Vec<SortableEventId>`.

**`json_round_trip_preserves_the_profile` stays.** It asserts the derived serde
impls *composed with nostr_sdk's* impls for `PublicKey`, `Timestamp` and
`Metadata`, which is not a property our derive alone provides. Worth saying
separately: the serde derive on `Profile` has no production user — the only
`serde_json` call on a `Profile` anywhere in the crate is that test. Whether the
derive should be there at all is a different question from whether the test is.

## Split: no name carries more than one claim

| was | is |
|---|---|
| `duplicate_inserts_keep_the_id_index_and_the_events_in_step` | `duplicate_inserts_leave_one_event_per_id` |
| | `a_duplicate_insert_leaves_the_event_already_stored` |
| | `the_id_index_and_the_events_stay_in_step` |
| `with_capacity_reserves_and_still_dedupes_by_id` | `with_capacity_reserves_the_capacity_asked_for` |
| | `a_thousand_inserts_drawn_from_256_ids_leave_256_events` |
| | `contains_finds_an_id_even_on_an_event_it_never_saw` |
| | `contains_is_false_for_an_id_never_inserted` |
| | `retain_keeps_only_the_events_its_predicate_accepts` |

The two that share an arrangement share it through an `overlapping_inserts()`
helper rather than by repeating the loops.

Six assertions got stronger on the way, three of them only after review caught
the new name claiming past its body:

- **`retain`** was `assert!(events.len() < 256)` — satisfied by a `retain` that
  dropped everything, or kept the wrong half. It now pins the survivors
  themselves: `["keep 1", "keep 3", "keep 5"]`.
- **`contains`** only ever checked that a differing-content event with a known
  id *is* found. `contains_reads_the_id_and_not_the_content` was the wrong name
  for it either way: `contains(&self, event_id: &EventId)` is never handed
  content, so no implementation could read it. The two directions are two
  claims, and they are two tests —
  `contains_finds_an_id_even_on_an_event_it_never_saw` and
  `contains_is_false_for_an_id_never_inserted`.
- **`the_id_index_and_the_events_stay_in_step`** passed on a set that stored
  nothing. Both sides of `events.len() == event_ids.len()` were zero, and the
  expected vector took its length from the same `Vec` it was compared against,
  so it checked `[]` against `[]`. The fifteen is a literal now, and the index's
  own length is asserted with it, so a spare id there fails too.
- **`a_duplicate_insert_leaves_the_event_already_stored`** pinned all fifteen
  contents when only the six ids offered twice carry its claim — coupling it to
  `overlapping_inserts`'s ranges, which is the brittleness the shared helper
  exists to remove. It reads ids 5-10 by id now.
- **`duplicate_inserts_leave_one_event_per_id`** first asserted `len() == 15`,
  which an `insert` that *replaced* the stored event on a duplicate id also
  satisfies — and so did the index test, so nothing in the file pinned which of
  two same-id events survives. It asserts the ids themselves now, and
  `a_duplicate_insert_leaves_the_event_already_stored` asserts the contents,
  which is where a replacing `insert` shows up. The expected ids come from an
  `id_of` helper `create_test_event` uses too, so the two cannot drift.
- **`with_capacity`** read `capacity()`, which is `events.capacity()` alone — an
  `event_ids: HashSet::new()` passed it. Both halves now, and `>=` rather than
  `==`, since at-least is all `Vec` and `HashSet` promise.

## Checks

`just fmt`, `just lint`, `just test` — 413 passed, 0 failed.

Every new test was watched failing under the mutation it names, then the
implementation was put back. None of these is in the diff:

| mutation | tests killed |
|---|---|
| `insert` pushes unconditionally | `duplicate_inserts_leave_one_event_per_id`, `the_id_index_and_the_events_stay_in_step`, `a_thousand_inserts_drawn_from_256_ids_leave_256_events` |
| `with_capacity` builds a `Vec::new()` | `with_capacity_reserves_the_capacity_asked_for` |
| `contains` returns `false` always | `contains_finds_an_id_even_on_an_event_it_never_saw` |
| `contains` returns `true` always | `contains_is_false_for_an_id_never_inserted` |
| `insert` stores nothing | `the_id_index_and_the_events_stay_in_step`, `retain_keeps_only_the_events_its_predicate_accepts`, `a_thousand_inserts_drawn_from_256_ids_leave_256_events` |
| `retain` negates its predicate | `retain_keeps_only_the_events_its_predicate_accepts` |
| `insert` replaces the stored event on a duplicate id | `a_duplicate_insert_leaves_the_event_already_stored` (the other two hold, correctly — the id set is unchanged) |
| `with_capacity` leaves `event_ids` unreserved | `with_capacity_reserves_the_capacity_asked_for` |

### Two gaps left alone, on purpose

- Nothing asserts that `retain` also drops the removed ids from `event_ids`. Only
  the `debug_assert_eq!` inside `retain` guards it, and that would miss a
  `retain` removing the wrong id from the index. The gap is pre-existing — the
  deleted test asserted `len() < 256` and nothing more — and `retain` has no
  production caller anywhere in the crate, so closing it here would be new
  coverage rather than this PR's subject.
- `the_id_index_and_the_events_stay_in_step` leaves one theoretical hole: fifteen
  events over fourteen distinct ids plus one orphan id in the index would also
  pass. `duplicate_inserts_leave_one_event_per_id` pins the ids, so the file as a
  whole closes it.

### Coverage, which #557 asked to check before deleting

`cargo llvm-cov --all-features --workspace --show-missing-lines`, before and
after:

| file | missed lines before | after |
|---|---|---|
| `domain/collections.rs` | 23 | 23 (same list) |
| `domain/nostr/event.rs` | 0 | 0 |
| `domain/nostr/profile.rs` | 2 (171, 187) | 2 (171, 187) |
| `presentation/widgets/tab_bar.rs` | 0 | 0 |

No line the deleted tests reached went uncovered — including the derived impls,
whose regions are still counted as reached. `collections.rs` gains 5 missed
*regions* (48 → 53 of 543), which are in the added test code: no production line
in the file changed, and every `?` in a new test body adds an `Err` arm the happy
path never takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi


