### PR TITLE
test: the verdict that decides "Posted" had no test for saying yes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,17 +39,22 @@ Pull request titles take the same shape. Nothing verifies any of this.
 ## Tests
 
 Tests live in a `mod tests` at the end of the file they exercise, the one
-doctest aside. `tests/` holds the exception: a test that cannot be written
-against the crate from the inside, because what it needs to observe is only
-reachable through the public API or only produced by something outside the
-process.
+doctest aside. `tests/` holds the integration tests: the ones that stand the
+crate up and drive it from outside, rather than exercising the item they sit
+next to.
 
-There is one today. `tests/publish_verdict.rs` stands up a local relay and
-publishes to it, because `EventSendStatus::Ack` wraps a type nostr-sdk gives no
-public constructor — a relay answering `OK true` is the only way to obtain one,
-so the accepting half of the publish verdict has no unit test to be written
-([#523](https://github.com/akiomik/nostui/issues/523)). Reach for `tests/` when
-that is the situation, not because a test feels like an integration test.
+There is one today. `tests/publish_verdict.rs` runs a local relay and publishes
+to it over a socket, because the accepting half of the publish verdict needs a
+relay to answer `OK true`: `EventSendStatus::Ack` wraps a type for which
+nostr-sdk gives no public constructor, so no `SendEventOutput` assembled in a
+test can carry one
+([#523](https://github.com/akiomik/nostui/issues/523)).
+
+Note what does *not* decide this. A `mod tests` unit test can reach
+dev-dependencies, open a socket, and call private items besides, so nothing
+forced that file out of `src`. What put it in `tests/` is that it drives the
+whole publish path end to end. Something you could write either way belongs
+beside the code it is about.
 
 ### A name says what is asserted
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,17 @@ Pull request titles take the same shape. Nothing verifies any of this.
 ## Tests
 
 Tests live in a `mod tests` at the end of the file they exercise, the one
-doctest aside. There is no `tests/` directory.
+doctest aside. `tests/` holds the exception: a test that cannot be written
+against the crate from the inside, because what it needs to observe is only
+reachable through the public API or only produced by something outside the
+process.
+
+There is one today. `tests/publish_verdict.rs` stands up a local relay and
+publishes to it, because `EventSendStatus::Ack` wraps a type nostr-sdk gives no
+public constructor — a relay answering `OK true` is the only way to obtain one,
+so the accepting half of the publish verdict has no unit test to be written
+([#523](https://github.com/akiomik/nostui/issues/523)). Reach for `tests/` when
+that is the situation, not because a test feels like an integration test.
 
 ### A name says what is asserted
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,20 +41,7 @@ Pull request titles take the same shape. Nothing verifies any of this.
 Tests live in a `mod tests` at the end of the file they exercise, the one
 doctest aside. `tests/` holds the integration tests: the ones that stand the
 crate up and drive it from outside, rather than exercising the item they sit
-next to.
-
-There is one today. `tests/publish_verdict.rs` runs a local relay and publishes
-to it over a socket, because the accepting half of the publish verdict needs a
-relay to answer `OK true`: `EventSendStatus::Ack` wraps a type for which
-nostr-sdk gives no public constructor, so no `SendEventOutput` assembled in a
-test can carry one
-([#523](https://github.com/akiomik/nostui/issues/523)).
-
-Note what does *not* decide this. A `mod tests` unit test can reach
-dev-dependencies, open a socket, and call private items besides, so nothing
-forced that file out of `src`. What put it in `tests/` is that it drives the
-whole publish path end to end. Something you could write either way belongs
-beside the code it is about.
+next to. A test you could write either way goes beside the code it is about.
 
 ### A name says what is asserted
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "btreecap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6160c957d8aa33d0a8ba1dbab98e3cb57023ad9374c501441e88559f99e6c4c9"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2023,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-memory"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2b7b21ffca47ad6dc32474d06d7fd1e8f83f218f7b350f4309eb5f49e7f97d"
+dependencies = [
+ "btreecap",
+ "nostr",
+ "nostr-database",
+ "tokio",
+]
+
+[[package]]
 name = "nostr-sdk"
 version = "0.45.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2049,7 @@ dependencies = [
  "nostr",
  "nostr-database",
  "nostr-gossip",
+ "nostr-memory",
  "opaquerr",
  "rand 0.10.2",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,14 +53,13 @@ unicode-width = "0.2"
 
 [dev-dependencies]
 criterion = "0.8"
-futures = "0.3"
-# `local-relay` is what makes tests/publish_verdict.rs possible: a relay that answers
-# `OK true` is the only way to obtain an `EventSendStatus::Ack` from outside nostr-sdk.
+# The one dependency a test adds rather than reuses: `local-relay` is what makes
+# tests/publish_verdict.rs possible, since a relay answering `OK true` is the only way
+# to obtain an `EventSendStatus::Ack`. Everything else the tests need is in
+# `[dependencies]`, which Cargo puts on every target.
 nostr-sdk = { version = "0.45", features = ["local-relay"] }
 pretty_assertions = "1"
 rstest = "0.26"
-tears = "0.11.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [lints.clippy]
 absolute_paths = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,14 @@ unicode-width = "0.2"
 
 [dev-dependencies]
 criterion = "0.8"
+futures = "0.3"
+# `local-relay` is what makes tests/publish_verdict.rs possible: a relay that answers
+# `OK true` is the only way to obtain an `EventSendStatus::Ack` from outside nostr-sdk.
+nostr-sdk = { version = "0.45", features = ["local-relay"] }
 pretty_assertions = "1"
 rstest = "0.26"
+tears = "0.11.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [lints.clippy]
 absolute_paths = "warn"

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -604,10 +604,10 @@ mod tests {
         // any policy but `AckPolicy::all`, so if that setting is ever dropped from the
         // send this must report failure rather than quietly calling it published.
         //
-        // The accepting direction cannot be covered here: `EventSendStatus::Ack` wraps an
-        // `EventSendAcknowledgement` with no public constructor, so it cannot be built
-        // from outside nostr-sdk. It is covered end to end against a local relay, in
-        // `tests/publish_verdict.rs`.
+        // The accepting direction needs a relay to answer `OK true`:
+        // `EventSendStatus::Ack` wraps an `EventSendAcknowledgement` with no public
+        // constructor, so no `SendEventOutput` assembled here can carry one. It is
+        // covered against a local relay in `tests/publish_verdict.rs`.
         let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
 
         assert!(NostrEvents::relay_verdict(&output).is_err());

--- a/src/infrastructure/subscription/nostr.rs
+++ b/src/infrastructure/subscription/nostr.rs
@@ -604,10 +604,10 @@ mod tests {
         // any policy but `AckPolicy::all`, so if that setting is ever dropped from the
         // send this must report failure rather than quietly calling it published.
         //
-        // The accepting direction is not covered by a unit test: `EventSendStatus::Ack`
-        // wraps an `EventSendAcknowledgement` with no public constructor, so it cannot be
-        // built here. It is reachable end to end — nostr-sdk ships a `local-relay`
-        // feature — which is #523.
+        // The accepting direction cannot be covered here: `EventSendStatus::Ack` wraps an
+        // `EventSendAcknowledgement` with no public constructor, so it cannot be built
+        // from outside nostr-sdk. It is covered end to end against a local relay, in
+        // `tests/publish_verdict.rs`.
         let output = send_output(&["wss://a.example"], &[("wss://b.example", "rate-limited")]);
 
         assert!(NostrEvents::relay_verdict(&output).is_err());

--- a/tests/publish_verdict.rs
+++ b/tests/publish_verdict.rs
@@ -1,21 +1,25 @@
-//! The accepting side of the publish verdict, which no unit test can reach.
+//! The accepting side of the publish verdict, end to end against a local relay.
 //!
-//! `NostrEvents::relay_verdict` decides whether a publish is reported as done, and its
-//! refusing directions are covered in that file's `mod tests`. The accepting one is not:
-//! `EventSendStatus::Ack` wraps an `EventSendAcknowledgement` whose constructor is
-//! private to nostr-sdk, so a `SendEventOutput` assembled by hand can only carry
-//! `EventSendStatus::Sent` — the variant the verdict deliberately refuses. A relay has to
-//! answer `OK true` for an `Ack` to exist at all, which is why this test opens a socket
-//! (#523).
+//! `NostrEvents::relay_verdict` decides whether a publish is reported as done. Its
+//! refusing directions are unit-tested beside it; this covers the branch that returns
+//! `Ok(())`, which decides whether "Posted" is ever shown.
 //!
-//! It drives the same path the application does — `NostrEvents::stream()`, a
-//! `SendEventBuilder` command, the `EventPublished` message that comes back — rather than
-//! calling the verdict directly, which from here is private anyway.
+//! It needs a real relay. `EventSendStatus::Ack` wraps an `EventSendAcknowledgement`
+//! whose constructor nostr-sdk keeps private, so a `SendEventOutput` assembled by hand
+//! can only carry `EventSendStatus::Sent` — the variant the verdict deliberately
+//! refuses. A relay answering `OK true` is the only source of an `Ack` (#523).
+//!
+//! Needing a socket is not what puts this file here: a `mod tests` unit test could open
+//! one too, and would reach `relay_verdict` directly instead of reading the outcome off
+//! `Message::EventPublished`. What puts it here is that it drives the whole publish path
+//! the application drives — `NostrEvents::stream()`, a `SendEventBuilder` command, the
+//! `EventPublished` that comes back — rather than the one function.
 
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::slice;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,8 +37,15 @@ const PUBLISH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A relay that answers `OK false` to everything, so that a send can be refused by one
 /// relay while another accepts it.
+///
+/// It counts what it was offered. A relay holding nothing afterwards is not evidence
+/// that it refused — a send that never reached it looks the same — and without this the
+/// partial case would degrade into the accepting one, silently, the day something stops
+/// writing to every registered relay.
 #[derive(Debug)]
-struct RefuseEverything;
+struct RefuseEverything {
+    offered: Arc<AtomicUsize>,
+}
 
 impl WritePolicy for RefuseEverything {
     fn admit_event<'a>(
@@ -43,6 +54,7 @@ impl WritePolicy for RefuseEverything {
         _addr: &'a SocketAddr,
     ) -> Pin<Box<dyn Future<Output = WritePolicyResult> + Send + 'a>> {
         Box::pin(async move {
+            self.offered.fetch_add(1, Ordering::SeqCst);
             WritePolicyResult::reject(MachineReadablePrefix::Blocked, "refused on purpose")
         })
     }
@@ -127,7 +139,12 @@ async fn one_relay_acknowledging_is_a_publish_even_when_another_refuses() -> Res
     let accepting = MockRelay::run().await?;
     let accepting_url = accepting.url().await;
 
-    let refusing = LocalRelay::builder().write_policy(RefuseEverything).build();
+    let offered_to_the_refusing_relay = Arc::new(AtomicUsize::new(0));
+    let refusing = LocalRelay::builder()
+        .write_policy(RefuseEverything {
+            offered: Arc::clone(&offered_to_the_refusing_relay),
+        })
+        .build();
     refusing.run().await?;
     let refusing_url = refusing.url().await;
 
@@ -139,8 +156,10 @@ async fn one_relay_acknowledging_is_a_publish_even_when_another_refuses() -> Res
     // is logged rather than reported.
     assert_eq!(outcome, Ok(()));
 
-    // The halves really were different, which is the whole point of this case — without
-    // these the test is the accepting one with a second relay attached.
+    // The halves really were different, which is the whole point of this case. The
+    // count is the load-bearing one: a refusing relay that holds nothing and a relay
+    // that was never written to are indistinguishable from the outside.
+    assert_eq!(offered_to_the_refusing_relay.load(Ordering::SeqCst), 1);
     assert_eq!(notes_held_by(&accepting_url, keys.public_key()).await?, 1);
     assert_eq!(notes_held_by(&refusing_url, keys.public_key()).await?, 0);
 

--- a/tests/publish_verdict.rs
+++ b/tests/publish_verdict.rs
@@ -1,0 +1,148 @@
+//! The accepting side of the publish verdict, which no unit test can reach.
+//!
+//! `NostrEvents::relay_verdict` decides whether a publish is reported as done, and its
+//! refusing directions are covered in that file's `mod tests`. The accepting one is not:
+//! `EventSendStatus::Ack` wraps an `EventSendAcknowledgement` whose constructor is
+//! private to nostr-sdk, so a `SendEventOutput` assembled by hand can only carry
+//! `EventSendStatus::Sent` — the variant the verdict deliberately refuses. A relay has to
+//! answer `OK true` for an `Ack` to exist at all, which is why this test opens a socket
+//! (#523).
+//!
+//! It drives the same path the application does — `NostrEvents::stream()`, a
+//! `SendEventBuilder` command, the `EventPublished` message that comes back — rather than
+//! calling the verdict directly, which from here is private anyway.
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::slice;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use nostr_sdk::prelude::*;
+use nostui::infrastructure::subscription::nostr::NostrEvents;
+use nostui::model::nostr_gateway::{Message, NostrCommand, PublishId};
+use nostui::Result;
+use tears::SubscriptionSource;
+use tokio::time::timeout;
+
+/// Long enough that a slow machine is not what fails this, short enough that a hung
+/// socket is reported as a failure rather than by the harness killing the run.
+const PUBLISH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A relay that answers `OK false` to everything, so that a send can be refused by one
+/// relay while another accepts it.
+#[derive(Debug)]
+struct RefuseEverything;
+
+impl WritePolicy for RefuseEverything {
+    fn admit_event<'a>(
+        &'a self,
+        _event: &'a Event,
+        _addr: &'a SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = WritePolicyResult> + Send + 'a>> {
+        Box::pin(async move {
+            WritePolicyResult::reject(MachineReadablePrefix::Blocked, "refused on purpose")
+        })
+    }
+}
+
+/// Publish one text note through the real subscription and return what the application
+/// would have been told.
+///
+/// The relays are passed in rather than started here so that a caller can also query
+/// them afterwards: a partial-success test that never checked the refusing relay refused
+/// would be the accepting test written twice.
+async fn publish_through_nostr_events(
+    relays: &[RelayUrl],
+    keys: &Keys,
+) -> Result<Result<(), String>> {
+    let client = Client::new();
+    for url in relays {
+        client.add_relay(url).await?;
+    }
+    client.connect().await;
+
+    let nostr_events = NostrEvents::new(Arc::new(client), keys.public_key(), Some(keys.clone()));
+    let mut stream = nostr_events.stream();
+
+    let Some(Message::Ready { sender }) = stream.next().await else {
+        panic!("the subscription's first message is Ready, carrying the command sender");
+    };
+
+    sender.send(NostrCommand::SendEventBuilder {
+        id: Some(PublishId(1)),
+        event_builder: EventBuilder::new(Kind::TextNote, "published by an integration test"),
+    })?;
+
+    // Relay notifications arrive on the same stream, so read past them.
+    let outcome = timeout(PUBLISH_TIMEOUT, async {
+        while let Some(message) = stream.next().await {
+            if let Message::EventPublished { id, result } = message {
+                assert_eq!(id, PublishId(1), "the outcome names the publish it settles");
+                return result;
+            }
+        }
+        panic!("the subscription ended without reporting the publish");
+    })
+    .await?;
+
+    Ok(outcome)
+}
+
+/// What one relay is holding for an author, asked over a connection of its own.
+async fn notes_held_by(url: &RelayUrl, author: PublicKey) -> Result<usize> {
+    let client = Client::new();
+    client.add_relay(url).await?;
+    client.connect().await;
+
+    let events = client
+        .fetch_events(Filter::new().author(author).kind(Kind::TextNote))
+        .timeout(PUBLISH_TIMEOUT)
+        .await?;
+
+    client.disconnect().await;
+
+    Ok(events.len())
+}
+
+#[tokio::test]
+async fn a_send_a_relay_acknowledged_is_a_publish() -> Result<()> {
+    let relay = MockRelay::run().await?;
+    let url = relay.url().await;
+    let keys = Keys::generate();
+
+    let outcome = publish_through_nostr_events(slice::from_ref(&url), &keys).await?;
+
+    assert_eq!(outcome, Ok(()));
+    // And the relay really is holding it, so the `Ok` is not a verdict on nothing.
+    assert_eq!(notes_held_by(&url, keys.public_key()).await?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn one_relay_acknowledging_is_a_publish_even_when_another_refuses() -> Result<()> {
+    let accepting = MockRelay::run().await?;
+    let accepting_url = accepting.url().await;
+
+    let refusing = LocalRelay::builder().write_policy(RefuseEverything).build();
+    refusing.run().await?;
+    let refusing_url = refusing.url().await;
+
+    let keys = Keys::generate();
+    let outcome =
+        publish_through_nostr_events(&[accepting_url.clone(), refusing_url.clone()], &keys).await?;
+
+    // One relay holding the event is enough: it exists on the network, and the refusal
+    // is logged rather than reported.
+    assert_eq!(outcome, Ok(()));
+
+    // The halves really were different, which is the whole point of this case — without
+    // these the test is the accepting one with a second relay attached.
+    assert_eq!(notes_held_by(&accepting_url, keys.public_key()).await?, 1);
+    assert_eq!(notes_held_by(&refusing_url, keys.public_key()).await?, 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #523.

## The gap

`NostrEvents::relay_verdict` decides whether a publish is reported as done. Its
refusing directions are covered — nothing acknowledged, nobody answered, reasons
in a stable order, the message not growing with the relay count. The branch that
returns `Ok(())`, the one that decides whether "Posted" is ever shown, was not.

That is not an oversight in #520 — an `Ack` cannot be built at all outside
nostr-sdk:

```rust
// nostr-sdk-0.45.2/src/relay/api/send_event.rs
pub struct EventSendAcknowledgement { message: Option<String> }
impl EventSendAcknowledgement {
    fn new(message: String) -> Self { … }   // no `pub`
}
impl EventSendStatus {
    fn ack(message: String) -> Self { … }   // nor here
}
```

A `SendEventOutput` assembled by hand can therefore only carry
`EventSendStatus::Sent`, which the verdict deliberately refuses. A relay
answering `OK true` is the only source of an `Ack`.

**This PR first claimed that also forced the test out of `src`. It does not**, and
review caught it. A `mod tests` unit test reaches dev-dependencies, opens
sockets and calls private items, so `MockRelay` works there and `relay_verdict`
is callable directly — I wrote that test, watched it pass, and deleted it. The
file stays in `tests/` because it drives the whole publish path, not because
anything forced it there, and the header, the comment beside the unit test and
CONTRIBUTING all say so now. CONTRIBUTING additionally says that a test
placeable either way belongs beside the code it is about, so the new section
cannot be read as an invitation to move unit-testable work out of `src`.

## What this adds

`tests/publish_verdict.rs`, on nostr-sdk's `local-relay` feature as a
dev-dependency.

It drives the path the application drives — `NostrEvents::stream()`, the
`Ready { sender }` it opens with, a `SendEventBuilder` command, the
`EventPublished` that comes back — rather than calling `relay_verdict`, which
from an integration test is private anyway. That makes the test cover the whole
publish path rather than the one function.

- `a_send_a_relay_acknowledged_is_a_publish` — one `MockRelay`, and the note is
  read back off it afterwards so the `Ok` is not a verdict on nothing.
- `one_relay_acknowledging_is_a_publish_even_when_another_refuses` — a second
  relay built with a `WritePolicy` that refuses everything. The policy counts
  what it was offered, and the test asserts that count: a refusing relay holding
  nothing looks exactly like a relay nothing was ever sent to, so without the
  count this would degrade into the first test the day something stopped writing
  to every registered relay. It also reads the note back off the accepting relay
  and confirms the refusing one has none.

## Checks

`just fmt`, `just lint`, `just test` — 413 unit + 2 integration + 1 doctest, 0
failed.

Watched failing, then put back. None of these is in the diff:

| mutation | result |
|---|---|
| `relay_verdict`'s ack check becomes `if false` | both integration tests fail — this is #523's first acceptance criterion, literally |
| the refusing relay's `WritePolicy` returns `Accept` | `one_relay_acknowledging_is_a_publish_even_when_another_refuses` fails, so the partial case really is partial |
| `relay_verdict` accepts any non-empty `success` | the two integration tests pass (correctly — they produce genuine acks) and the unit test `a_send_nobody_acknowledged_is_not_a_publish` fails |
| the publish reaches only the first registered relay | `one_relay_acknowledging_is_a_publish_even_when_another_refuses` fails on the offered count — this one is in the test helper, since the production lever it models is inside nostr-sdk's send |

The third is the split working as intended: the socket test owns the accepting
direction, the unit test owns the `Sent`-is-not-an-ack direction, and neither
covers for the other.

### On flakiness

This is the first test in the suite to open a socket, so I measured rather than
guessed: **40 consecutive runs of `cargo test --test publish_verdict`, 0
failures**, at 0.02s per run. It stays in the ordinary `Test Suite` job.

There is no retry anywhere. The single knob is a `PUBLISH_TIMEOUT` constant at
30s, which is what a slow CI runner would want raised. If it ever does turn
flaky, the order is: find the cause, then raise that constant, and only if
neither works split it into a separate non-required job.

### Dependencies

Only `nostr-sdk` with `local-relay` is added. An earlier revision also listed
`futures`, `tears` and `tokio` under `[dev-dependencies]`; Cargo already puts
`[dependencies]` on every target, so those were inert. The `tokio` one was
actively misleading — it read as the tests' feature contract while changing
nothing, so trimming the real dependency's features would have broken the tests
with nothing to point at.

### Two things left alone, on purpose

- `publish_through_nostr_events` never sends `NostrCommand::Shutdown`, so each
  call leaves a worker task and its sockets alive until the test binary exits.
  Harmless at two tests, and each test owns its own relays, so nothing
  interferes. Worth revisiting if this file grows.
- The partial case asserts the outcome and that the refusal happened, but not
  that the refusal reached the `log::warn!` branch inside `relay_verdict`. There
  is no accessible signal for that from here — `Message::EventPublished` carries
  `Ok(())` and nothing else — and asserting on logs is not something this
  repository does anywhere.

## CONTRIBUTING

It said "There is no `tests/` directory." There is one now, so it says what
belongs there instead: the integration tests, the ones that stand the crate up
and drive it from outside, and a test you could write either way goes beside the
code it is about.

That is all it says. An earlier revision also named this file and its nostr-sdk
reason, which put a copy of the directory's contents in a document that would
then need resyncing, and argued at length about what does not decide the
placement — a review answer rather than a rule. The explanation lives in the
test file's own header, where it moves with the code it is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi


