### PR TITLE
test: the one line that makes nostui refuse an unknown argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -961,6 +987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1237,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1978,6 +2019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nostr"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2109,7 @@ dependencies = [
 name = "nostui"
 version = "0.1.1"
 dependencies = [
+ "assert_cmd",
  "better-panic",
  "chrono",
  "clap",
@@ -2080,6 +2128,7 @@ dependencies = [
  "nostr-sdk",
  "nowhear",
  "percent-encoding",
+ "predicates",
  "pretty_assertions",
  "ratatui",
  "regex",
@@ -2564,6 +2613,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3467,6 +3546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "termwiz"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +4155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,13 @@ tui-widget-list = "0.15"
 unicode-width = "0.2"
 
 [dev-dependencies]
+assert_cmd = "2"
 criterion = "0.8"
-# The one dependency a test adds rather than reuses: `local-relay` is what makes
+# Repeated from `[dependencies]` for one feature: `local-relay` is what makes
 # tests/publish_verdict.rs possible, since a relay answering `OK true` is the only way
-# to obtain an `EventSendStatus::Ack`. Everything else the tests need is in
-# `[dependencies]`, which Cargo puts on every target.
+# to obtain an `EventSendStatus::Ack`.
 nostr-sdk = { version = "0.45", features = ["local-relay"] }
+predicates = "3"
 pretty_assertions = "1"
 rstest = "0.26"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ async fn tokio_main() -> Result<()> {
     initialize_panic_handler()?;
 
     // Parsed for `--help`, `--version`, and to reject anything else; nostui takes no
-    // options of its own since #527 removed `--tick-rate`.
+    // options of its own since #527 removed `--tick-rate`. It binds nothing and returns
+    // a value with no fields, so deleting it looks like tidying — `tests/cli.rs` runs
+    // the binary to make that a failing test rather than a silent change of behaviour.
     let _ = <Cli as Parser>::parse();
 
     // Load configuration

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -40,7 +40,12 @@ fn nostui() -> Result<Command> {
     let mut command = Command::cargo_bin("nostui")?;
     command
         .env("NOSTUI_CONFIG", config_dir())
-        .env("NOSTUI_DATA", data_dir());
+        .env("NOSTUI_DATA", data_dir())
+        // clap styles the words asserted below, and it colours a pipe too when the
+        // caller exports `CLICOLOR_FORCE`. `anstream` reads `NO_COLOR` before that one,
+        // so this is the whole of it: nothing here should turn red over an environment
+        // the change under test has nothing to do with.
+        .env("NO_COLOR", "1");
     Ok(command)
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -78,15 +78,20 @@ fn help_is_printed_and_the_application_does_not_start() -> Result<()> {
 #[test]
 fn version_is_printed_with_the_directories_it_would_use() -> Result<()> {
     let expected_config_dir = config_dir().display().to_string();
+    let expected_data_dir = data_dir().display().to_string();
 
     nostui()?
         .arg("--version")
         .assert()
         .success()
         .stdout(contains(format!("v{}", env!("CARGO_PKG_VERSION"))))
-        // The directory it names is the one it was told to use, which is also what
-        // keeps these runs out of the real one.
-        .stdout(contains(format!("Config directory: {expected_config_dir}")));
+        // Both directories it names are the ones it was told to use, which is also the
+        // only thing standing between these runs and the real ones. The data directory
+        // needs saying as much as the config one: `initialize_logging` runs before the
+        // parse and truncates the log file it opens, so an env key that stopped working
+        // would empty the log of whoever ran the tests, quietly.
+        .stdout(contains(format!("Config directory: {expected_config_dir}")))
+        .stdout(contains(format!("Data directory: {expected_data_dir}")));
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,6 +18,7 @@
 //! is not there, and exits 1 saying something went wrong.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use assert_cmd::Command;
 use nostui::Result;
@@ -36,9 +37,20 @@ fn data_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("cli-data")
 }
 
+/// Nothing here should take a measurable amount of time; this is the difference between
+/// a regression that fails and one that hangs `cargo test` with no output.
+///
+/// What would hang: the only reason a run that gets past argument handling stops is that
+/// `Config::new` refuses to start, which is an invariant of another module. Were
+/// configuration to become optional, `ratatui::init()` would follow, and crossterm opens
+/// `/dev/tty` rather than the piped stdout — so on a developer's machine it would
+/// succeed, take the real terminal, and wait for input forever.
+const RUN_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn nostui() -> Result<Command> {
     let mut command = Command::cargo_bin("nostui")?;
     command
+        .timeout(RUN_TIMEOUT)
         .env("NOSTUI_CONFIG", config_dir())
         .env("NOSTUI_DATA", data_dir())
         // clap styles the words asserted below, and it colours a pipe too when the

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,87 @@
+//! What the one `Cli` parse in `tokio_main` buys, asserted against the built binary.
+//!
+//! `Cli` has no fields — `--tick-rate` was the last one and #527 removed it — so the
+//! call that parses it binds nothing and returns a value with nothing in it:
+//!
+//! ```ignore
+//! let _ = <Cli as Parser>::parse();
+//! ```
+//!
+//! That one line is the whole of `nostui --help`, `nostui --version`, and `nostui`
+//! refusing an argument it does not know. A tidy-up would delete it and leave
+//! `nostui --bogus` starting the application instead of saying no. A unit test over
+//! `Cli::try_parse_from` would not notice: it asserts that clap rejects the argument,
+//! which clap does whether or not anything calls it (#533).
+//!
+//! So these run the binary. Each one fails if that line goes: without it the arguments
+//! reach nothing that reads them, the program carries on to load a configuration that
+//! is not there, and exits 1 saying something went wrong.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use nostui::Result;
+use predicates::str::contains;
+
+/// A directory with no configuration file in it, which is the point: `Config::new`
+/// refuses to start without one, so a run that gets past argument handling ends in a
+/// diagnosable failure rather than a terminal this test cannot drive.
+fn config_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("cli-config-that-is-not-there")
+}
+
+/// Somewhere to put the log file `initialize_logging` opens before the parse, so these
+/// runs do not write into the data directory of whoever runs the tests.
+fn data_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("cli-data")
+}
+
+fn nostui() -> Result<Command> {
+    let mut command = Command::cargo_bin("nostui")?;
+    command
+        .env("NOSTUI_CONFIG", config_dir())
+        .env("NOSTUI_DATA", data_dir());
+    Ok(command)
+}
+
+#[test]
+fn an_unknown_argument_is_refused_rather_than_ignored() -> Result<()> {
+    nostui()?
+        .arg("--bogus")
+        .assert()
+        // clap's own exit code, and its own words: reaching the application instead
+        // would exit 1 complaining about the configuration, which is the failure this
+        // test exists to tell apart from a refusal.
+        .code(2)
+        .stderr(contains("unexpected argument '--bogus'"));
+
+    Ok(())
+}
+
+#[test]
+fn help_is_printed_and_the_application_does_not_start() -> Result<()> {
+    nostui()?
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("Usage: nostui"))
+        .stdout(contains("--version"));
+
+    Ok(())
+}
+
+#[test]
+fn version_is_printed_with_the_directories_it_would_use() -> Result<()> {
+    let expected_config_dir = config_dir().display().to_string();
+
+    nostui()?
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(contains(format!("v{}", env!("CARGO_PKG_VERSION"))))
+        // The directory it names is the one it was told to use, which is also what
+        // keeps these runs out of the real one.
+        .stdout(contains(format!("Config directory: {expected_config_dir}")));
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #533.

## The gap

`Cli` has had no fields since #527 removed `--tick-rate`, so `tokio_main` parses
it for its side effects alone:

```rust
let _ = <Cli as Parser>::parse();
```

That one call is the whole of `nostui --help`, `nostui --version`, and
`nostui --bogus` exiting instead of starting the application. It binds nothing
and returns a value with no fields, so deleting it reads as tidying — and
nothing failed if you did. Only the comment above it said otherwise, and
`main.rs` has no tests: its module went with `tick_timer_from_rate`.

A unit test over `Cli::try_parse_from(["nostui", "--bogus"])` does not close it.
That asserts clap rejects the argument, which clap does whether or not anything
calls it, so it keeps passing with the call site gone.

## What this adds

`tests/cli.rs`, running the built binary over `assert_cmd`:

| test | asserts |
|---|---|
| `an_unknown_argument_is_refused_rather_than_ignored` | exit 2, stderr names `--bogus` |
| `help_is_printed_and_the_application_does_not_start` | exit 0, `Usage: nostui` |
| `version_is_printed_with_the_directories_it_would_use` | exit 0, the version and the config directory it was told to use |

Each run points `NOSTUI_CONFIG` at a directory with no configuration file in it
and `NOSTUI_DATA` under `CARGO_TARGET_TMPDIR`. That keeps the runs out of the
data directory of whoever runs the tests — and it is what makes the deletion
*diagnosable* rather than hanging: `Config::new` refuses to start without a
configuration file (`application/config.rs:84`), so a run that gets past
argument handling exits 1 instead of reaching for a terminal this test cannot
drive.

The helper also sets a `RUN_TIMEOUT`. `assert()` otherwise waits on the child
with no deadline, and the only thing ending a run that gets past argument
handling is `Config::new` refusing to start — the same invariant the deletion
scenario leans on, owned by another module. Were configuration to become
optional, `--help` would reach `ratatui::init()`, and crossterm opens `/dev/tty`
rather than the piped stdout: on a developer's machine that succeeds, takes the
real terminal and waits for input, and `cargo test` stops with nothing to read.
`assert_cmd` already carries `wait-timeout`, so the deadline costs nothing.

`--version` prints the directories it would use, so asserting the paths it names
also pins that the isolation took effect — both of them. Asserting only the
config one left `NOSTUI_DATA` as a line nothing checked: a rename or a typo
would have kept the suite green while every `cargo test` truncated the log file
of whoever ran it, since `initialize_logging` runs before the parse and
`File::create` empties what it opens.

It also sets `NO_COLOR=1`. clap colours a pipe when the caller exports
`CLICOLOR_FORCE`, and it styles exactly the words these tests read — review
caught two of the three failing under `CLICOLOR_FORCE=1` on
`unexpected argument '\e[33m--bogus\e[0m'` and `\e[1m\e[4mUsage:\e[0m`.
`anstream` reads `NO_COLOR` first, so that one line covers it: the suite passes
under `CLICOLOR_FORCE=1`, `CLICOLOR=1 COLORTERM=truecolor` and `CI=1`, and
swapping the line for an `env_remove` puts the failures back.

## Checks

`just fmt`, `just lint`, `just test` — 413 unit + 3 CLI + 2 relay + 1 doctest, 0
failed.

Watched failing, then put back. **The mutation is not just the call.**
`#![deny(warnings)]` catches that on its own — `clap::Parser` and
`infrastructure::cli::Cli` go unused and the binary stops compiling. The tidy-up
a person would actually make removes the two imports as well, and that compiles:

```
---- an_unknown_argument_is_refused_rather_than_ignored stdout ----
Unexpected return code, failed var == 2
code=1
---- help_is_printed_and_the_application_does_not_start stdout ----
Unexpected failure.
code=1
---- version_is_printed_with_the_directories_it_would_use stdout ----
Unexpected failure.
code=1
```

All three, on the exit code predicted above.

Two more, from review of this branch — the guards themselves had to be watched
failing, not just the line they guard:

| mutation | result |
|---|---|
| `NO_COLOR` line swapped for an `env_remove` | two tests fail under `CLICOLOR_FORCE=1` |
| `NOSTUI_DATA` key renamed to `NOSTUI_DATA_TYPO` | the version test fails (before the `Data directory:` assertion it did not) |
| `RUN_TIMEOUT` set to 1ms | all three fail on the timeout, so the deadline is wired rather than decorative |

None of these mutations is in the diff.

## Dependencies

`assert_cmd` and `predicates`, dev-only. The comment above `nostr-sdk` in
`[dev-dependencies]` said it was "the one dependency a test adds rather than
reuses", which these two make false; it now says what it is actually there for,
which is the `local-relay` feature.

No new test infrastructure beyond that: `CARGO_BIN_EXE_nostui` and
`CARGO_TARGET_TMPDIR` are Cargo's, and `tests/` itself arrived with #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi


