### PR TITLE
fix: a mention that opens or closes a note was not found

### DIFF
--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -6,8 +6,12 @@ use regex::Regex;
 /// The delimiters are word boundaries rather than characters the match consumes, so a mention
 /// still counts when it opens or closes the note, and when only one space separates it from the
 /// next one.
+///
+/// `(?-u:\b)` makes those boundaries ASCII-only. A bech32 URI is ASCII, so what has to be ruled
+/// out is a URI running into surrounding ASCII; Japanese writes no space before a mention, and a
+/// Unicode boundary would treat `こんにちはnostr:npub1…さん` as one word and find nothing in it.
 static REFERENCE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\bnostr:(?:npub|note)1[a-z0-9]{58}\b")
+    Regex::new(r"(?-u:\b)nostr:(?:npub|note)1[a-z0-9]{58}(?-u:\b)")
         .expect("hardcoded NIP-27 reference regex must be valid")
 });
 
@@ -120,6 +124,24 @@ mod tests {
             Reference::new(
                 Nip21::EventId(EventId::from_nostr_uri("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv").unwrap()),
                 String::from("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv")
+            ),
+        ])
+    ]
+    #[case(
+        "こんにちはnostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug",
+        vec![
+            Reference::new(
+                Nip21::Pubkey(PublicKey::from_nostr_uri("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug").unwrap()),
+                String::from("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug")
+            ),
+        ])
+    ]
+    #[case(
+        "nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmugさん、ありがとう",
+        vec![
+            Reference::new(
+                Nip21::Pubkey(PublicKey::from_nostr_uri("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug").unwrap()),
+                String::from("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug")
             ),
         ])
     ]

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -10,6 +10,11 @@ use regex::Regex;
 /// `(?-u:\b)` makes those boundaries ASCII-only. A bech32 URI is ASCII, so what has to be ruled
 /// out is a URI running into surrounding ASCII; Japanese writes no space before a mention, and a
 /// Unicode boundary would treat `こんにちはnostr:npub1…さん` as one word and find nothing in it.
+///
+/// The cost is paid by scripts that do use spaces: `нетnostr:npub1…` is a mention here, where
+/// `foobarnostr:npub1…` is not. Reading the two apart needs to know which script writes spaces,
+/// which a word boundary cannot, and getting Japanese right is worth more than rejecting a
+/// mention nobody writes.
 static REFERENCE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?-u:\b)nostr:(?:npub|note)1[a-z0-9]{58}(?-u:\b)")
         .expect("hardcoded NIP-27 reference regex must be valid")

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -1,5 +1,15 @@
+use std::sync::LazyLock;
+
 use nostr_sdk::prelude::*;
 use regex::Regex;
+
+/// The delimiters are word boundaries rather than characters the match consumes, so a mention
+/// still counts when it opens or closes the note, and when only one space separates it from the
+/// next one.
+static REFERENCE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bnostr:(?:npub|note)1[a-z0-9]{58}\b")
+        .expect("hardcoded NIP-27 reference regex must be valid")
+});
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Reference {
@@ -15,12 +25,7 @@ impl Reference {
 
     pub fn find(text: &str) -> Vec<Self> {
         // TODO: Add nevent and nprofile support
-        // The delimiters are word boundaries rather than characters the match consumes, so a
-        // mention still counts when it opens or closes the note, and when only one space
-        // separates it from the next one.
-        let pattern = Regex::new(r"\bnostr:(?:npub|note)1[a-z0-9]{58}\b")
-            .expect("hardcoded NIP-27 reference regex must be valid");
-        pattern
+        REFERENCE_PATTERN
             .find_iter(text)
             .filter_map(|matched| {
                 let uri = matched.as_str();

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -11,10 +11,9 @@ use regex::Regex;
 /// out is a URI running into surrounding ASCII; Japanese writes no space before a mention, and a
 /// Unicode boundary would treat `こんにちはnostr:npub1…さん` as one word and find nothing in it.
 ///
-/// The cost is paid by scripts that do use spaces: `нетnostr:npub1…` is a mention here, where
-/// `foobarnostr:npub1…` is not. Reading the two apart needs to know which script writes spaces,
-/// which a word boundary cannot, and getting Japanese right is worth more than rejecting a
-/// mention nobody writes.
+/// The cost is that one character decides — the one next to the URI — and any non-ASCII
+/// character counts as a delimiter: `нетnostr:npub1…` is a mention where `foobarnostr:npub1…`
+/// is not. Getting Japanese right is worth that.
 static REFERENCE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?-u:\b)nostr:(?:npub|note)1[a-z0-9]{58}(?-u:\b)")
         .expect("hardcoded NIP-27 reference regex must be valid")

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -96,6 +96,8 @@ mod tests {
             )
         ])
     ]
+    #[case("Hello, foobar_nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug!", vec![])]
+    #[case("Hello, nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug_foobar!", vec![])]
     #[case(
         "nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug",
         vec![

--- a/src/domain/nostr/nip27.rs
+++ b/src/domain/nostr/nip27.rs
@@ -15,12 +15,15 @@ impl Reference {
 
     pub fn find(text: &str) -> Vec<Self> {
         // TODO: Add nevent and nprofile support
-        let pattern = Regex::new(r"[^\w](nostr:(npub|note)1[a-z0-9]{58})[^\w]")
+        // The delimiters are word boundaries rather than characters the match consumes, so a
+        // mention still counts when it opens or closes the note, and when only one space
+        // separates it from the next one.
+        let pattern = Regex::new(r"\bnostr:(?:npub|note)1[a-z0-9]{58}\b")
             .expect("hardcoded NIP-27 reference regex must be valid");
         pattern
-            .captures_iter(text)
-            .filter_map(|capture| {
-                let (_, [uri, _]) = capture.extract();
+            .find_iter(text)
+            .filter_map(|matched| {
+                let uri = matched.as_str();
 
                 Nip21::parse(uri)
                     .ok()
@@ -82,6 +85,37 @@ mod tests {
                 Nip21::EventId(EventId::from_nostr_uri("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv").unwrap()),
                 String::from("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv")
             )
+        ])
+    ]
+    #[case(
+        "nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug",
+        vec![
+            Reference::new(
+                Nip21::Pubkey(PublicKey::from_nostr_uri("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug").unwrap()),
+                String::from("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug")
+            ),
+        ])
+    ]
+    #[case(
+        "Hello, nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv",
+        vec![
+            Reference::new(
+                Nip21::EventId(EventId::from_nostr_uri("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv").unwrap()),
+                String::from("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv")
+            ),
+        ])
+    ]
+    #[case(
+        "Hello, nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv!",
+        vec![
+            Reference::new(
+                Nip21::Pubkey(PublicKey::from_nostr_uri("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug").unwrap()),
+                String::from("nostr:npub1f5uuywemqwlejj2d7he6zjw8jz9wr0r5z6q8lhttxj333ph24cjsymjmug")
+            ),
+            Reference::new(
+                Nip21::EventId(EventId::from_nostr_uri("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv").unwrap()),
+                String::from("nostr:note1jnnkqfzn70k6z94nwljdnaw5s5pd8jlf0eyjfmc2pvsytvsa7unsex9dyv")
+            ),
         ])
     ]
     #[allow(clippy::unwrap_used)]


### PR DESCRIPTION
Closes #551.

## What was wrong

`Reference::find` matched with `[^\w](nostr:(npub|note)1[a-z0-9]{58})[^\w]`. The delimiters were characters the match had to consume, not assertions about the position, and that cost four cases:

- a note that **opens** with a mention — nothing precedes the URI for `[^\w]` to match;
- a note that **closes** with one — the same at the other end, and the ordinary case, since a mention ending a sentence needs no punctuation after it;
- **two mentions separated by one space** — `captures_iter` resumes after the first match, which had already eaten the space, leaving the second URI without a leading delimiter;
- **a mention abutting Japanese text** — `\w` is Unicode-aware, so `[^\w]` did not match `は` or `さ`, and `こんにちはnostr:npub1…さん` yielded nothing. Japanese writes no space around a mention, which makes this the ordinary shape rather than an edge case. It is the same defect as the first three and is fixed here; #551 lists only the ASCII three because that is what was visible from the test file.

Nothing calls `Reference::find` outside its own module yet, so all four were invisible; once NIP-27 rendering is wired up they would have rendered as plain text and read as a rendering bug.

## The change

`(?-u:\b)nostr:(?:npub|note)1[a-z0-9]{58}(?-u:\b)` asserts the boundaries instead of consuming them. The whole match is now the URI, so `captures_iter` and the capture groups give way to `find_iter`.

`(?-u:\b)` makes the boundaries ASCII-only, which is what fixes the fourth case. A bech32 URI is ASCII, so the thing worth ruling out is a URI running into surrounding **ASCII** — a Unicode boundary instead reads `こんにちはnostr:npub1…` as a single word and finds nothing in it. Both `(?-u:)` scopes are load-bearing: drop the leading one and the case whose note opens with `こんにちは` fails; drop the trailing one and the case whose note ends in `さん、ありがとう` fails.

Over-matching is unchanged. `foobarnostr:npub1…` and `nostr:npub1…foobar` are still rejected — the bech32 part is fixed-length with nothing to backtrack into — and the cases covering that stayed green throughout. `_` is rejected as well, but for a different reason: `(?-u:\b)` counts it as a word character. Nothing asserted that, so two cases now do.

A separate commit moves the compiled pattern into a `LazyLock` static. `find` was calling `Regex::new` on every invocation, which would have been once per rendered note; `std::sync::LazyLock` has covered this since 1.80, so no crate is involved. It is the only `Regex::new` in the tree and the same statement this PR already rewrites, which is why it is here rather than in its own issue.

## Tests

A `#[case]` per bullet above, and each was watched failing on the pattern that preceded it: the three ASCII ones on the old `[^\w]` pattern, the two Japanese ones on the Unicode `\b`.

Two further cases reject a mention abutting `_`. That rejection rests on `(?-u:\b)` counting `_` as a word character, which is a different property from the one the `foobar` cases rest on — so a boundary hand-rolled from `is_ascii_alphanumeric` would accept `foobar_nostr:npub1…` with the `foobar` cases still green. Writing that boundary fails the two new cases and nothing else, which is how I checked they carry weight.

The existing cases pass throughout, and the `LazyLock` commit changes no behaviour — the same cases cover it.

`just fmt`, `just lint`, `just test` and `RUSTDOCFLAGS='-D warnings' just doc` all clean, integration tests and the doctest included.

## Left out

- **#565** — the tree now spells the same lazy static two ways, `lazy_static!` in `src/utils/` and `LazyLock` here. Migrating the two older sites is a separate change.
- **#566** — `find` returns no byte span, and silently drops a URI that matches the pattern but fails `Nip21::parse` (a mistyped npub). Both are pre-existing and both want the renderer's requirements to settle their shape, so they belong with the work that wires NIP-27 rendering up.
- **#567** — two mentions pasted with *no* separator find neither, which is this same bug with the separator count taken to zero. A boundary cannot tell a URI running into a longer bech32 token from a URI followed by another URI, and `regex` has no look-around to tell them apart with, so closing it means checking the following bytes in Rust — a scanner rather than a pattern. That is a different shape from this change, and #566 pushes `find` toward scanning for its own reasons, so the two are better done together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi



