### PR TITLE
fix: a reply was called a Note on every line it produced

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1800,6 +1800,48 @@ mod tests {
     }
 
     #[test]
+    fn a_reply_is_dispatched_carrying_the_tags_that_make_it_one() {
+        let (mut state, mut rx) = connected_state();
+        let keys = Keys::generate();
+        let target =
+            create_text_note(&keys, "hello", Timestamp::from(1000)).expect("a valid text note");
+        let target_id = target.id;
+        let target_author = target.pubkey;
+
+        state.editor.update(EditorMessage::ReplyStarted {
+            to: Box::new(target),
+            profile: Box::new(None),
+        });
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+
+        // What the bar calls a reply is settled by `PublishKind`; what makes the event
+        // one is these tags, and nothing else asserted they were still being attached.
+        // Dropping the `.tags(…)` call publishes an untagged note under the name
+        // `[Replied]`, which every other test here would sit through.
+        let Ok(NostrCommand::SendEventBuilder { event_builder, .. }) = rx.try_recv() else {
+            panic!("the reply should have been handed to the worker");
+        };
+        let event = event_builder
+            .finalize(&Keys::generate())
+            .expect("the builder should sign");
+
+        assert_eq!(
+            event.tags.event_ids().collect::<Vec<_>>(),
+            vec![target_id],
+            "a reply names the note it answers"
+        );
+        assert_eq!(
+            event.tags.public_keys().collect::<Vec<_>>(),
+            vec![target_author],
+            "and the author it answers"
+        );
+    }
+
+    #[test]
     fn a_reply_a_relay_refused_is_named_a_reply_and_not_a_note() {
         let (mut state, _rx) = state_replying();
         state.editor.update(EditorMessage::KeyEventReceived {

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -419,7 +419,9 @@ impl<'a> AppState<'a> {
             // nothing" gets triaged by grepping the log at warn and above, and a refusal
             // that only shows at info is missing from exactly that search. The bar is no
             // help by then — the next status has overwritten it.
-            log::warn!("Refusing to publish a blank note");
+            // Named from `kind` like the bar is: a maintainer reading this line and the
+            // `[ERR: …]` the user reported has to be able to tell they are the same event.
+            log::warn!("Refusing to publish a blank {}", kind.subject());
             self.set_status_error(kind.subject(), "nothing to post");
             return Command::none();
         }

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -93,6 +93,10 @@ const NOW_PLAYING_LABEL: &str = "Music";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublishKind {
     Note,
+    /// A note with a reply target, which the bar has to name apart from a top-level one:
+    /// the bar holds a single line, so a user with both in flight otherwise cannot tell
+    /// which of them an error is about (#546).
+    Reply,
     Reaction,
     Repost,
 }
@@ -103,6 +107,7 @@ impl PublishKind {
     const fn settled_label(self) -> &'static str {
         match self {
             Self::Note => "Posted",
+            Self::Reply => "Replied",
             Self::Reaction => "Reacted",
             Self::Repost => "Reposted",
         }
@@ -113,6 +118,7 @@ impl PublishKind {
     const fn subject(self) -> &'static str {
         match self {
             Self::Note => "Note",
+            Self::Reply => "Reply",
             Self::Reaction => "Reaction",
             Self::Repost => "Repost",
         }
@@ -386,6 +392,15 @@ impl<'a> AppState<'a> {
 
         let content = self.editor.get_content();
 
+        // Decided here rather than alongside the tags below, because the refusal in
+        // between has to name it too: a blank reply that reported `[ERR: Note]` would be
+        // the same publish named two different ways depending on how it ended.
+        let kind = if self.editor.reply_target().is_some() {
+            PublishKind::Reply
+        } else {
+            PublishKind::Note
+        };
+
         // Refused before it costs anything. An empty note is a real event on the relays
         // that says nothing and cannot be recalled, and `Ctrl+P` on a composer nobody has
         // typed into is far likelier to be a slip than a request.
@@ -402,7 +417,7 @@ impl<'a> AppState<'a> {
             // that only shows at info is missing from exactly that search. The bar is no
             // help by then — the next status has overwritten it.
             log::warn!("Refusing to publish a blank note");
-            self.set_status_error(PublishKind::Note.subject(), "nothing to post");
+            self.set_status_error(kind.subject(), "nothing to post");
             return Command::none();
         }
 
@@ -420,7 +435,7 @@ impl<'a> AppState<'a> {
         // loses the text for good — the next `ComposingStarted` clears the buffer — and
         // this change is what makes a pre-send failure knowable in time to keep it. A
         // failure the relays report later still loses it: #514.
-        if self.publish(PublishKind::Note, &content, event_builder) {
+        if self.publish(kind, &content, event_builder) {
             self.editor.update(EditorMessage::ComposingCanceled);
         }
 
@@ -1445,7 +1460,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_note_as_reply_posts_and_resets_editor() -> Result<()> {
+    fn submit_note_as_reply_is_reported_as_a_reply_and_resets_the_editor() -> Result<()> {
         let (mut state, _rx) = connected_state();
         let keys = Keys::generate();
 
@@ -1468,7 +1483,7 @@ mod tests {
 
         let _ = state.resolve_publish(id, Ok(()));
 
-        assert_eq!(state.status_bar.message(), Some("[Posted] y"));
+        assert_eq!(state.status_bar.message(), Some("[Replied] y"));
 
         Ok(())
     }
@@ -1756,6 +1771,52 @@ mod tests {
         let _ = state.submit_note();
 
         assert!(!state.editor.is_active());
+    }
+
+    /// A connected state with the composer open as a reply and nothing typed into it.
+    ///
+    /// The target is a note the timeline never saw: a reply is a reply because `reply_to`
+    /// is set, and nothing on this path reads the note back.
+    fn state_replying() -> (AppState<'static>, mpsc::UnboundedReceiver<NostrCommand>) {
+        let (mut state, rx) = connected_state();
+        let keys = Keys::generate();
+        let target =
+            create_text_note(&keys, "hello", Timestamp::from(1000)).expect("a valid text note");
+
+        state.editor.update(EditorMessage::ReplyStarted {
+            to: Box::new(target),
+            profile: Box::new(None),
+        });
+
+        (state, rx)
+    }
+
+    #[test]
+    fn a_reply_a_relay_refused_is_named_a_reply_and_not_a_note() {
+        let (mut state, _rx) = state_replying();
+        state.editor.update(EditorMessage::KeyEventReceived {
+            event: KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+        });
+
+        let _ = state.submit_note();
+        let id = only_pending(&state);
+        let _ = state.resolve_publish(id, Err(String::from("refused")));
+
+        // The bar holds one line: a user with a note and a reply both in flight reads
+        // this one and has to know which of them it is about.
+        assert_eq!(state.status_bar.message(), Some("[ERR: Reply] refused (h)"));
+    }
+
+    #[test]
+    fn a_blank_reply_is_refused_under_the_name_a_sent_one_would_have_had() {
+        let (mut state, _rx) = state_replying();
+
+        let _ = state.submit_note();
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some("[ERR: Reply] nothing to post")
+        );
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -392,10 +392,13 @@ impl<'a> AppState<'a> {
 
         let content = self.editor.get_content();
 
-        // Decided here rather than alongside the tags below, because the refusal in
-        // between has to name it too: a blank reply that reported `[ERR: Note]` would be
-        // the same publish named two different ways depending on how it ended.
-        let kind = if self.editor.reply_target().is_some() {
+        // Read once and owned, so the name on the bar and the tags on the event cannot
+        // disagree about whether this is a reply. They are decided in two places — the
+        // refusal in between has to name it too, since a blank reply reported as
+        // `[ERR: Note]` would be the same publish named two ways depending on how it
+        // ended — and one `reply_target` read is what keeps those two places honest.
+        let reply_target = self.editor.reply_target().cloned();
+        let kind = if reply_target.is_some() {
             PublishKind::Reply
         } else {
             PublishKind::Note
@@ -421,11 +424,11 @@ impl<'a> AppState<'a> {
             return Command::none();
         }
 
-        let event_builder = if let Some(reply_to_event) = self.editor.reply_target() {
+        let event_builder = if let Some(reply_to_event) = reply_target {
             log::info!("Publishing reply: {content}");
             // Build NIP-10 reply tags (root/reply markers, deduped p-tag).
             EventBuilder::new(Kind::TextNote, &content)
-                .tags(ReplyTagsBuilder::build(reply_to_event.clone()))
+                .tags(ReplyTagsBuilder::build(reply_to_event))
         } else {
             log::info!("Publishing note: {content}");
             EventBuilder::new(Kind::TextNote, &content)

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -392,16 +392,25 @@ impl<'a> AppState<'a> {
 
         let content = self.editor.get_content();
 
-        // Read once and owned, so the name on the bar and the tags on the event cannot
-        // disagree about whether this is a reply. They are decided in two places — the
-        // refusal in between has to name it too, since a blank reply reported as
-        // `[ERR: Note]` would be the same publish named two ways depending on how it
-        // ended — and one `reply_target` read is what keeps those two places honest.
-        let reply_target = self.editor.reply_target().cloned();
-        let kind = if reply_target.is_some() {
-            PublishKind::Reply
-        } else {
-            PublishKind::Note
+        // One decision, two products. The name the bar gives this publish and the tags
+        // the event carries come out of the same arm, so no later edit can narrow one
+        // without the other — a tag branch that grew a condition of its own would send a
+        // top-level note while the bar called it a reply, which is this defect inverted.
+        //
+        // Above the refusal below rather than after it, because that refusal has to name
+        // the publish too: a blank reply reported as `[ERR: Note]` would be the same
+        // publish named two ways depending on how it ended.
+        let (kind, event_builder) = match self.editor.reply_target().cloned() {
+            Some(reply_to_event) => (
+                PublishKind::Reply,
+                // Build NIP-10 reply tags (root/reply markers, deduped p-tag).
+                EventBuilder::new(Kind::TextNote, &content)
+                    .tags(ReplyTagsBuilder::build(reply_to_event)),
+            ),
+            None => (
+                PublishKind::Note,
+                EventBuilder::new(Kind::TextNote, &content),
+            ),
         };
 
         // Refused before it costs anything. An empty note is a real event on the relays
@@ -426,15 +435,9 @@ impl<'a> AppState<'a> {
             return Command::none();
         }
 
-        let event_builder = if let Some(reply_to_event) = reply_target {
-            log::info!("Publishing reply: {content}");
-            // Build NIP-10 reply tags (root/reply markers, deduped p-tag).
-            EventBuilder::new(Kind::TextNote, &content)
-                .tags(ReplyTagsBuilder::build(reply_to_event))
-        } else {
-            log::info!("Publishing note: {content}");
-            EventBuilder::new(Kind::TextNote, &content)
-        };
+        // Below the refusal, so a draft that never went anywhere is not logged as one
+        // that did; named from `kind` for the same reason the warn above it is.
+        log::info!("Publishing {}: {content}", kind.subject());
 
         // Only discard the draft once it is actually on its way. Closing the editor
         // loses the text for good — the next `ComposingStarted` clears the buffer — and

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -102,8 +102,8 @@ enum PublishKind {
 }
 
 impl PublishKind {
-    /// How the bar names it once a relay has accepted it — past tense, and the wording
-    /// the bar has always used.
+    /// How the bar names it once a relay has accepted it. Past tense, and never the word
+    /// for a publish that did not happen — [`Self::subject`] is what says that.
     const fn settled_label(self) -> &'static str {
         match self {
             Self::Note => "Posted",

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -1818,10 +1818,12 @@ mod tests {
 
         let _ = state.submit_note();
 
+        assert!(state.pending_publishes.is_empty(), "nothing was published");
         assert_eq!(
             state.status_bar.message(),
             Some("[ERR: Reply] nothing to post")
         );
+        assert!(state.editor.is_active(), "the composer stays open");
     }
 
     #[test]

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -413,9 +413,9 @@ impl<'a> AppState<'a> {
             ),
         };
 
-        // Refused before it costs anything. An empty note is a real event on the relays
-        // that says nothing and cannot be recalled, and `Ctrl+P` on a composer nobody has
-        // typed into is far likelier to be a slip than a request.
+        // An empty note is a real event on the relays that says nothing and cannot be
+        // recalled, and `Ctrl+P` on a composer nobody has typed into is far likelier to
+        // be a slip than a request.
         //
         // Trimmed only to decide: whitespace and a stray newline are as empty as nothing
         // at all. What gets published is the content as typed.
@@ -430,7 +430,7 @@ impl<'a> AppState<'a> {
             // help by then — the next status has overwritten it.
             // Named from `kind` like the bar is: a maintainer reading this line and the
             // `[ERR: …]` the user reported has to be able to tell they are the same event.
-            log::warn!("Refusing to publish a blank {}", kind.subject());
+            log::warn!("Refusing to publish a blank draft ({})", kind.subject());
             self.set_status_error(kind.subject(), "nothing to post");
             return Command::none();
         }


### PR DESCRIPTION
Closes #546.

## What was wrong

`submit_note` builds a top-level note and a reply from the same path, branching on `self.editor.reply_target()` only to decide the NIP-10 tags. Both were reported as `PublishKind::Note`, so every line a reply produced named it a note:

- `[Posted] <text>` when a relay took it;
- `[ERR: Note] …` for every refusal and failure, including `[ERR: Note] nothing to post` for a blank reply.

The status bar holds one line, and a relay's answer can arrive a full ack timeout after the submit. A user with a note and a reply both in flight reads that one line and cannot tell which of the two it is about.

## The change

`PublishKind::Reply`, with `subject` `"Reply"` and `settled_label` `"Replied"` — the same present/past pair the other variants already use (`Note`/`Posted`, `Reaction`/`Reacted`, `Repost`/`Reposted`), so the error line never borrows the word for a success.

The kind is chosen from the reply target **above** the blank-draft refusal rather than beside the tag-building below it. Choosing it lower would leave the same publish named one way when it is sent and another when it is refused for being empty, which is the bug in miniature.

That leaves the name and the NIP-10 tags decided in two places, which agreed only by inspection: a condition added to the tag branch — `reply_target.filter(…)`, say — would send a top-level note while the bar called it a reply, this same defect coming back the other way round. Later commits close that, first by sharing one owned read and then, when that turned out to buy ownership rather than agreement, by having one `match` yield both:

```rust
let (kind, event_builder) = match self.editor.reply_target().cloned() {
    Some(reply_to_event) => (PublishKind::Reply, …tags(ReplyTagsBuilder::build(reply_to_event))),
    None => (PublishKind::Note, …),
};
```

A kind now cannot be had without the builder from the same arm. Two consequences fall out of putting the builder above the blank-draft refusal: the two `log::info!` lines fold into one named from `kind`, since a line saying the draft is on its way cannot sit above the refusal; and a refused blank draft builds an `EventBuilder` and its NIP-10 tags before dropping them, on a path that runs once per user slip.

Nothing reads `PublishKind` for behaviour — `resolve_publish` and `abandon_publish` only report — so what gets published is unchanged.

Worth noting for anyone matching this against the issue: the in-flight line is `[Sending] <text>` and carries no kind at all, for any publish. There was nothing to change there, and this does not add one — giving the pending line a subject would be the status bar growing a case, which #516 exists to stop.

A third commit takes the blank-draft refusal's `log::warn!` with it. It read `Refusing to publish a blank note` for a reply as well — the bar had stopped saying "note" while the log stream kept it. The comment above that line says it is a warn so a "Ctrl+P did nothing" report can be triaged by grepping at warn and above, which only works if the line names what the user saw named. Nothing in this repository asserts log output, so that one is carried by reading rather than by a test, and this says so rather than implying otherwise.

## Left out

**#571** — the two `log::error!` lines that report a failed publish name `pending.message` and not the kind, so a user's `[ERR: Reaction] … (note1abc…)` is matched in the log by a line that could equally be a repost. Those are silent about the kind rather than wrong about it, and they concern every publish rather than replies, so they are a separate change.

**#572** — `Editor::is_reply` is a second spelling of the question `submit_note` asks through `reply_target`, and every caller is an assertion in the test module written for it. Removing it means editing `editor.rs` and six of its tests, which is a file this change otherwise has no business in.

## Tests

`submit_note_as_reply_posts_and_resets_editor` asserted `[Posted] y` for a reply. That is the defect recorded as an expectation, so it is updated to `[Replied] y` and renamed to say what it now claims.

Two cases are added for the paths that test does not reach: a reply a relay refused (`[ERR: Reply] refused (h)`) and a blank reply (`[ERR: Reply] nothing to post`).

A fourth case pulls the dispatched `SendEventBuilder` off the worker channel, finalizes it, and asserts the reply's `e` and `p` tags. The `match` makes the name and the builder inseparable, but nothing asserted the `.tags(ReplyTagsBuilder::build(…))` call inside that arm still attached anything — emptying it publishes a reply as a plain note under `[Replied]`, and before this case the whole suite sat through that. `ReplyTagsBuilder`'s own tests build tags without publishing them, and `submit_note_dispatches_send_event` opens the composer with `ComposingStarted`, so neither reaches it.

I checked they carry weight rather than assuming it. Making `submit_note` always pick `Note` does not compile — `#![deny(warnings)]` catches the unconstructed variant — so the mutation that proves them is inverting the branch, which keeps both variants live. That fails all three, and also fails `a_failed_note_is_not_called_posted` and `submit_note_posts_content_and_resets_editor`, so the top-level side is pinned too.

`just fmt`, `just lint`, `just test` and `RUSTDOCFLAGS='-D warnings' just doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi





