### PR TITLE
fix: the log for a failed publish did not say what had failed

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -125,27 +125,31 @@ impl PublishKind {
     }
 }
 
-/// Which of the two ways a publish did not happen.
+/// Which of the two ways a publish did not happen, as far as this layer can tell.
 ///
-/// Whether it was ever handed over is the first thing a report about one has to settle,
-/// and the cause cannot be read for it: the SDK answers a dispatch it would not make
-/// with `relay not connected`, a word away from this layer's `not connected`, and with
-/// `cannot send events in read-only mode`, which contains this layer's `read-only mode`
-/// whole.
+/// The line it draws is whether the worker ever had it — not whether a relay answered,
+/// which this layer cannot know. A signing failure, a queue drained at shutdown and a
+/// relay's refusal all come back through one channel as `Err`, so a word promising a
+/// relay verdict would be wrong for two of the three.
+///
+/// A value rather than a word each caller spells, because the cause cannot be read for
+/// it: the worker answers a dispatch it would not make with `cannot send events in
+/// read-only mode`, which contains this layer's `read-only mode` whole, and the SDK with
+/// `relay not connected`, a word from this layer's `not connected`.
 #[derive(Clone, Copy)]
 enum PublishFailure {
-    /// It reached the worker. A relay answered, or none did.
-    Rejected,
-    /// It never reached the worker.
-    NotSent,
+    /// The worker had it and answered. Whether a relay ever saw it is in the cause.
+    Reported,
+    /// It never left this layer, so nothing will answer for it.
+    NotDispatched,
 }
 
 impl PublishFailure {
     /// How the log names it.
     const fn label(self) -> &'static str {
         match self {
-            Self::Rejected => "failed",
-            Self::NotSent => "not sent",
+            Self::Reported => "failed",
+            Self::NotDispatched => "not dispatched",
         }
     }
 }
@@ -694,7 +698,7 @@ impl<'a> AppState<'a> {
             Ok(()) => self.set_status(pending.kind.settled_label(), pending.message),
             Err(reason) => self.report_publish_failure(
                 pending.kind,
-                PublishFailure::Rejected,
+                PublishFailure::Reported,
                 &reason,
                 pending.message,
             ),
@@ -724,7 +728,7 @@ impl<'a> AppState<'a> {
 
         self.report_publish_failure(
             pending.kind,
-            PublishFailure::NotSent,
+            PublishFailure::NotDispatched,
             cause,
             pending.message,
         );

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -459,8 +459,13 @@ impl<'a> AppState<'a> {
             // help by then — the next status has overwritten it.
             // Named from `kind` like the bar is: a maintainer reading this line and the
             // `[ERR: …]` the user reported has to be able to tell they are the same event.
-            log::warn!("Refusing to publish a blank draft ({})", kind.subject());
-            self.set_status_error(kind.subject(), "nothing to post");
+            // One binding for both, as in `report_publish_failure` — this refusal cannot
+            // use that helper, since there is no content for it to name, but a word the
+            // two sinks each spell for themselves is a word they can be parted on.
+            let subject = kind.subject();
+
+            log::warn!("Refusing to publish a blank draft ({subject})");
+            self.set_status_error(subject, "nothing to post");
             return Command::none();
         }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -125,6 +125,31 @@ impl PublishKind {
     }
 }
 
+/// Which of the two ways a publish did not happen.
+///
+/// Whether it was ever handed over is the first thing a report about one has to settle,
+/// and the cause cannot be read for it: the SDK answers a dispatch it would not make
+/// with `relay not connected`, a word away from this layer's `not connected`, and with
+/// `cannot send events in read-only mode`, which contains this layer's `read-only mode`
+/// whole.
+#[derive(Clone, Copy)]
+enum PublishFailure {
+    /// It reached the worker. A relay answered, or none did.
+    Rejected,
+    /// It never reached the worker.
+    NotSent,
+}
+
+impl PublishFailure {
+    /// How the log names it.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Rejected => "failed",
+            Self::NotSent => "not sent",
+        }
+    }
+}
+
 /// A publish handed to the worker and waiting for a relay's answer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingPublish {
@@ -624,7 +649,13 @@ impl<'a> AppState<'a> {
     /// That pairing works only while the two name the same publish, which is why they are
     /// written here rather than at each call site: the label and the detail reaching the
     /// bar are the same values the log line is built from (#571).
-    fn report_publish_failure(&mut self, kind: PublishKind, cause: &str, message: String) {
+    fn report_publish_failure(
+        &mut self,
+        kind: PublishKind,
+        failure: PublishFailure,
+        cause: &str,
+        message: String,
+    ) {
         // Cause first: the bar is one line, and what a reaction or repost carries as
         // content is a bech32 id — long, and far less use than why it failed.
         let detail = format!("{cause} ({message})");
@@ -635,7 +666,7 @@ impl<'a> AppState<'a> {
         // changes the bar, and the bar is asserted.
         let subject = kind.subject();
 
-        log::error!("{subject} failed: {detail}");
+        log::error!("{subject} {}: {detail}", failure.label());
         self.set_status_error(subject, detail);
     }
 
@@ -661,7 +692,12 @@ impl<'a> AppState<'a> {
         // which is what that issue exists to stop.
         match result {
             Ok(()) => self.set_status(pending.kind.settled_label(), pending.message),
-            Err(reason) => self.report_publish_failure(pending.kind, &reason, pending.message),
+            Err(reason) => self.report_publish_failure(
+                pending.kind,
+                PublishFailure::Rejected,
+                &reason,
+                pending.message,
+            ),
         }
 
         Command::none()
@@ -686,7 +722,12 @@ impl<'a> AppState<'a> {
             "not connected"
         };
 
-        self.report_publish_failure(pending.kind, cause, pending.message);
+        self.report_publish_failure(
+            pending.kind,
+            PublishFailure::NotSent,
+            cause,
+            pending.message,
+        );
     }
 
     /// Record that the Nostr subscription is ready and store its command sender,
@@ -1964,11 +2005,13 @@ mod tests {
         assert_eq!(sent, Some(tracked));
     }
 
-    /// #571: the log line for a failure is built from the same `kind` as the bar's, so
-    /// what pins one pins the other. The reaction half is
-    /// `publish_failure_reports_an_error_instead_of_success`; this is the half that makes
-    /// them a pair, since a reaction and a repost of the same note are otherwise reported
-    /// in identical words.
+    /// #571 wants a reaction and a repost that fail on the same note told apart. The
+    /// reaction half is `publish_failure_reports_an_error_instead_of_success`; this is
+    /// the other half of the pair.
+    ///
+    /// What it pins is the bar. Nothing here can read the log, so the log carrying the
+    /// same word rests on the two being written from one binding — not on this failing
+    /// if they ever part.
     #[test]
     fn a_repost_that_fails_is_not_reported_as_the_reaction_it_could_have_been() -> Result<()> {
         let (mut state, _rx) = connected_state();

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -136,7 +136,7 @@ impl PublishKind {
 /// it: the worker answers a dispatch it would not make with `cannot send events in
 /// read-only mode`, which contains this layer's `read-only mode` whole, and the SDK with
 /// `relay not connected`, a word from this layer's `not connected`.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 enum PublishFailure {
     /// The worker had it and answered. Whether a relay ever saw it is in the cause.
     Reported,

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -670,7 +670,7 @@ impl<'a> AppState<'a> {
         // changes the bar, and the bar is asserted.
         let subject = kind.subject();
 
-        log::error!("{subject} {}: {detail}", failure.label());
+        log::error!("Publish {} ({subject}): {detail}", failure.label());
         self.set_status_error(subject, detail);
     }
 

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -617,6 +617,28 @@ impl<'a> AppState<'a> {
         id
     }
 
+    /// Report a publish that did not happen, to the log and to the bar together.
+    ///
+    /// The bar holds one line and the next status overwrites it, so what a bug report is
+    /// reconstructed from is the log — paired with whatever the user managed to read.
+    /// That pairing works only while the two name the same publish, which is why they are
+    /// written here rather than at each call site: the label and the detail reaching the
+    /// bar are the same values the log line is built from (#571).
+    fn report_publish_failure(&mut self, kind: PublishKind, cause: &str, message: String) {
+        // Cause first: the bar is one line, and what a reaction or repost carries as
+        // content is a bech32 id — long, and far less use than why it failed.
+        let detail = format!("{cause} ({message})");
+
+        // Both records read from one binding rather than calling `subject` twice, which
+        // is what a test can reach: nothing asserts log output here, so a log line with a
+        // name of its own could be changed without anything failing. Changing this one
+        // changes the bar, and the bar is asserted.
+        let subject = kind.subject();
+
+        log::error!("{subject} failed: {detail}");
+        self.set_status_error(subject, detail);
+    }
+
     /// Settle the publish this outcome belongs to.
     ///
     /// An id with no entry is ignored: it can only mean the entry was already settled,
@@ -639,15 +661,7 @@ impl<'a> AppState<'a> {
         // which is what that issue exists to stop.
         match result {
             Ok(()) => self.set_status(pending.kind.settled_label(), pending.message),
-            Err(reason) => {
-                log::error!("Failed to publish {}: {reason}", pending.message);
-                // Reason first: the bar is one line, and what a reaction or repost carries
-                // as content is a bech32 id — long, and far less use than why it failed.
-                self.set_status_error(
-                    pending.kind.subject(),
-                    format!("{reason} ({})", pending.message),
-                );
-            }
+            Err(reason) => self.report_publish_failure(pending.kind, &reason, pending.message),
         }
 
         Command::none()
@@ -672,11 +686,7 @@ impl<'a> AppState<'a> {
             "not connected"
         };
 
-        log::error!("Publish not sent, {cause}: {}", pending.message);
-        self.set_status_error(
-            pending.kind.subject(),
-            format!("{cause} ({})", pending.message),
-        );
+        self.report_publish_failure(pending.kind, cause, pending.message);
     }
 
     /// Record that the Nostr subscription is ready and store its command sender,
@@ -1952,6 +1962,33 @@ mod tests {
         // its submission and every publish strands on "Sending" — silently, since each
         // half is individually plausible.
         assert_eq!(sent, Some(tracked));
+    }
+
+    /// #571: the log line for a failure is built from the same `kind` as the bar's, so
+    /// what pins one pins the other. The reaction half is
+    /// `publish_failure_reports_an_error_instead_of_success`; this is the half that makes
+    /// them a pair, since a reaction and a repost of the same note are otherwise reported
+    /// in identical words.
+    #[test]
+    fn a_repost_that_fails_is_not_reported_as_the_reaction_it_could_have_been() -> Result<()> {
+        let (mut state, _rx) = connected_state();
+        let keys = Keys::generate();
+
+        let event = create_text_note(&keys, "hello", Timestamp::from(1000))?;
+        let Ok(note1) = event.id.to_bech32();
+        let _ = state.process_nostr_event_for_tab(event, &FeedKind::Home);
+        let _ = state.timeline.update(TimelineMessage::FirstItemSelected);
+
+        let _ = state.repost_selected();
+        let id = only_pending(&state);
+        let _ = state.resolve_publish(id, Err(String::from("refused")));
+
+        assert_eq!(
+            state.status_bar.message(),
+            Some(format!("[ERR: Repost] refused ({note1})").as_str())
+        );
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Closes #571.

## What was wrong

The status bar named a failed publish by its `PublishKind`; the two log lines for the same event did not.

```rust
log::error!("Failed to publish {}: {reason}", pending.message);   // resolve_publish
log::error!("Publish not sent, {cause}: {}", pending.message);    // abandon_publish
```

`pending.message` is the note's text for a note or a reply and a bech32 event id for a reaction or a repost, so a user reporting `[ERR: Reaction] no relay confirmed (note1abc…)` was matched in the log by `Failed to publish note1abc…: no relay confirmed` — a line a repost of the same note produces identically.

The bar holds one line and the next status overwrites it, so the log is what a bug report gets reconstructed from, and reconstructing it means pairing what the user saw with what was written. The kind was the part of the bar's line the log could not supply.

## The change

One `report_publish_failure`, called from both places, writing the log line and the bar line from the same values.

Not two call sites kept in step by hand: nothing in this repository asserts log output, so a log line carrying a name of its own could drift from the bar and no test would fail. The two read from a single `subject` binding instead, which is what a test can reach — changing it changes the bar, and the bar is asserted. The `deny(warnings)` in `src/lib.rs` closes the cruder version of the same mistake: a helper that ignores its `kind` argument does not compile.

There is a third place that names a publish to both sinks, the blank-draft refusal in `submit_note`, and it was spelling the word once for each. It cannot use the helper — with no content the bar would read `nothing to post ()` — so it binds once on its own. Every site that tells the log and the bar what kind of publish this is now reads that word a single time. The two `subject` calls left over write only the log; the bar beside them says `Sending`, which is not the kind.

The two lines also said the same thing in different words — "Failed to publish" against "Publish not sent" — for no reason beyond where they sat, so the wording is now one shape: `Publish failed (Reaction): no relay confirmed (note1abc…)` and `Publish not dispatched (Note): read-only mode (h)`. The kind sits where the blank-draft warn beside it already puts it, `Refusing to publish a blank draft (Note)`, and the cause and content stay last, which is the order the bar shows them in.

I first folded them without the phase word, on the argument that the cause already said which had happened. It does not, and a later commit puts it back as `PublishFailure`. The SDK answers a dispatch it would not make with `relay not connected` — one word from this layer's `not connected` — and with `cannot send events in read-only mode`, which contains this layer's `read-only mode` whole. Whether the event was ever handed over is the first thing a publish report has to settle, and it was being inferred from strings that collide. It is a value rather than a `&str` phase argument for the reason `PublishKind` already is one: two adjacent `&str` parameters are swappable at a call site.

The words took a second pass to get right. `failed` against `not sent` reads as a relay verdict against a dispatch that never happened, and `resolve_publish` does not only see relay verdicts: a queue drained at shutdown, a signing failure and the worker's own read-only arm all arrive as `Err` having never gone near a relay. The line this layer can draw is whether the worker ever had it — `Reported` / `NotDispatched`, logged as `failed` / `not dispatched`. Whether a relay saw it is in the cause, where it was all along.

## Tests

A failed repost is asserted for the first time: `[ERR: Repost] refused (note1…)`. The reaction half already existed, and the pair is what the issue asks for — a reaction and a repost failing on the same note have to be told apart, and before this they were reported in identical words.

Checked rather than assumed. Renaming `Repost`'s subject to `"Reaction"` fails the new case and nothing else. Pointing the shared binding at a fixed kind does not compile, because `kind` then goes unused.

Both call sites keep their existing bar assertions — `[ERR: Reaction] no relay confirmed …` for the resolve path, `[ERR: Note] read-only mode (h)` / `connection lost` / `not connected` for the abandon path — so the bar output is pinned where the refactor lands, and it is byte-identical to before.

## Coverage

Codecov is red on this patch, and the whole of it is `PublishFailure::label` — `cargo llvm-cov --show-missing-lines` names those lines and no others that this change added.

It is the second of the two cases `CONTRIBUTING.md` distinguishes, not the first. `label` is reached only from inside `log::error!`, and a log macro does not evaluate its arguments when no logger is installed, which is the state every test in this repository runs in. So the lines are not merely untested, they are unreachable from a test as things stand — the same wall #574 describes, showing up as a number. The pre-existing uncovered lines in this file include another log macro's arguments for exactly that reason.

What would buy the percentage back is asserting `Reported.label() == "failed"`, a test that compares two literals and would pass just as happily if the log line stopped calling it. #574 is what would cover these lines through the behaviour instead.

## Left out

`src/infrastructure/subscription/nostr.rs` logs `Untracked publish failed: {reason}` for an outcome nobody is waiting on, and that line names neither the kind nor the event — the same gap #571 describes, one layer down. `PublishKind` does not exist there, and today the line fires only for the NIP-38 status, so closing it is a different change from this one.

## Not claimed

**The log text is not asserted, and cannot be here.** Measured, not assumed: gutting the log line so it no longer names the publish — #571 itself — leaves all 424 tests green. So nothing in this PR is a regression guard on the log; the new repost case pins the bar's subject, and the log carrying the same word rests on the two being written from one binding and on reading. `log::set_logger` takes effect once per process while tests run in parallel in one, which is why building the harness is #574 rather than a line here.

What the shared binding buys is that the two cannot drift by editing one thing, and that a helper ignoring its `kind` does not compile. Not that they cannot be driven apart deliberately.

`PublishFailure` is guarded further than I first wrote, and by the compiler rather than by a test: pointing one call site at the other variant leaves the first unconstructed, and `dead_code` under `deny(warnings)` refuses it. Swapping *both* sites, or swapping the two strings `label` returns, still compiles silently — that is the part #574 would reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi





