### PR TITLE
refactor: is_reply was a second way to ask what reply_target answers

### DIFF
--- a/src/model/editor.rs
+++ b/src/model/editor.rs
@@ -35,11 +35,6 @@ impl<'a> Editor<'a> {
         self.is_active
     }
 
-    /// Returns true if currently composing a reply
-    pub fn is_reply(&self) -> bool {
-        self.reply_to.is_some()
-    }
-
     /// Returns the event being replied to, if any
     pub fn reply_target(&self) -> Option<&Event> {
         self.reply_to.as_ref()
@@ -138,7 +133,6 @@ mod tests {
     fn new_editor_default_state() {
         let editor = Editor::new();
         assert!(!editor.is_active());
-        assert!(!editor.is_reply());
         assert_eq!(editor.reply_target(), None);
         assert_eq!(editor.get_content(), "");
     }
@@ -149,7 +143,6 @@ mod tests {
         editor.update(Message::ComposingStarted);
 
         assert!(editor.is_active());
-        assert!(!editor.is_reply());
         assert_eq!(editor.reply_target(), None);
         assert_eq!(editor.get_content(), "");
     }
@@ -166,7 +159,6 @@ mod tests {
         });
 
         assert!(editor.is_active());
-        assert!(editor.is_reply());
         assert_eq!(editor.reply_target(), Some(&event));
     }
 
@@ -181,7 +173,6 @@ mod tests {
         });
 
         assert!(editor.is_active());
-        assert!(editor.is_reply());
         assert_eq!(editor.reply_target(), Some(&event));
     }
 
@@ -202,14 +193,13 @@ mod tests {
 
         // Start a reply
         editor.update(Message::ReplyStarted {
-            to: Box::new(event),
+            to: Box::new(event.clone()),
             profile: Box::new(None),
         });
-        assert!(editor.is_reply());
+        assert_eq!(editor.reply_target(), Some(&event));
 
         // Start new composition
         editor.update(Message::ComposingStarted);
-        assert!(!editor.is_reply());
         assert_eq!(editor.reply_target(), None);
     }
 


### PR DESCRIPTION
Closes #572.

## What it was

```rust
/// Returns true if currently composing a reply
pub fn is_reply(&self) -> bool {
    self.reply_to.is_some()
}
```

Every caller was an assertion in `editor.rs`'s own test module. The one place in the program that asks the question, `submit_note`, asks `reply_target` instead — it needs the target itself a few lines later, and one read is what keeps the status bar's name and the NIP-10 tags from disagreeing (#546).

`deny(warnings)` could not point this out: `Editor` is `pub` in a `pub` module, so nothing in the crate can tell the method is unreachable from outside it.

## What the assertions do now

The issue suggests rewriting all six to read `reply_target`. Five of them turn out to sit *directly above* a `reply_target` assertion already claiming the same thing, more precisely:

```rust
assert!(!editor.is_reply());
assert_eq!(editor.reply_target(), None);
```

Rewriting those makes each a copy of the line below it, so they are deleted and the neighbour carries the claim — which it already did, and it prints the target on failure where `assert!` printed nothing.

The sixth stood alone: the setup step of `composing_started_clears_reply_state`, asserting the reply had begun before the clearing under test. It names the target it expects now, which needed the event cloned into the message rather than moved.

## How I know the claims survived

Two mutations, run rather than reasoned about:

- `ReplyStarted` recording no target fails five tests, including `composing_started_clears_reply_state` — so the replaced assertion still catches what it caught.
- `ComposingStarted` not clearing the target fails exactly one test, `composing_started_clears_reply_state`, which is the test that is about precisely that.

`just fmt`, `just lint`, `just test` and `RUSTDOCFLAGS='-D warnings' just doc` all clean.

## Worth saying plainly

This removes a `pub` item from a crate that CD publishes, which is a breaking change in the strict sense of 0.1.x. It is deliberate. The lib target here is the inside of a TUI binary rather than an API anyone is invited to build on — `pub struct App`, `pub enum Action` and `pub struct Cli` have all left it since v0.1.1 was published — and `reply_target`, which answers the same question and more, stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cxcvPGJ5QQssGBK66bnSi